### PR TITLE
Added package.json to ipfs-blocks so multihashes gets installed

### DIFF
--- a/submodules/ipfs-blocks/package.json
+++ b/submodules/ipfs-blocks/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ipfs-blocks",
+  "version": "0.0.0",
+  "description": "subsystem of ipfs that provides or coordinates block retrieval for the other subsystems.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "ipfs",
+    "block",
+    "retrieval"
+  ],
+  "author": "Juan Benet <juan@benet.ai> (http://juan.benet.ai/)",
+  "license": "MIT",
+  "dependencies": {
+    "multihashes": "^0.1.2"
+  }
+}


### PR DESCRIPTION
`ipfs-blocks` is missing `package.json` so that the `multihashes` package is installed when `make` is run.
