### PR TITLE
Refactor HTTP API routes

### DIFF
--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Command = require('ronin').Command
-const IPFS = require('../../ipfs-core')
+const utils = require('../utils')
 const debug = require('debug')
 const log = debug('cli:version')
 log.error = debug('cli:version:error')
@@ -26,11 +26,16 @@ module.exports = Command.extend({
   },
 
   run: (name) => {
-    var node = new IPFS()
-    node.version((err, version) => {
+    var ipfs = utils.getIPFS()
+    ipfs.version((err, version) => {
       if (err) { return log.error(err) }
 
-      console.log(version)
+      if (typeof version === 'object') { // js-ipfs-api output
+        console.log('ipfs version', version.Version)
+        return
+      }
+
+      console.log('ipfs version', version)
     })
   }
 })

--- a/src/http-api/index.js
+++ b/src/http-api/index.js
@@ -46,7 +46,7 @@ exports.start = (callback) => {
     server.connection({ host: gateway[2], port: gateway[4], labels: 'Gateway' })
 
     // load routes
-    require('./routes')
+    require('./routes')(server)
 
     server.start((err) => {
       if (err) {

--- a/src/http-api/resources/version.js
+++ b/src/http-api/resources/version.js
@@ -18,8 +18,7 @@ exports.get = (request, reply) => {
         Version: ipfsVersion,
         Commit: '',
         Repo: repoVersion
-      }).header('Transfer-Encoding', 'chunked')
-        .type('application/json')
+      })
     })
   })
 }

--- a/src/http-api/routes/block.js
+++ b/src/http-api/routes/block.js
@@ -1,10 +1,12 @@
-const api = require('./../index.js').server.select('API')
 const resources = require('./../resources')
 
 // TODO
+module.exports = (server) => {
+  const api = server.select('API')
 
-api.route({
-  method: 'GET',
-  path: '/api/v0/block',
-  handler: resources.block
-})
+  api.route({
+    method: 'GET',
+    path: '/api/v0/block',
+    handler: resources.block
+  })
+}

--- a/src/http-api/routes/bootstrap.js
+++ b/src/http-api/routes/bootstrap.js
@@ -1,47 +1,50 @@
-const api = require('./../index.js').server.select('API')
 const resources = require('./../resources')
 const Joi = require('joi')
 
