### PR TITLE
fix repo path for tests in browser

### DIFF
--- a/test/core-tests/repo-path.js
+++ b/test/core-tests/repo-path.js
@@ -1,5 +1,10 @@
 'use strict'
 
 const path = require('path')
+const isNode = require('detect-node')
 
-module.exports = path.join(__dirname, '../repo-tests-run')
+if (isNode) {
+  module.exports = path.join(__dirname, '../repo-tests-run')
+} else {
+  module.exports = 'ipfs'
+}


### PR DESCRIPTION
the one time I don’t wait for CI, a 1 line change PR, something was indeed broken (the browser couldn’t take the crazy path for indexedDB). Fixed now.

https://github.com/ipfs/js-ipfs/pull/273

I guess this teaches me a lesson, that I kind of knew xD :D