### PR TITLE
Promisify ipfs.files.get

### DIFF
--- a/src/core/ipfs/files.js
+++ b/src/core/ipfs/files.js
@@ -120,9 +120,9 @@ module.exports = function files (self) {
       })
     }),
 
-    get: (hash, callback) => {
+    get: promisify((hash, callback) => {
       var exportFile = Exporter(hash, self._dagS)
       callback(null, exportFile)
-    }
+    })
   }
 }


### PR DESCRIPTION
This is needed for interface-ipfs-core consistency.

Depends on https://github.com/ipfs/js-ipfs-unixfs-engine/pull/52