### PR TITLE
Added package.json to ipfs-mount

### DIFF
--- a/submodules/ipfs-mount/package.json
+++ b/submodules/ipfs-mount/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ipfs-mount",
+  "version": "0.0.0",
+  "description": "Mount ipfs paths via FUSE",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "ipfs",
+    "FUSE",
+    "filesystem"
+  ],
+  "author": "Juan Benet <juan@benet.ai> (http://juan.benet.ai/)",
+  "license": "MIT",
+  "dependencies": {
+    "base58-native": "^0.1.4",
+    "fuse4js": "^0.1.9",
+    "lodash.map": "^2.4.1",
+    "mkdirp": "^0.5.0",
+    "prettysize": "0.0.3",
+    "rimraf": "^2.2.8",
+    "single-line-log": "^0.4.1"
+  }
+}


### PR DESCRIPTION
`ipfs-mount` is missing `package.json` so that the `base58-native`, `fuse4js`, `lodash.map`, `mkdirp`, `mkdirp` `prettysize`, `rimraf` `single-line-log` packages are installed when `make` is run.