-// https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L818
-api.route({
-  method: 'GET',
-  path: '/api/v0/bootstrap',
-  handler: resources.bootstrap.list
-})
+module.exports = (server) => {
+  const api = server.select('API')
 
-// https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L866
-api.route({
-  method: 'GET',
-  path: '/api/v0/bootstrap/add',
-  handler: resources.bootstrap.add,
-  config: {
-    validate: {
-      query: {
-        arg: Joi.string().required(), // multiaddr to add
-        default: Joi.boolean()
+  // https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L818
+  api.route({
+    method: 'GET',
+    path: '/api/v0/bootstrap',
+    handler: resources.bootstrap.list
+  })
+
+  // https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L866
+  api.route({
+    method: 'GET',
+    path: '/api/v0/bootstrap/add',
+    handler: resources.bootstrap.add,
+    config: {
+      validate: {
+        query: {
+          arg: Joi.string().required(), // multiaddr to add
+          default: Joi.boolean()
+        }
       }
     }
-  }
-})
+  })
 
-// https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L1081
-api.route({
-  method: 'GET',
-  path: '/api/v0/bootstrap/list',
-  handler: resources.bootstrap.list
-})
+  // https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L1081
+  api.route({
+    method: 'GET',
+    path: '/api/v0/bootstrap/list',
+    handler: resources.bootstrap.list
+  })
 
-// https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L1131
-api.route({
-  method: 'GET',
-  path: '/api/v0/bootstrap/rm',
-  handler: resources.bootstrap.rm,
-  config: {
-    validate: {
-      query: {
-        arg: Joi.string().required(), // multiaddr to rm
-        all: Joi.boolean()
+  // https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L1131
+  api.route({
+    method: 'GET',
+    path: '/api/v0/bootstrap/rm',
+    handler: resources.bootstrap.rm,
+    config: {
+      validate: {
+        query: {
+          arg: Joi.string().required(), // multiaddr to rm
+          all: Joi.boolean()
+        }
       }
     }
-  }
-})
+  })
+}

--- a/src/http-api/routes/config.js
+++ b/src/http-api/routes/config.js
@@ -1,34 +1,37 @@
-const api = require('./../index.js').server.select('API')
 const resources = require('./../resources')
 
-api.route({
-  method: '*',
-  path: '/api/v0/config/{key?}',
-  config: {
-    pre: [
-      { method: resources.config.getOrSet.parseArgs, assign: 'args' }
-    ],
-    handler: resources.config.getOrSet.handler
-  }
-})
+module.exports = (server) => {
+  const api = server.select('API')
 
-api.route({
-  method: '*',
-  path: '/api/v0/config/show',
-  handler: resources.config.show
-})
+  api.route({
+    method: '*',
+    path: '/api/v0/config/{key?}',
+    config: {
+      pre: [
+        { method: resources.config.getOrSet.parseArgs, assign: 'args' }
+      ],
+      handler: resources.config.getOrSet.handler
+    }
+  })
 
-api.route({
-  method: '*',
-  path: '/api/v0/config/replace',
-  config: {
-    payload: {
-      parse: false,
-      output: 'stream'
-    },
-    pre: [
-      { method: resources.config.replace.parseArgs, assign: 'args' }
-    ],
-    handler: resources.config.replace.handler
-  }
-})
+  api.route({
+    method: '*',
+    path: '/api/v0/config/show',
+    handler: resources.config.show
+  })
+
+  api.route({
+    method: '*',
+    path: '/api/v0/config/replace',
+    config: {
+      payload: {
+        parse: false,
+        output: 'stream'
+      },
+      pre: [
+        { method: resources.config.replace.parseArgs, assign: 'args' }
+      ],
+      handler: resources.config.replace.handler
+    }
+  })
+}

--- a/src/http-api/routes/id.js
+++ b/src/http-api/routes/id.js
@@ -1,8 +1,11 @@
-const api = require('./../index.js').server.select('API')
 const resources = require('./../resources')
 
-api.route({
-  method: 'GET',
-  path: '/api/v0/id',
-  handler: resources.id.get
-})
+module.exports = (server) => {
+  const api = server.select('API')
+
+  api.route({
+    method: 'GET',
+    path: '/api/v0/id',
+    handler: resources.id.get
+  })
+}

--- a/src/http-api/routes/index.js
+++ b/src/http-api/routes/index.js
@@ -1,7 +1,9 @@
-require('./version')
-require('./id')
-require('./bootstrap')
-// require('./block')
-// require('./object')
-// require('./repo')
-require('./config')
+module.exports = (server) => {
+  require('./version')(server)
+  require('./id')(server)
+  require('./bootstrap')(server)
+  // require('./block')(server)
+  // require('./object')(server)
+  // require('./repo')(server)
+  require('./config')(server)
+}

--- a/src/http-api/routes/object.js
+++ b/src/http-api/routes/object.js
@@ -1,10 +1,12 @@
-const api = require('./../index.js').server.select('API')
 const resources = require('./../resources')
 
 // TODO
+module.exports = (server) => {
+  const api = server.select('API')
 
-api.route({
-  method: 'GET',
-  path: '/api/v0/object',
-  handler: resources.object
-})
+  api.route({
+    method: 'GET',
+    path: '/api/v0/object',
+    handler: resources.object
+  })
+}

--- a/src/http-api/routes/repo.js
+++ b/src/http-api/routes/repo.js
@@ -1,10 +1,12 @@
-const api = require('./../index.js').server.select('API')
 const resources = require('./../resources')
 
 // TODO
+module.exports = (server) => {
+  const api = server.select('API')
 
-api.route({
-  method: 'GET',
-  path: '/api/v0/repo',
-  handler: resources.repo
-})
+  api.route({
+    method: 'GET',
+    path: '/api/v0/repo',
+    handler: resources.repo
+  })
+}

--- a/src/http-api/routes/version.js
+++ b/src/http-api/routes/version.js
@@ -1,8 +1,11 @@
-const api = require('./../index.js').server.select('API')
 const resources = require('./../resources')
 
-api.route({
-  method: 'GET',
-  path: '/api/v0/version',
-  handler: resources.version.get
-})
+module.exports = (server) => {
+  const api = server.select('API')
+
+  api.route({
+    method: 'GET',
+    path: '/api/v0/version',
+    handler: resources.version.get
+  })
+}

--- a/tests/test-cli/test-version.js
+++ b/tests/test-cli/test-version.js
@@ -2,14 +2,15 @@
 
 const expect = require('chai').expect
 const nexpect = require('nexpect')
+const httpAPI = require('../../src/http-api')
 
 describe('version', () => {
   describe('api offline', () => {
     it('get the version', (done) => {
       nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'version'])
-        .expect('0.4.0-dev')
         .run((err, stdout, exitcode) => {
           expect(err).to.not.exist
+          expect(stdout[0]).to.equal('ipfs version 0.4.0-dev')
           expect(exitcode).to.equal(0)
           done()
         })
@@ -17,6 +18,28 @@ describe('version', () => {
   })
 
   describe('api running', () => {
-    // TODO
+    before((done) => {
+      httpAPI.start((err) => {
+        expect(err).to.not.exist
+        done()
+      })
+    })
+
+    after((done) => {
+      httpAPI.stop((err) => {
+        expect(err).to.not.exist
+        done()
+      })
+    })
+
+    it('get the version', (done) => {
+      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'version'])
+        .run((err, stdout, exitcode) => {
+          expect(err).to.not.exist
+          expect(exitcode).to.equal(0)
+          expect(stdout[0]).to.equal('ipfs version 0.4.0-dev')
+          done()
+        })
+    })
   })
 })

--- a/tests/test-http-api/test-version.js
+++ b/tests/test-http-api/test-version.js
@@ -35,8 +35,7 @@ describe('version', () => {
       done()
     })
 
-    // TODO fix: only fails on travis
-    it.skip('get the version', (done) => {
+    it('get the version', (done) => {
       ctl.version((err, result) => {
         expect(err).to.not.exist
         expect(result).to.have.a.property('Version')


### PR DESCRIPTION
Use dependency injection on routes so that we can start and stop the http-api multiple times without issues on the tests. 
~~Updated `jsipfs version` to work with the api running and added a test to make sure it works :)~~ Got similar bug to #70