### PR TITLE
benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules
 
 lib
 dist
+
+current.json

--- a/.npmignore
+++ b/.npmignore
@@ -32,3 +32,5 @@ build
 node_modules
 
 test
+
+current.json

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "release": "gulp release",
     "release-minor": "gulp release --type minor",
     "release-major": "gulp release --type major",
-    "coverage-publish": "aegir-coverage publish"
+    "coverage-publish": "aegir-coverage publish",
+    "bench": "./scripts/bench.sh"
   },
   "pre-commit": [
     "lint",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,10 @@
+# Scripts
+
+## `bench.sh`
+
+Run benchmarks using [ipfs-whatever](https://github.com/whyrusleeping/ipfs-whatever). This will create a file called `current.json` in the current folder with the results.
+
+### Requirements
+
+- go
+- Node.js

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "-- downloading benchmarks"
+go get github.com/whyrusleeping/ipfs-whatever
+
+echo "-- setting up ipfs"
+export IPFS_PATH=/tmp/bench-repo
+node src/cli/bin.js init
+node src/cli/bin.js daemon &
+sleep 5
+
+echo "-- running benchmarks"
+ipfs-whatever > current.json
+
+echo "-- cleaning up"
+rm -rf /tmp/bench-repo

--- a/src/http-api/resources/files.js
+++ b/src/http-api/resources/files.js
@@ -23,9 +23,14 @@ exports.parseKey = (request, reply) => {
     }).code(400).takeover()
   }
 
+  let arg = request.query.arg
   try {
+    if (arg.indexOf('/ipfs/') === 0) {
+      arg = arg.replace('/ipfs/', '')
+    }
+
     return reply({
-      key: mh.fromB58String(request.query.arg)
+      key: mh.fromB58String(arg)
     })
   } catch (err) {
     log.error(err)


### PR DESCRIPTION
As discussed in #455 this adds a simple shell script to run [ipfs-whatever](https://github.com/whyrusleeping/ipfs-whatever) benchmarks agains js-ipfs. 

Missing currently
- [x] top level alias`cat` for `files.cat`
- [x] top level alias `add` for `files.add`
