### PR TITLE
Add getIPFS util and refactor id command to use it

### DIFF
--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -1,5 +1,4 @@
 const Command = require('ronin').Command
-const IPFS = require('../../ipfs-core')
 const debug = require('debug')
 const utils = require('../utils')
 const log = debug('cli')
@@ -16,22 +15,13 @@ module.exports = Command.extend({
   },
 
   run: (name) => {
-    if (utils.isDaemonOn()) {
-      const ctl = utils.getAPICtl()
-      ctl.id((err, result) => {
-        if (err) {
-          return log.error(err)
-        }
-        console.log(result)
-      })
-    } else {
-      const node = new IPFS()
-      node.id((err, id) => {
-        if (err) {
-          return log.error(err)
-        }
-        console.log(id)
-      })
-    }
+    var ipfs = utils.getIPFS()
+
+    ipfs.id((err, id) => {
+      if (err) {
+        return log.error(err)
+      }
+      console.log(id)
+    })
   }
 })

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const os = require('os')
 const APIctl = require('ipfs-api')
 const multiaddr = require('multiaddr')
+const IPFS = require('../ipfs-core')
 const debug = require('debug')
 const log = debug('cli')
 log.error = debug('cli:error')
@@ -22,11 +23,20 @@ function isDaemonOn () {
   }
 }
 
-exports.getAPICtl = () => {
-  if (!isDaemonOn) {
+exports.getAPICtl = getAPICtl
+function getAPICtl () {
+  if (!isDaemonOn()) {
     throw new Error('daemon is not on')
   }
 
   const apiAddr = multiaddr(fs.readFileSync(repoPath + '/api').toString())
   return APIctl(apiAddr.toString())
+}
+
+exports.getIPFS = () => {
+  if (!isDaemonOn()) {
+    return new IPFS()
+  }
+
+  return getAPICtl()
 }

--- a/tests/test-cli/test-bootstrap.js
+++ b/tests/test-cli/test-bootstrap.js
@@ -3,7 +3,7 @@
 const expect = require('chai').expect
 const nexpect = require('nexpect')
 
-describe('id', () => {
+describe('bootstrap', () => {
   describe('api offline', () => {
     const defaultList = [
       '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',


### PR DESCRIPTION
Add `getIPFS` method to cli utils that returns a `js-ipfs-api` instance if a daemon is running or a new core instance if not. 

Simplifies the cli commands as the two APIs are mostly equal :)