### PR TITLE
fix(cli): use right argument for cli .cat

### DIFF
--- a/src/cli/commands/files/cat.js
+++ b/src/cli/commands/files/cat.js
@@ -13,7 +13,7 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    const path = argv.ipfsPath
+    const path = argv['ipfs-path']
     utils.getIPFS((err, ipfs) => {
       if (err) {
         throw err

--- a/test/cli/test-files.js
+++ b/test/cli/test-files.js
@@ -17,6 +17,7 @@ describe('files', () => {
         .run((err, stdout, exitcode) => {
           expect(err).to.not.exist
           expect(exitcode).to.equal(0)
+          expect(stdout[0]).to.equal('hello world')
           done()
         })
     })


### PR DESCRIPTION
Add tests for making sure .cat shows right output and fix that test by
using the right argument from cli. Ref: issue #476