### PR TITLE
remove toString

### DIFF
--- a/src/http-api/resources/object.js
+++ b/src/http-api/resources/object.js
@@ -160,7 +160,7 @@ exports.data = {
         }).code(500)
       }
 
-      return reply(data.toString())
+      return reply(data)
     })
   }
 }


### PR DESCRIPTION
I found that this was causing incorrect returns when writing the ```add``` http resource. JS-IPFS-API makes http requests to the js-ipfs ```object``` core now with the addition of the new ```add``` support for core <a href="https://github.com/ipfs/js-ipfs-api/blob/master/src/get-dagnode.js#L19">here</a>.

If the data is a string then the buffer is sent correctly, however if the data field is something else it seems to be wrapping the buffer with some extra maybe new line characters. 

@diasdavid @dignifiedquire 
Is there a specific reason for the data to be return as a string in the ```object/data``` http resource?

<a href="https://github.com/ipfs/js-ipfs/pull/323">PR 323</a> Is blocked by this issue.

