### PR TITLE
feat(http): make swarm interface-ipfs-core compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",
     "lodash.sortby": "^4.7.0",
+    "lodash.values": "^4.3.0",
     "mafmt": "^2.1.2",
     "map-limit": "0.0.1",
     "multiaddr": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "joi": "^9.0.4",
     "libp2p-ipfs": "^0.14.1",
     "libp2p-ipfs-browser": "^0.15.1",
+    "lodash.flatmap": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "gulp": "^3.9.1",
     "idb-plus-blob-store": "^1.1.2",
     "idb-pull-blob-store": "^0.4.0",
-    "interface-ipfs-core": "^0.14.6",
+    "interface-ipfs-core": "^0.15.0",
     "left-pad": "^1.1.1",
     "lodash": "^4.15.0",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "detect-node": "^2.0.3",
     "glob": "^7.0.6",
     "hapi": "^15.0.3",
-    "ipfs-api": "^8.0.4",
+    "ipfs-api": "^9.0.0",
     "ipfs-bitswap": "^0.7.0",
     "ipfs-block": "^0.3.0",
     "ipfs-block-service": "^0.5.0",

--- a/src/cli/commands/swarm/addrs.js
+++ b/src/cli/commands/swarm/addrs.js
@@ -20,7 +20,21 @@ module.exports = {
       if (err) {
         throw err
       }
-      // TODO
+
+      ipfs.swarm.addrs((err, res) => {
+        if (err) {
+          throw err
+        }
+
+        res.forEach((peer) => {
+          const count = peer.multiaddrs.length
+          console.log(`${peer.id.toB58String()} (${count})`)
+          peer.multiaddrs.forEach((addr) => {
+            const res = addr.decapsulate('ipfs').toString()
+            console.log(`\t${res}`)
+          })
+        })
+      })
     })
   }
 }

--- a/src/cli/commands/swarm/addrs/local.js
+++ b/src/cli/commands/swarm/addrs/local.js
@@ -27,8 +27,8 @@ module.exports = {
           throw err
         }
 
-        res.Strings.forEach((addr) => {
-          console.log(addr)
+        res.forEach((addr) => {
+          console.log(addr.toString())
         })
       })
     })

--- a/src/cli/commands/swarm/peers.js
+++ b/src/cli/commands/swarm/peers.js
@@ -27,8 +27,8 @@ module.exports = {
           throw err
         }
 
-        res.Strings.forEach((addr) => {
-          console.log(addr)
+        res.forEach((addr) => {
+          console.log(addr.toString())
         })
       })
     })

--- a/src/core/components/swarm.js
+++ b/src/core/components/swarm.js
@@ -3,6 +3,7 @@
 const multiaddr = require('multiaddr')
 const promisify = require('promisify-es6')
 const flatMap = require('lodash.flatmap')
+const values = require('lodash.values')
 
 const OFFLINE_ERROR = require('../utils').OFFLINE_ERROR
 
@@ -13,18 +14,24 @@ module.exports = function swarm (self) {
         return callback(OFFLINE_ERROR)
       }
 
-      const mas = collectAddrs(self._libp2pNode.peerBook)
+      const peers = self._libp2pNode.peerBook.getAll()
+      const mas = flatMap(Object.keys(peers), (id) => {
+        return peers[id].multiaddrs
+      })
+
       callback(null, mas)
     }),
+
     // all the addrs we know
     addrs: promisify((callback) => {
       if (!self.isOnline()) {
         return callback(OFFLINE_ERROR)
       }
 
-      const mas = collectAddrs(self._libp2pNode.peerBook)
-      callback(null, mas)
+      const peers = values(self._libp2pNode.peerBook.getAll())
+      callback(null, peers)
     }),
