### PR TITLE
Make ipfs.files.add return DAGNodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ipfs-merkle-dag": "^0.6.0",
     "ipfs-multipart": "^0.1.0",
     "ipfs-repo": "^0.8.0",
-    "ipfs-unixfs-engine": "^0.8.0",
+    "ipfs-unixfs-engine": "^0.9.0",
     "isstream": "^0.1.2",
     "joi": "^8.0.5",
     "libp2p-ipfs": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ipfs-multipart": "^0.1.0",
     "ipfs-repo": "^0.8.0",
     "ipfs-unixfs-engine": "^0.8.0",
+    "isstream": "^0.1.2",
     "joi": "^8.0.5",
     "libp2p-ipfs": "^0.10.1",
     "libp2p-ipfs-browser": "^0.9.1",
@@ -92,7 +93,8 @@
     "run-parallel-limit": "^1.0.3",
     "run-series": "^1.1.4",
     "run-waterfall": "^1.1.3",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "through2": "^2.0.1"
   },
   "contributors": [
     "Andrew de Andrade <andrew@deandrade.com.br>",

--- a/src/cli/commands/files/add.js
+++ b/src/cli/commands/files/add.js
@@ -73,7 +73,7 @@ module.exports = Command.extend({
             if (!fs.statSync(element).isDirectory()) {
               i.write({
                 path: element.substring(index + 1, element.length),
-                stream: fs.createReadStream(element)
+                content: fs.createReadStream(element)
               })
             }
             callback()
@@ -86,7 +86,7 @@ module.exports = Command.extend({
         } else {
           rs = fs.createReadStream(inPath)
           inPath = inPath.substring(inPath.lastIndexOf('/') + 1, inPath.length)
-          filePair = {path: inPath, stream: rs}
+          filePair = {path: inPath, content: rs}
           i.write(filePair)
           i.end()
         }

--- a/src/cli/commands/files/cat.js
+++ b/src/cli/commands/files/cat.js
@@ -36,7 +36,7 @@ module.exports = Command.extend({
           throw (err)
         }
         res.on('data', (data) => {
-          data.stream.pipe(process.stdout)
+          data.content.pipe(process.stdout)
         })
       })
     })

--- a/src/cli/commands/files/get.js
+++ b/src/cli/commands/files/get.js
@@ -48,7 +48,7 @@ function fileHandler (result, dir) {
       const dirPath = path.join(dir, file.path)
       // Check to see if the result is a directory
       if (file.dir === false) {
-        file.stream.pipe(fs.createWriteStream(dirPath))
+        file.content.pipe(fs.createWriteStream(dirPath))
       } else {
         ensureDir(dirPath, (err) => {
           if (err) {
@@ -64,7 +64,7 @@ function fileHandler (result, dir) {
           throw err
         }
 
-        file.stream.pipe(fs.createWriteStream(dirPath))
+        file.content.pipe(fs.createWriteStream(dirPath))
       })
     }
   }

--- a/src/core/ipfs/files.js
+++ b/src/core/ipfs/files.js
@@ -3,38 +3,68 @@
 const Importer = require('ipfs-unixfs-engine').importer
 const Exporter = require('ipfs-unixfs-engine').exporter
 const UnixFS = require('ipfs-unixfs')
+const bs58 = require('bs58')
+const through = require('through2')
+const isStream = require('isstream')
+const promisify = require('promisify-es6')
 
 module.exports = function files (self) {
   return {
-    add: (arr, callback) => {
-      if (typeof arr === 'function') {
-        callback = arr
-        arr = undefined
-      }
-      if (callback === undefined) {
-        callback = function noop () {}
-      }
-      if (arr === undefined) {
+    createAddStream: promisify((callback) => {
+      // TODO: wip
+      if (data === undefined) {
         return new Importer(self._dagS)
+      }
+    }),
+
+    add: promisify((data, callback) => {
+      // Buffer input
+      if (Buffer.isBuffer(data)) {
+        data = [{
+          path: '',
+          content: data
+        }]
+      }
+      // Readable stream input
+      if (isStream.isReadable(data)) {
+        data = [{
+          path: '',
+          content: data
+        }]
+      }
+      if (!callback || typeof callback !== 'function') {
+        callback = function oop () {}
+      }
+      if (!Array.isArray(data)) {
+        return callback(new Error('"data" must be an array of { path: string, content: Buffer|Readable } or Buffer or Readable'))
       }
 
       const i = new Importer(self._dagS)
       const res = []
 
-      i.on('data', (info) => {
-        res.push(info)
-      })
-
-      i.once('end', () => {
+      // Transform file info tuples to DAGNodes
+      i.pipe(through.obj(function transform (info, enc, next) {
+        const mh = bs58.encode(info.multihash).toString()
+        self._dagS.get(mh, (err, node) => {
+          if (err) return callback(err)
+          var obj = {
+            path: info.path || mh,
+            node: node
+          }
+          res.push(obj)
+          next()
+        })
+      }, function end (done) {
         callback(null, res)
-      })
+      }))
 
-      arr.forEach((tuple) => {
+      data.forEach((tuple) => {
         i.write(tuple)
       })
 
       i.end()
-    },
+    }),
+
     cat: (hash, callback) => {
       self._dagS.get(hash, (err, fetchedNode) => {
         if (err) {

--- a/src/core/ipfs/init.js
+++ b/src/core/ipfs/init.js
@@ -91,7 +91,7 @@ module.exports = function init (self) {
             const rs = new Readable()
             rs.push(fs.readFileSync(element))
             rs.push(null)
-            const filePair = {path: addPath, stream: rs}
+            const filePair = {path: addPath, content: rs}
             i.write(filePair)
           }
           callback()

--- a/src/http-api/resources/files.js
+++ b/src/http-api/resources/files.js
@@ -43,7 +43,7 @@ exports.cat = {
         }).code(500)
       }
       stream.on('data', (data) => {
-        return reply(data.stream)
+        return reply(data.content)
       })
     })
   }

--- a/test/cli/test-bitswap.js
+++ b/test/cli/test-bitswap.js
@@ -12,7 +12,7 @@ const createTempNode = require('../utils/temp-node')
 const repoPath = require('./index').repoPath
 
 describe('bitswap', function () {
-  this.timeout(20000)
+  this.timeout(40000)
   const env = _.clone(process.env)
   env.IPFS_PATH = repoPath
 

--- a/test/core/both/test-bitswap.js
+++ b/test/core/both/test-bitswap.js
@@ -196,7 +196,7 @@ describe('bitswap', () => {
             ipfs.files.cat(hash, (err, res) => {
               expect(err).to.not.exist
               res.on('file', (data) => {
-                data.stream.pipe(bl((err, bldata) => {
+                data.content.pipe(bl((err, bldata) => {
                   expect(err).to.not.exist
                   expect(bldata.toString()).to.equal('I love IPFS <3')
                   cb()

--- a/test/core/both/test-bitswap.js
+++ b/test/core/both/test-bitswap.js
@@ -101,7 +101,8 @@ describe('bitswap', () => {
       })
 
       afterEach((done) => {
-        setTimeout(() => ipfs.goOffline(done), 500)
+        // ipfs.goOffline(done)
+        setTimeout(() => ipfs.goOffline(done), 1500)
       })
 
       it('2 peers', (done) => {

--- a/test/core/both/test-files.js
+++ b/test/core/both/test-files.js
@@ -1,64 +1,19 @@
 /* eslint-env mocha */
 'use strict'
 
-const bl = require('bl')
-const expect = require('chai').expect
-const Readable = require('stream').Readable
-const bs58 = require('bs58')
-
+const test = require('interface-ipfs-core')
 const IPFS = require('../../../src/core')
 
-describe('files', () => {
-  let ipfs
-
-  before((done) => {
-    ipfs = new IPFS(require('../../utils/repo-path'))
-    ipfs.load(done)
-  })
-
-  it('add', (done) => {
-    const buffered = new Buffer('some data')
-    const rs = new Readable()
-    rs.push(buffered)
-    rs.push(null)
-    const arr = []
-    const filePair = {path: 'data.txt', stream: rs}
-    arr.push(filePair)
-    ipfs.files.add(arr, (err, res) => {
-      expect(err).to.not.exist
-      expect(res[0].path).to.equal('data.txt')
-      expect(res[0].size).to.equal(17)
-      expect(bs58.encode(res[0].multihash).toString()).to.equal('QmVv4Wz46JaZJeH5PMV4LGbRiiMKEmszPYY3g6fjGnVXBS')
-      done()
+const common = {
+  setup: function (cb) {
+    const ipfs = new IPFS(require('../../utils/repo-path'))
+    ipfs.load(() => {
+      cb(null, ipfs)
     })
-  })
+  },
+  teardown: function (cb) {
+    cb()
+  }
+}
 
-  it('cat', (done) => {
-    const hash = 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
-    ipfs.files.cat(hash, (err, res) => {
-      expect(err).to.not.exist
-      res.on('data', (data) => {
-        data.stream.pipe(bl((err, bldata) => {
-          expect(err).to.not.exist
-          expect(bldata.toString()).to.equal('hello world\n')
-          done()
-        }))
-      })
-    })
-  })
-
-  it('get', (done) => {
-    // TODO create non-trival get test
-    const hash = 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
-    ipfs.files.get(hash, (err, res) => {
-      expect(err).to.not.exist
-      res.on('data', (data) => {
-        data.stream.pipe(bl((err, bldata) => {
-          expect(err).to.not.exist
-          expect(bldata.toString()).to.equal('hello world\n')
-          done()
-        }))
-      })
-    })
-  })
-})
+test.files(common)

--- a/test/core/node-only/test-swarm.js
+++ b/test/core/node-only/test-swarm.js
@@ -7,7 +7,7 @@ const parallel = require('run-parallel')
 const createTempNode = require('../../utils/temp-node')
 
 describe('swarm', function () {
-  this.timeout(20 * 1000)
+  this.timeout(40 * 1000)
 
   let nodeA
   let nodeB

--- a/test/http-api/test-files.js
+++ b/test/http-api/test-files.js
@@ -9,8 +9,9 @@ module.exports = (httpAPI) => {
     describe('api', () => {
       let api
 
-      it('api', () => {
+      before((done) => {
         api = httpAPI.server.select('API')
+        done()
       })
 
       describe('/files/cat', () => {


### PR DESCRIPTION
- [x] transform file tuples into `DAGNode`s
- [ ] use + pass interface-ipfs-core tests for files.add

NOTE: this breaks backwards compatibility for `add` and will require a major semver bump.