### PR TITLE
Run core tests in the browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ before_install:
   # Workaround for a permissions issue with Travis virtual machine images
 script:
   - npm test
+
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,73 @@
+module.exports = function (config) {
+  config.set({
+
+    // base path, that will be used to resolve files and exclude
+    basePath: '',
+
+    // frameworks to use
+    frameworks: ['mocha'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'tests/test-core/browser.js'
+    ],
+
+    // list of preprocessors
+    preprocessors: {
+      'tests/test-core/*': ['webpack']
+    },
+
+    webpack: {
+      resolve: {
+        extensions: ['', '.js']
+      },
+      externals: {
+        fs: '{}'
+      },
+      node: {
+        Buffer: true
+      }
+    },
+
+    webpackMiddleware: {
+      noInfo: true,
+      stats: {
+        colors: true
+      }
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
+    reporters: ['spec'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera (has to be installed with `npm install karma-opera-launcher`)
+    // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
+    // - PhantomJS
+    // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
+    browsers: process.env.TRAVIS ? ['Firefox'] : ['Chrome'],
+
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 60000,
+
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: true
+  })
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "lint": "standard",
     "coverage": "istanbul cover --print both -- _mocha tests/test-*/index.js",
-    "test": "mocha tests/test-*/index.js",
+    "test": "npm run test:node && npm run test:browser",
+    "test:node": "mocha tests/test-*/index.js",
+    "test:browser": "karma start karma.conf.js",
     "test:core": "mocha tests/test-core/index.js",
     "test:cli": "mocha tests/test-cli/index.js",
     "test:cli-offline": "mocha tests/test-cli-offline/index.js"
@@ -32,20 +34,33 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs#readme",
   "devDependencies": {
+    "async": "^1.5.2",
     "chai": "^3.4.1",
+    "fs-blob-store": "^5.2.1",
     "istanbul": "^0.4.1",
+    "karma": "^0.13.19",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-cli": "^0.1.2",
+    "karma-firefox-launcher": "^0.1.7",
+    "karma-mocha": "^0.2.1",
+    "karma-spec-reporter": "0.0.23",
+    "karma-webpack": "^1.7.0",
+    "local-storage-blob-store": "0.0.2",
+    "lodash": "^4.0.0",
     "mocha": "^2.3.4",
     "ncp": "^2.0.0",
     "nexpect": "^0.5.0",
     "pre-commit": "^1.1.2",
+    "raw-loader": "^0.5.1",
     "rimraf": "^2.4.4",
-    "standard": "^5.3.1"
+    "standard": "^5.4.1",
+    "webpack": "^1.12.11"
   },
   "dependencies": {
     "boom": "^3.1.1",
     "debug": "^2.2.0",
     "hapi": "^12.0.0",
-    "ipfs-repo": "^0.2.2",
+    "ipfs-repo": "^0.4.1",
     "lodash.get": "^4.0.0",
     "lodash.set": "^4.0.0",
     "ronin": "^0.3.11"

--- a/src/ipfs-core/config.js
+++ b/src/ipfs-core/config.js
@@ -1,9 +1,0 @@
-'use strict'
-
-const os = require('os')
-
-exports = module.exports
-
-exports.repoPath = function () {
-  return process.env.IPFS_PATH || os.homedir() + '/.ipfs'
-}

--- a/src/ipfs-core/default-repo/browser.js
+++ b/src/ipfs-core/default-repo/browser.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const localStorage = require('local-storage-blob-store')
+const IPFSRepo = require('ipfs-repo')
+
+const options = {
+  stores: {
+    keys: localStorage,
+    config: localStorage,
+    datastore: localStorage,
+    // datastoreLegacy: needs https://github.com/ipfs/js-ipfs-repo/issues/6#issuecomment-164650642
+    logs: localStorage,
+    locks: localStorage,
+    version: localStorage
+  }
+}
+
+module.exports = () => {
+  return new IPFSRepo('ipfs', options)
+}

--- a/src/ipfs-core/default-repo/index.js
+++ b/src/ipfs-core/default-repo/index.js
@@ -1,0 +1,5 @@
+const isNode = !global.window
+
+module.exports = isNode
+  ? require('./node')
+  : require('./browser')

--- a/src/ipfs-core/default-repo/node.js
+++ b/src/ipfs-core/default-repo/node.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const os = require('os')
+const fs = require('fs-blob-store')
+const IPFSRepo = require('ipfs-repo')
+
+const options = {
+  stores: {
+    keys: fs,
+    config: fs,
+    datastore: fs,
+    // datastoreLegacy: needs https://github.com/ipfs/js-ipfs-repo/issues/6#issuecomment-164650642
+    logs: fs,
+    locks: fs,
+    version: fs
+  }
+}
+
+module.exports = () => {
+  const repoPath = process.env.IPFS_PATH || os.homedir() + '/.ipfs'
+  return new IPFSRepo(repoPath, options)
+}

--- a/src/ipfs-core/index.js
+++ b/src/ipfs-core/index.js
@@ -1,17 +1,17 @@
 'use strict'
 
-const config = require('./config')
-const IPFSRepo = require('ipfs-repo')
+const defaultRepo = require('./default-repo')
 
 exports = module.exports = IPFS
-exports.config = config
 
-function IPFS () {
+function IPFS (repo) {
   if (!(this instanceof IPFS)) {
     throw new Error('Must be instantiated with new')
   }
 
-  var repo = new IPFSRepo(config.repoPath())
+  if (!repo) {
+    repo = defaultRepo()
+  }
 
   this.daemon = callback => {
     // 1. read repo to get peer data

--- a/tests/test-core/browser.js
+++ b/tests/test-core/browser.js
@@ -1,0 +1,44 @@
+/* globals describe, before */
+
+// const expect = require('chai').expect
+const async = require('async')
+const store = require('local-storage-blob-store')
+const _ = require('lodash')
+
+var repoContext = require.context('raw!../repo-example', true)
+
+describe('core', function () {
+  before(function (done) {
+    window.localStorage.clear()
+
+    var repoData = []
+    repoContext.keys().forEach(function (key) {
+      repoData.push({
+        key: key.replace('./', ''),
+        value: repoContext(key)
+      })
+    })
+
+    var mainBlob = store('ipfs')
+    var blocksBlob = store('ipfs/')
+
+    async.eachSeries(repoData, (file, cb) => {
+      if (_.startsWith(file.key, 'datastore/')) {
+        return cb()
+      }
+
+      const blob = _.startsWith(file.key, 'blocks/')
+        ? blocksBlob
+        : mainBlob
+
+      blob.createWriteStream({
+        key: file.key
+      }).end(file.value, cb)
+    }, done)
+  })
+
+  const testsContext = require.context('.', true, /test-*/)
+  testsContext
+    .keys()
+    .forEach(key => testsContext(key))
+})

--- a/tests/test-core/index.js
+++ b/tests/test-core/index.js
@@ -28,7 +28,7 @@ describe('core', () => {
 
   const tests = fs.readdirSync(__dirname)
   tests.filter(file => {
-    if (file === 'index.js') {
+    if (file === 'index.js' || file === 'browser.js') {
       return false
     } else {
       return true

--- a/tests/test-core/test-config.js
+++ b/tests/test-core/test-config.js
@@ -67,7 +67,7 @@ describe('config', () => {
   }
 
   it('show', done => {
-    let ipfs = new IPFS()
+    const ipfs = new IPFS()
     ipfs.config.show((err, config) => {
       expect(err).to.not.exist
       expect(config).to.deep.equal(defaultConfig)
@@ -76,7 +76,7 @@ describe('config', () => {
   })
 
   it('replace', done => {
-    let ipfs = new IPFS()
+    const ipfs = new IPFS()
     ipfs.config.replace({}, err => {
       expect(err).to.not.exist
       ipfs.config.show((err, config) => {
@@ -92,7 +92,7 @@ describe('config', () => {
 
   // cli only feature built with show and replace
   // it.skip('edit', done => {
-  //   let ipfs = new IPFS()
+  //   const ipfs = new IPFS()
   //  ipfs.config((err, config) => {
   //    expect(err).to.not.exist
   //    done()

--- a/tests/test-core/test-id.js
+++ b/tests/test-core/test-id.js
@@ -9,7 +9,7 @@ const IPFS = require('../../src/ipfs-core')
 
 describe('id', () => {
   it('get id', done => {
-    let ipfs = new IPFS()
+    const ipfs = new IPFS()
     ipfs.id((err, id) => {
       expect(err).to.not.exist
       expect(id).to.deep.equal({ ID: 'QmQ2zigjQikYnyYUSXZydNXrDRhBut2mubwJBaLXobMt3A',

--- a/tests/test-core/test-version.js
+++ b/tests/test-core/test-version.js
@@ -9,7 +9,7 @@ const IPFS = require('../../src/ipfs-core')
 
 describe('version', () => {
   it('get version', done => {
-    let ipfs = new IPFS()
+    const ipfs = new IPFS()
     ipfs.version((err, version) => {
       expect(err).to.not.exist
       expect(version).to.equal('0.4.0-dev')


### PR DESCRIPTION
This is mostly the same as https://github.com/ipfs/js-ipfs-repo/pull/26.

Changed IPFS core to allow it to be instantiated with a custom `ipfs-repo`, but if none is provided it will use the default with `fs-blob-store` for `node`, or with `local-storage-blob-store` for the browser.

Also had to replace `let`'s by `const`'s on the tests [because of Firefox](https://travis-ci.org/ipfs/js-ipfs/jobs/104435637#L867).
