### PR TITLE
fix(cli): alias add, cat and get to top-level cli

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -12,10 +12,23 @@ updateNotifier({
   updateCheckInterval: 1000 * 60 * 60 * 24 * 7 // 1 week
 }).notify()
 
-yargs
+const cli = yargs
   .commandDir('commands')
   .demand(1)
-  .help()
+
+// NOTE: This creates an alias of
+// `jsipfs files {add, get, cat}` to `jsipfs {add, get, cat}`.
+// This will stay until https://github.com/ipfs/specs/issues/98 is resolved.
+const addCmd = require('./commands/files/add')
+const catCmd = require('./commands/files/cat')
+const getCmd = require('./commands/files/get')
+const aliases = [addCmd, catCmd, getCmd]
+aliases.forEach((alias) => {
+  cli.command(alias.command, alias.describe, alias.builder, alias.handler)
+})
+
+// finalize cli setup
+cli.help()
   .strict()
   .completion()
-  .argv
+.argv

--- a/test/cli/test-files.js
+++ b/test/cli/test-files.js
@@ -16,6 +16,12 @@ describe('files', () => {
       })
     })
 
+    it('cat alias', () => {
+      return ipfs('cat QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o').then((out) => {
+        expect(out).to.be.eql('hello world')
+      })
+    })
+
     it('get', () => {
       return ipfs('files get QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o').then((out) => {
         expect(out).to.be.eql(
@@ -33,8 +39,33 @@ describe('files', () => {
       })
     })
 
+    it('get alias', () => {
+      return ipfs('get QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o').then((out) => {
+        expect(out).to.be.eql(
+          'Saving file(s) to QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
+        )
+
+        const file = path.join(process.cwd(), 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o')
+        expect(
+          fs.readFileSync(file).toString()
+        ).to.be.eql(
+          'hello world\n'
+        )
+
+        fs.unlinkSync(file)
+      })
+    })
+
     it('add', () => {
       return ipfs('files add src/init-files/init-docs/readme').then((out) => {
+        expect(out).to.be.eql(
+          'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme'
+        )
+      })
+    })
+
+    it('add alias', () => {
+      return ipfs('add src/init-files/init-docs/readme').then((out) => {
         expect(out).to.be.eql(
           'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme'
         )


### PR DESCRIPTION
Aliases add, cat and get to be in the top-level namespace of the cli.

Reference: https://github.com/ipfs/js-ipfs/issues/455#issuecomment-245939074

Left to do:
- [x] Add tests for aliases
