### PR TITLE
Use buffer-loader for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "homepage": "https://github.com/ipfs/js-ipfs#readme",
   "devDependencies": {
     "async": "^1.5.2",
-    "binary-loader": "0.0.1",
     "brfs": "^1.4.3",
+    "buffer-loader": "0.0.1",
     "chai": "^3.4.1",
     "fs-blob-store": "^5.2.1",
     "idb-plus-blob-store": "^1.0.0",
@@ -55,7 +55,6 @@
     "ncp": "^2.0.0",
     "nexpect": "^0.5.0",
     "pre-commit": "^1.1.2",
-    "raw-loader": "^0.5.1",
     "rimraf": "^2.4.4",
     "standard": "^5.4.1",
     "transform-loader": "^0.2.3",

--- a/tests/test-core/browser.js
+++ b/tests/test-core/browser.js
@@ -4,7 +4,7 @@ const async = require('async')
 const store = require('idb-plus-blob-store')
 const _ = require('lodash')
 
-const repoContext = require.context('raw!./../repo-example', true)
+const repoContext = require.context('buffer!./../repo-example', true)
 
 const idb = window.indexedDB ||
         window.mozIndexedDB ||

--- a/tests/test-core/test-block.js
+++ b/tests/test-core/test-block.js
@@ -10,20 +10,15 @@ const Block = require('ipfs-merkle-dag').Block
 
 const isNode = !global.window
 
-// FIXME remove this (it is only here because otherwise webpack is not loading Buffer and it is needed to the tests bellow)
-const noop = new Buffer([]) // eslint-disable-line
-
 const fileA = isNode
   ? fs.readFileSync(process.cwd() + '/tests/repo-example/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data')
   : require('buffer!./../repo-example/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data')
 
-// console.log('=>', fileA)
-// console.log('=>', fileA.length)
-
-describe('block', () => {
+// TODO use arrow funtions again when https://github.com/webpack/webpack/issues/1944 is fixed
+describe('block', function () {
   var ipfs
 
-  it('get', done => {
+  it('get', function (done) {
     ipfs = new IPFS()
     const b58mh = 'QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVzxTt3qVe'
     const mh = new Buffer(base58.decode(b58mh))
@@ -64,7 +59,7 @@ describe('block', () => {
     })
   })
 
-  it('stat', done => {
+  it('stat', function (done) {
     const mh = new Buffer(base58
         .decode('QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVzxTt3qVe'))
     ipfs.block.stat(mh, (err, stats) => {

--- a/tests/test-core/test-block.js
+++ b/tests/test-core/test-block.js
@@ -10,9 +10,12 @@ const Block = require('ipfs-merkle-dag').Block
 
 const isNode = !global.window
 
+// FIXME remove this (it is only here because otherwise webpack is not loading Buffer and it is needed to the tests bellow)
+const noop = new Buffer([]) // eslint-disable-line
+
 const fileA = isNode
   ? fs.readFileSync(process.cwd() + '/tests/repo-example/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data')
-  : new Buffer(require('binary!./../repo-example/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data'), 'binary')
+  : require('buffer!./../repo-example/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data')
 
 // console.log('=>', fileA)
 // console.log('=>', fileA.length)
@@ -27,7 +30,6 @@ describe('block', () => {
     ipfs.block.get(mh, (err, block) => {
       expect(err).to.not.exist
       const eq = fileA.equals(block.data)
-      console.log(block)
       expect(eq).to.equal(true)
       done()
     })


### PR DESCRIPTION
I implemented a simple [`buffer-loader`](https://github.com/xicombd/buffer-loader) based on the `binary-loader` which fixes the two missing tests.

However I got a weird bug with webpack as it doesn't seem to define `Buffer` if it is not used outside the tests, so  [I added an hack on top of the file](https://github.com/ipfs/js-ipfs/compare/update/ipfs-repo...xicombd:use-buffer-loader?expand=1#diff-9c147124754a0b48ca1d40235e76a0b6R14). 
@dignifiedquire do you have any idea how to avoid this?