### PR TITLE
updated cat core to return just file stream

### DIFF
--- a/src/cli/commands/files/add.js
+++ b/src/cli/commands/files/add.js
@@ -59,37 +59,41 @@ module.exports = Command.extend({
         if (err) {
           throw err
         }
-        const i = ipfs.files.add()
-        var filePair
-        i.on('data', (file) => {
-          console.log('added', bs58.encode(file.multihash).toString(), file.path)
-        })
-        i.once('end', () => {
-          return
-        })
-        if (res.length !== 0) {
-          const index = inPath.lastIndexOf('/')
-          parallelLimit(res.map((element) => (callback) => {
-            if (!fs.statSync(element).isDirectory()) {
-              i.write({
-                path: element.substring(index + 1, element.length),
-                stream: fs.createReadStream(element)
-              })
-            }
-            callback()
-          }), 10, (err) => {
-            if (err) {
-              throw err
-            }
-            i.end()
+        ipfs.files.add((err, i) => {
+          if (err) {
+            throw err
+          }
+          var filePair
+          i.on('data', (file) => {
+            console.log('added', bs58.encode(file.multihash).toString(), file.path)
           })
-        } else {
-          rs = fs.createReadStream(inPath)
-          inPath = inPath.substring(inPath.lastIndexOf('/') + 1, inPath.length)
-          filePair = {path: inPath, stream: rs}
-          i.write(filePair)
-          i.end()
-        }
+          i.once('end', () => {
+            return
+          })
+          if (res.length !== 0) {
+            const index = inPath.lastIndexOf('/')
+            parallelLimit(res.map((element) => (callback) => {
+              if (!fs.statSync(element).isDirectory()) {
+                i.write({
+                  path: element.substring(index + 1, element.length),
+                  stream: fs.createReadStream(element)
+                })
+              }
+              callback()
+            }), 10, (err) => {
+              if (err) {
+                throw err
+              }
+              i.end()
+            })
+          } else {
+            rs = fs.createReadStream(inPath)
+            inPath = inPath.substring(inPath.lastIndexOf('/') + 1, inPath.length)
+            filePair = {path: inPath, stream: rs}
+            i.write(filePair)
+            i.end()
+          }
+        })
       })
     })
   }

--- a/src/cli/commands/files/cat.js
+++ b/src/cli/commands/files/cat.js
@@ -31,13 +31,11 @@ module.exports = Command.extend({
         })
         return
       }
-      ipfs.files.cat(path, (err, res) => {
+      ipfs.files.cat(path, (err, file) => {
         if (err) {
           throw (err)
         }
-        res.on('data', (data) => {
-          data.stream.pipe(process.stdout)
-        })
+        file.pipe(process.stdout)
       })
     })
   }

--- a/src/cli/commands/files/cat.js
+++ b/src/cli/commands/files/cat.js
@@ -35,6 +35,7 @@ module.exports = Command.extend({
         if (err) {
           throw (err)
         }
+        console.log(file)
         file.pipe(process.stdout)
       })
     })

--- a/src/core/ipfs/files.js
+++ b/src/core/ipfs/files.js
@@ -45,7 +45,9 @@ module.exports = function files (self) {
           callback('This dag node is a directory', null)
         } else {
           const exportStream = Exporter(hash, self._dagS)
-          callback(null, exportStream)
+          exportStream.on('data', (object) => {
+            callback(null, object.stream)
+          })
         }
       })
     },

--- a/src/core/ipfs/files.js
+++ b/src/core/ipfs/files.js
@@ -3,16 +3,17 @@
 const Importer = require('ipfs-unixfs-engine').importer
 const Exporter = require('ipfs-unixfs-engine').exporter
 const UnixFS = require('ipfs-unixfs')
