### PR TITLE
fix(cli): add output for cli init

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -32,6 +32,9 @@ module.exports = {
   handler (argv) {
     const path = utils.getRepoPath()
 
+    const log = utils.createLogger(true)
+    log(`initializing ipfs node at ${path}`)
+
     const repo = new IpfsRepo(path, {
       stores: Store
     })
@@ -41,7 +44,8 @@ module.exports = {
     ipfs.init({
       bits: argv.bits,
       force: argv.force,
-      emptyRepo: argv.emptyRepo
+      emptyRepo: argv.emptyRepo,
+      log
     }, function (err) {
       if (err) {
         console.error(err.toString())

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -49,3 +49,18 @@ exports.getIPFS = (callback) => {
 exports.getRepoPath = () => {
   return process.env.IPFS_PATH || os.homedir() + '/.ipfs'
 }
+
+exports.createLogger = (visible) => {
+  return (msg, newline) => {
+    if (newline === undefined) {
+      newline = true
+    }
+    if (visible) {
+      if (msg === undefined) {
+        msg = ''
+      }
+      msg = newline ? msg + '\n' : msg
+      process.stdout.write(msg)
+    }
+  }
+}


### PR DESCRIPTION
Shows exactly same information as go-ipfs except for change of the cmd +
cat so `ipfs cat` turns into `jsipfs files cat` instead. Ref: issue #286