### PR TITLE
Fix peer-id errors on browser tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
 module.exports = function (config) {
   var path = require('path')
-  var nodeForgePath = path.resolve(__dirname, 'node_modules/peer-id/deps/forge.bundle.js')
+  var nodeForgePath = path.resolve(__dirname, 'node_modules/peer-id/vendor/forge.bundle.js')
 
   config.set({
     basePath: '',
@@ -31,7 +31,12 @@ module.exports = function (config) {
       module: {
         loaders: [
           { test: /\.json$/, loader: 'json' }
-        ]
+        ],
+        postLoaders: [{
+          test: /\.js$/,
+          loader: 'transform?brfs',
+          include: /node_modules\/peer-id/
+        }]
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "libp2p-ipfs": "^0.2.0",
     "lodash.get": "^4.0.0",
     "lodash.set": "^4.0.0",
-    "peer-id": "^0.6.1",
+    "peer-id": "^0.6.3",
     "peer-info": "^0.6.0",
     "ronin": "^0.3.11",
     "temp": "^0.8.3"


### PR DESCRIPTION
Fixes #131 & #130 

- [x] `forge.bundle.js` path change
- [x] fs support [more info here](https://github.com/diasdavid/js-peer-id/pull/12/files#diff-1fdf421c05c1140f6d71444ea2b27638L15)

The `postLoader` can be removed when we switch to `dignified.js`. 
Thanks @dignifiedquire for the help :)