+const promisify = require('promisify-es6')
 
 module.exports = function files (self) {
   return {
-    add: (arr, callback) => {
+    add: promisify((arr, cb) => {
       if (typeof arr === 'function') {
-        callback = arr
+        cb = arr
         arr = undefined
       }
-      if (callback === undefined) {
-        callback = function noop () {}
+      if (cb === undefined) {
+        cb = function noop () {}
       }
       if (arr === undefined) {
         return new Importer(self._dagS)
@@ -26,7 +27,7 @@ module.exports = function files (self) {
       })
 
       i.once('end', () => {
-        callback(null, res)
+        cb(null, res)
       })
 
       arr.forEach((tuple) => {
@@ -34,26 +35,28 @@ module.exports = function files (self) {
       })
 
       i.end()
-    },
-    cat: (hash, callback) => {
+    }),
+
+    cat: promisify((hash, cb) => {
       self._dagS.get(hash, (err, fetchedNode) => {
         if (err) {
-          return callback(err, null)
+          return cb(err, null)
         }
         const data = UnixFS.unmarshal(fetchedNode.data)
         if (data.type === 'directory') {
-          callback('This dag node is a directory', null)
+          cb('This dag node is a directory', null)
         } else {
           const exportStream = Exporter(hash, self._dagS)
           exportStream.once('data', (object) => {
-            callback(null, object.stream)
+            cb(null, object.stream)
           })
         }
       })
-    },
-    get: (hash, callback) => {
+    }),
+
+    get: promisify((hash, cb) => {
       var exportFile = Exporter(hash, self._dagS)
-      callback(null, exportFile)
-    }
+      cb(null, exportFile)
+    })
   }
 }

--- a/src/core/ipfs/files.js
+++ b/src/core/ipfs/files.js
@@ -45,7 +45,7 @@ module.exports = function files (self) {
           callback('This dag node is a directory', null)
         } else {
           const exportStream = Exporter(hash, self._dagS)
-          exportStream.on('data', (object) => {
+          exportStream.once('data', (object) => {
             callback(null, object.stream)
           })
         }

--- a/src/core/ipfs/files.js
+++ b/src/core/ipfs/files.js
@@ -16,7 +16,7 @@ module.exports = function files (self) {
         cb = function noop () {}
       }
       if (arr === undefined) {
-        return new Importer(self._dagS)
+        cb(null, new Importer(self._dagS))
       }
 
       const i = new Importer(self._dagS)

--- a/src/http-api/resources/files.js
+++ b/src/http-api/resources/files.js
@@ -42,9 +42,7 @@ exports.cat = {
           Code: 0
         }).code(500)
       }
-      stream.on('data', (data) => {
-        return reply(data.stream)
-      })
+      return reply(stream)
     })
   }
 }

--- a/test/core-tests/test-files.js
+++ b/test/core-tests/test-files.js
@@ -37,13 +37,11 @@ describe('files', () => {
     const hash = 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
     ipfs.files.cat(hash, (err, res) => {
       expect(err).to.not.exist
-      res.on('data', (data) => {
-        data.stream.pipe(bl((err, bldata) => {
-          expect(err).to.not.exist
-          expect(bldata.toString()).to.equal('hello world\n')
-          done()
-        }))
-      })
+      res.pipe(bl((err, bldata) => {
+        expect(err).to.not.exist
+        expect(bldata.toString()).to.equal('hello world\n')
+        done()
+      }))
     })
   })
 

--- a/test/core-tests/test-files.js
+++ b/test/core-tests/test-files.js
@@ -1,62 +1,20 @@
 /* eslint-env mocha */
 'use strict'
 
-const bl = require('bl')
-const expect = require('chai').expect
-const Readable = require('stream').Readable
-const bs58 = require('bs58')
+const test = require('interface-ipfs-core')
 
 const IPFS = require('../../src/core')
 
-describe('files', () => {
-  let ipfs
-
-  before((done) => {
-    ipfs = new IPFS(require('./repo-path'))
-    ipfs.load(done)
-  })
-
-  it('add', (done) => {
-    const buffered = new Buffer('some data')
-    const rs = new Readable()
-    rs.push(buffered)
-    rs.push(null)
-    const arr = []
-    const filePair = {path: 'data.txt', stream: rs}
-    arr.push(filePair)
-    ipfs.files.add(arr, (err, res) => {
-      expect(err).to.not.exist
-      expect(res[0].path).to.equal('data.txt')
-      expect(res[0].size).to.equal(17)
-      expect(bs58.encode(res[0].multihash).toString()).to.equal('QmVv4Wz46JaZJeH5PMV4LGbRiiMKEmszPYY3g6fjGnVXBS')
-      done()
+const common = {
+  setup: function (cb) {
+    const ipfs = new IPFS(require('./repo-path'))
+    ipfs.load(() => {
+      cb(null, ipfs)
     })
-  })
+  },
+  teardown: function (cb) {
+    cb()
+  }
+}
 
-  it('cat', (done) => {
-    const hash = 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
-    ipfs.files.cat(hash, (err, res) => {
-      expect(err).to.not.exist
-      res.pipe(bl((err, bldata) => {
-        expect(err).to.not.exist
-        expect(bldata.toString()).to.equal('hello world\n')
-        done()
-      }))
-    })
-  })
-
-  it('get', (done) => {
-    // TODO create non-trival get test
-    const hash = 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
-    ipfs.files.get(hash, (err, res) => {
-      expect(err).to.not.exist
-      res.on('data', (data) => {
-        data.stream.pipe(bl((err, bldata) => {
-          expect(err).to.not.exist
-          expect(bldata.toString()).to.equal('hello world\n')
-          done()
-        }))
-      })
-    })
-  })
-})
+test.files(common)


### PR DESCRIPTION
This came from conversation over the interface-core cat api talks <a href="https://github.com/ipfs/interface-ipfs-core/pull/21">PR</a>.

This changes the core files cat command to return just the stream part of the <a href="https://github.com/ipfs/js-ipfs-unixfs-engine/blob/master/src/exporter.js#L45">unixfs-engine.exporter</a>

This also updates the cat cli, http-api, and tests to respect the change.