+
     localAddrs: promisify((callback) => {
       if (!self.isOnline()) {
         return callback(OFFLINE_ERROR)
@@ -32,6 +39,7 @@ module.exports = function swarm (self) {
 
       callback(null, self._libp2pNode.peerInfo.multiaddrs)
     }),
+
     connect: promisify((maddr, callback) => {
       if (!self.isOnline()) {
         return callback(OFFLINE_ERROR)
@@ -43,6 +51,7 @@ module.exports = function swarm (self) {
 
       self._libp2pNode.dialByMultiaddr(maddr, callback)
     }),
+
     disconnect: promisify((maddr, callback) => {
       if (!self.isOnline()) {
         return callback(OFFLINE_ERROR)
@@ -54,16 +63,10 @@ module.exports = function swarm (self) {
 
       self._libp2pNode.hangUpByMultiaddr(maddr, callback)
     }),
+
     filters: promisify((callback) => {
       // TODO
       throw new Error('Not implemented')
     })
   }
-}
-
-function collectAddrs (book) {
-  const peers = book.getAll()
-  return flatMap(Object.keys(peers), (id) => {
-    return peers[id].multiaddrs
-  })
 }

--- a/src/http-api/routes/swarm.js
+++ b/src/http-api/routes/swarm.js
@@ -13,13 +13,13 @@ module.exports = (server) => {
     }
   })
 
-  // api.route({
-  //   method: '*',
-  //   path: '/api/v0/swarm/addrs',
-  //   config: {
-  //     handler: resources.swarm.addrs.handler
-  //   }
-  // })
+  api.route({
+    method: '*',
+    path: '/api/v0/swarm/addrs',
+    config: {
+      handler: resources.swarm.addrs.handler
+    }
+  })
 
   api.route({
     method: '*',
@@ -40,13 +40,16 @@ module.exports = (server) => {
     }
   })
 
-  // api.route({
-  //   method: '*',
-  //   path: '/api/v0/swarm/disconnect',
-  //   config: {
-  //     handler: resources.swarm.disconnect
-  //   }
-  // })
+  api.route({
+    method: '*',
+    path: '/api/v0/swarm/disconnect',
+    config: {
+      pre: [
+        { method: resources.swarm.disconnect.parseArgs, assign: 'args' }
+      ],
+      handler: resources.swarm.disconnect.handler
+    }
+  })
 
   // TODO
   // api.route({

--- a/test/cli/test-swarm.js
+++ b/test/cli/test-swarm.js
@@ -26,7 +26,8 @@ describe('swarm', function () {
         expect(err).to.not.exist
         ipfs.id((err, identity) => {
           expect(err).to.not.exist
-          ipfsAddr = `${identity.addresses[0]}/ipfs/${identity.id}`
+          ipfsAddr = identity.addresses[0]
+          console.log('addr', ipfsAddr)
           done()
         })
       })
@@ -51,18 +52,32 @@ describe('swarm', function () {
       })
     })
 
-    // TODO revisit these once interface-ipfs-core over http-api are done
-    it.skip('connect', (done) => {
+    it('connect', (done) => {
       nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'swarm', 'connect', ipfsAddr], {env})
         .run((err, stdout, exitcode) => {
           expect(err).to.not.exist
           expect(exitcode).to.equal(0)
+          expect(stdout).to.be.eql([
+            `connect ${ipfsAddr} success`
+          ])
           done()
         })
     })
 
-    it.skip('peers', (done) => {
+    it('peers', (done) => {
       nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'swarm', 'peers'], {env})
+        .run((err, stdout, exitcode) => {
+          expect(err).to.not.exist
+          expect(exitcode).to.equal(0)
+          expect(stdout).to.be.eql([
+            ipfsAddr
+          ])
+          done()
+        })
+    })
+
+    it('addrs', (done) => {
+      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'swarm', 'addrs'], {env})
         .run((err, stdout, exitcode) => {
           expect(err).to.not.exist
           expect(exitcode).to.equal(0)
@@ -71,7 +86,7 @@ describe('swarm', function () {
         })
     })
 
-    it.skip('addrs local', (done) => {
+    it('addrs local', (done) => {
       nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'swarm', 'addrs', 'local'], {env})
         .run((err, stdout, exitcode) => {
           expect(err).to.not.exist

--- a/test/http-api/interface-ipfs-core-over-ipfs-api/test-swarm.js
+++ b/test/http-api/interface-ipfs-core-over-ipfs-api/test-swarm.js
@@ -2,7 +2,6 @@
 
 'use strict'
 
-/*
 const test = require('interface-ipfs-core')
 const FactoryClient = require('./../../utils/factory-http')
 
@@ -17,7 +16,5 @@ const common = {
     fc.dismantle(callback)
   }
 }
-*/
-// TODO
-// Needs: https://github.com/ipfs/js-libp2p-ipfs/pull/16
-// test.swarm(common)
+
+test.swarm(common)


### PR DESCRIPTION
Currently fails on `ipfs swarm addrs` tests. `ipfs-api` currently expects to get a map, of addresses indexed by peers. It then flattens it, so that the current results for `ipfs swarm peers` and `ipfs swarm addrs` are identical, which makes little sense to me.

I suggest keeping `peers` as is, but changing `ipfs swarm addrs` to return a map as go ipfs does:

```
> ipfs swarm addrs
QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64 (5)
	/ip4/104.236.76.40/tcp/4001
	/ip4/127.0.0.1/tcp/4001
	/ip4/172.17.0.1/tcp/4001
	/ip6/::1/tcp/4001
	/ip6/fcd8:a4e5:3af7:557e:72e5:f9d1:a599:e329/tcp/4001
QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx (5)
	/ip4/104.236.151.122/tcp/4001
	/ip4/127.0.0.1/tcp/4001
	/ip4/172.17.0.1/tcp/4001
	/ip6/::1/tcp/4001
	/ip6/fc3d:9a4e:3c96:2fd2:1afa:18fe:8dd2:b602/tcp/4001
```

mapping peer id to available addrs

Fixes #439