### PR TITLE
Fix/files get

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const gulp = require('gulp')
-const parallel = require('run-parallel')
-const series = require('run-series')
+const parallel = require('async/parallel')
+const series = require('async/series')
 const createTempNode = require('./test/utils/temp-node')
 const API = require('./src/http-api')
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "transform-loader": "^0.2.3"
   },
   "dependencies": {
+    "async": "^2.0.1",
     "babel-runtime": "^6.11.6",
     "bl": "^1.1.2",
     "boom": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "aegir": "^8.0.1",
     "buffer-loader": "0.0.1",
     "chai": "^3.5.0",
+    "execa": "^0.4.0",
     "expose-loader": "^0.7.1",
     "form-data": "^2.0.0",
     "fs-pull-blob-store": "^0.3.0",

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -23,8 +23,7 @@ module.exports = {
         stats.Wantlist = stats.Wantlist || []
         stats.Peers = stats.Peers || []
 
-        console.log(`
-bitswap status
+        console.log(`bitswap status
   blocks received: ${stats.BlocksReceived}
   dup blocks received: ${stats.DupBlksReceived}
   dup data received: ${stats.DupDataReceived}B

--- a/src/cli/commands/block/stat.js
+++ b/src/cli/commands/block/stat.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const utils = require('../../utils')
-const bs58 = require('bs58')
 const debug = require('debug')
 const log = debug('cli:block')
 log.error = debug('cli:block:error')
@@ -24,7 +23,7 @@ module.exports = {
           throw err
         }
 
-        console.log('Key:', bs58.encode(stats.key).toString())
+        console.log('Key:', stats.key)
         console.log('Size:', stats.size)
       })
     })

--- a/src/cli/commands/bootstrap/add.js
+++ b/src/cli/commands/bootstrap/add.js
@@ -17,6 +17,7 @@ module.exports = {
       if (err) {
         throw err
       }
+
       ipfs.bootstrap.add(argv.peer, (err, list) => {
         if (err) {
           throw err

--- a/src/cli/commands/config/edit.js
+++ b/src/cli/commands/config/edit.js
@@ -3,7 +3,7 @@
 const spawn = require('child_process').spawn
 const fs = require('fs')
 const temp = require('temp')
-const waterfall = require('run-waterfall')
+const waterfall = require('async/waterfall')
 const debug = require('debug')
 const log = debug('cli:config')
 log.error = debug('cli:config:error')

--- a/src/cli/commands/files/cat.js
+++ b/src/cli/commands/files/cat.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const waterfall = require('run-waterfall')
 const debug = require('debug')
 const utils = require('../../utils')
 const log = debug('cli:files')
@@ -14,19 +15,16 @@ module.exports = {
 
   handler (argv) {
     const path = argv['ipfs-path']
-    utils.getIPFS((err, ipfs) => {
+
+    waterfall([
+      (cb) => utils.getIPFS(cb),
+      (ipfs, cb) => ipfs.files.cat(path, cb)
+    ], (err, file) => {
       if (err) {
         throw err
       }
 
-      ipfs.files.cat(path, onFile)
+      file.pipe(process.stdout)
     })
   }
-}
-
-function onFile (err, file) {
-  if (err) {
-    throw (err)
-  }
-  file.pipe(process.stdout)
 }

--- a/src/cli/commands/files/cat.js
+++ b/src/cli/commands/files/cat.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const waterfall = require('run-waterfall')
+const waterfall = require('async/waterfall')
 const debug = require('debug')
 const utils = require('../../utils')
 const log = debug('cli:files')

--- a/src/cli/commands/files/get.js
+++ b/src/cli/commands/files/get.js
@@ -65,6 +65,7 @@ function fileHandler (dir) {
           file.content.pipe(fs.createWriteStream(target))
             .once('error', cb)
             .once('end', cb)
+          return
         }
         cb()
       })

--- a/src/cli/commands/files/get.js
+++ b/src/cli/commands/files/get.js
@@ -98,12 +98,11 @@ module.exports = {
         if (err) {
           throw err
         }
-
+        console.log(`Saving file(s) to ${ipfsPath}`)
         pull(
           toPull.source(stream),
           pull.asyncMap(fileHandler(dir)),
           pull.onEnd((err) => {
-            console.log('finished writing')
             if (err) {
               throw err
             }

--- a/src/core/components/block.js
+++ b/src/core/components/block.js
@@ -33,7 +33,7 @@ module.exports = function block (self) {
           return callback(err)
         }
         callback(null, {
-          key: hash,
+          key: multihash.toB58String(hash),
           size: block.data.length
         })
       })

--- a/src/core/components/go-online.js
+++ b/src/core/components/go-online.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const series = require('run-series')
+const series = require('async/series')
 const Bitswap = require('ipfs-bitswap')
 
 module.exports = function goOnline (self) {

--- a/src/core/components/object.js
+++ b/src/core/components/object.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const mDAG = require('ipfs-merkle-dag')
-const waterfall = require('run-waterfall')
+const waterfall = require('async/waterfall')
 const promisify = require('promisify-es6')
 const bs58 = require('bs58')
 const DAGNode = mDAG.DAGNode
@@ -69,12 +69,7 @@ module.exports = function object (self) {
             cb(err, node)
           })
         }
-      ], (err, node) => {
-        if (err) {
-          return cb(err)
-        }
-        cb(null, node)
-      })
+      ], cb)
     }
   }
 

--- a/src/http-api/index.js
+++ b/src/http-api/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const parallel = require('run-parallel')
+const parallel = require('async/parallel')
 const Hapi = require('hapi')
 const debug = require('debug')
 const fs = require('fs')

--- a/src/http-api/resources/block.js
+++ b/src/http-api/resources/block.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const bs58 = require('bs58')
+const mh = require('multihashes')
 const multipart = require('ipfs-multipart')
 const Block = require('ipfs-block')
 const debug = require('debug')
@@ -17,7 +17,7 @@ exports.parseKey = (request, reply) => {
 
   try {
     return reply({
-      key: new Buffer(bs58.decode(request.query.arg))
+      key: mh.fromB58String(request.query.arg)
     })
   } catch (err) {
     log.error(err)
@@ -93,7 +93,7 @@ exports.put = {
       }
 
       return reply({
-        Key: bs58.encode(block.key).toString(),
+        Key: mh.toB58String(block.key),
         Size: block.data.length
       })
     })
@@ -112,7 +112,7 @@ exports.del = {
       if (err) {
         log.error(err)
         return reply({
-          Message: 'Failed to get block stats: ' + err,
+          Message: 'Failed to delete block: ' + err,
           Code: 0
         }).code(500)
       }
@@ -129,7 +129,7 @@ exports.stat = {
   // main route handler which is called after the above `parseArgs`, but only if the args were valid
   handler: (request, reply) => {
     const key = request.pre.args.key
-
+    console.log('fetching', key)
     request.server.app.ipfs.block.stat(key, (err, block) => {
       if (err) {
         log.error(err)
@@ -140,7 +140,7 @@ exports.stat = {
       }
 
       return reply({
-        Key: bs58.encode(block.key).toString(),
+        Key: block.key,
         Size: block.size
       })
     })

--- a/src/http-api/resources/bootstrap.js
+++ b/src/http-api/resources/bootstrap.js
@@ -1,11 +1,31 @@
 'use strict'
 
 const boom = require('boom')
+const multiaddr = require('multiaddr')
 
 exports = module.exports
 
+// common pre request handler that parses the args and returns `key` which is assigned to `request.pre.args`
+exports.parseKey = (request, reply) => {
+  if (!request.query.arg) {
+    return reply("Argument 'multiaddr' is required").code(400).takeover()
+  }
+
+  try {
+    return reply({
+      addr: multiaddr(request.query.arg)
+    })
+  } catch (err) {
+    return reply({
+      Message: 'Not a valid multiaddr',
+      Code: 0
+    }).code(500).takeover()
+  }
+}
+
 exports.list = (request, reply) => {
-  request.server.app.ipfs.bootstrap.list((err, list) => {
+  const ipfs = request.server.app.ipfs
+  ipfs.bootstrap.list((err, list) => {
     if (err) {
       return reply(boom.badRequest(err))
     }
@@ -13,16 +33,32 @@ exports.list = (request, reply) => {
   })
 }
 
-exports.add = (request, reply) => {
-//  request.server.app.ipfs.id((err, id) => {
-//    if (err) { return reply(boom.badRequest(err)) }
-//    return reply(id)
-//   })
+exports.add = {
+  parseArgs: exports.parseKey,
+  handler (request, reply) {
+    const ipfs = request.server.app.ipfs
+    const addr = request.pre.args.addr
+
+    ipfs.bootstrap.add(addr.toString(), (err, list) => {
+      if (err) {
+        return reply(boom.badRequest(err))
+      }
+      return reply()
+    })
+  }
 }
 
-exports.rm = (request, reply) => {
-//  request.server.app.ipfs.id((err, id) => {
-//    if (err) { return reply(boom.badRequest(err)) }
-//    return reply(id)
-//   })
+exports.rm = {
+  parseArgs: exports.parseKey,
+  handler (request, reply) {
+    const ipfs = request.server.app.ipfs
+    const addr = request.pre.args.addr
+
+    ipfs.bootstrap.rm(addr.toString(), (err, list) => {
+      if (err) {
+        return reply(boom.badRequest(err))
+      }
+      return reply()
+    })
+  }
 }

--- a/src/http-api/routes/bootstrap.js
+++ b/src/http-api/routes/bootstrap.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const resources = require('./../resources')
-const Joi = require('joi')
 
 module.exports = (server) => {
   const api = server.select('API')
@@ -17,14 +16,11 @@ module.exports = (server) => {
   api.route({
     method: '*',
     path: '/api/v0/bootstrap/add',
-    handler: resources.bootstrap.add,
     config: {
-      validate: {
-        query: {
-          arg: Joi.string().required(), // multiaddr to add
-          default: Joi.boolean()
-        }
-      }
+      pre: [
+        { method: resources.bootstrap.add.parseArgs, assign: 'args' }
+      ],
+      handler: resources.bootstrap.add.handler
     }
   })
 
@@ -39,14 +35,11 @@ module.exports = (server) => {
   api.route({
     method: '*',
     path: '/api/v0/bootstrap/rm',
-    handler: resources.bootstrap.rm,
     config: {
-      validate: {
-        query: {
-          arg: Joi.string().required(), // multiaddr to rm
-          all: Joi.boolean()
-        }
-      }
+      pre: [
+        { method: resources.bootstrap.rm.parseArgs, assign: 'args' }
+      ],
+      handler: resources.bootstrap.rm.handler
     }
   })
 }

--- a/src/http-api/routes/bootstrap.js
+++ b/src/http-api/routes/bootstrap.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Joi = require('joi')
 const resources = require('./../resources')
 
 module.exports = (server) => {
@@ -20,7 +21,14 @@ module.exports = (server) => {
       pre: [
         { method: resources.bootstrap.add.parseArgs, assign: 'args' }
       ],
-      handler: resources.bootstrap.add.handler
+      handler: resources.bootstrap.add.handler,
+      validate: {
+        query: {
+          arg: Joi.string().required(),
+          default: Joi.boolean(),
+          'stream-channels': Joi.boolean()
+        }
+      }
     }
   })
 
@@ -39,7 +47,14 @@ module.exports = (server) => {
       pre: [
         { method: resources.bootstrap.rm.parseArgs, assign: 'args' }
       ],
-      handler: resources.bootstrap.rm.handler
+      handler: resources.bootstrap.rm.handler,
+      validate: {
+        query: {
+          arg: Joi.string().required(),
+          default: Joi.boolean(),
+          'stream-channels': Joi.boolean()
+        }
+      }
     }
   })
 }

--- a/test/cli/test-bitswap.js
+++ b/test/cli/test-bitswap.js
@@ -8,7 +8,7 @@ const bs58 = require('bs58')
 const HttpAPI = require('../../src/http-api')
 const createTempNode = require('../utils/temp-node')
 const repoPath = require('./index').repoPath
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 
 describe('bitswap', () => {
   let node

--- a/test/cli/test-block.js
+++ b/test/cli/test-block.js
@@ -2,135 +2,41 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
-const HttpAPI = require('../../src/http-api')
-const path = require('path')
 const repoPath = require('./index').repoPath
-const _ = require('lodash')
-
-const spawn = (args) => {
-  const env = _.clone(process.env)
-  env.IPFS_PATH = repoPath
-  return nexpect.spawn(
-    'node',
-    [path.join(__dirname, '../../src/cli/bin.js')].concat(args),
-    {env}
-  )
-}
+const describeOnlineAndOffline = require('../utils/on-and-off')
+const ipfs = require('../utils/ipfs')(repoPath)
 
 describe('block', () => {
-  describe('api offline', () => {
-    it('put', (done) => {
-      spawn(['block', 'put', process.cwd() + '/test/test-data/hello'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0])
-            .to.equal('QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-          expect(exitcode).to.equal(0)
-          done()
-        })
-    })
-
-    it('get', (done) => {
-      spawn(['block', 'get', 'QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0])
-            .to.equal('hello world')
-          expect(exitcode).to.equal(0)
-          done()
-        })
-    })
-
-    it('stat', (done) => {
-      spawn(['block', 'stat', 'QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0])
-            .to.equal('Key: QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-          expect(stdout[1])
-            .to.equal('Size: 12')
-          expect(exitcode).to.equal(0)
-
-          done()
-        })
-    })
-
-    it.skip('rm', (done) => {
-      spawn(['block', 'rm', 'QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0])
-            .to.equal('removed QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-          expect(exitcode).to.equal(0)
-          done()
-        })
-    })
-  })
-
-  describe('api running', () => {
-    let httpAPI
-    before((done) => {
-      httpAPI = new HttpAPI(repoPath)
-      httpAPI.start((err) => {
-        expect(err).to.not.exist
-        done()
+  describeOnlineAndOffline(repoPath, () => {
+    it('put', () => {
+      return ipfs('block put test/test-data/hello').then((out) => {
+        expect(out).to.be.eql(
+          'QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'
+        )
       })
     })
 
-    after((done) => {
-      httpAPI.stop((err) => {
-        expect(err).to.not.exist
-        done()
+    it('get', () => {
+      return ipfs('block get QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp').then((out) => {
+        expect(out).to.be.eql('hello world\n')
       })
     })
 
-    it('put', (done) => {
-      spawn(['block', 'put', process.cwd() + '/test/test-data/hello'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          console.log
-          expect(stdout[0])
-            .to.equal('QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-          expect(exitcode).to.equal(0)
-          done()
-        })
+    it('stat', () => {
+      return ipfs('block stat QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp').then((out) => {
+        expect(out).to.be.eql([
+          'Key: QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp',
+          'Size: 12'
+        ].join('\n'))
+      })
     })
 
-    it('get', (done) => {
-      spawn(['block', 'get', 'QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0])
-            .to.equal('hello world')
-          expect(exitcode).to.equal(0)
-          done()
-        })
-    })
-
-    // TODO: Investigate why it doesn't work as expected
-    it.skip('stat', (done) => {
-      spawn(['block', 'stat', 'QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0])
-            .to.equal('Key: QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-          expect(stdout[1])
-            .to.equal('Size: 12')
-          expect(exitcode).to.equal(0)
-          done()
-        })
-    })
-
-    it.skip('rm', (done) => {
-      spawn(['block', 'rm', 'QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'])
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0])
-            .to.equal('removed QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-          expect(exitcode).to.equal(0)
-          done()
-        })
+    it.skip('rm', () => {
+      return ipfs('block rm QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp').then((out) => {
+        expect(out).to.be.eql(
+          'removed QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'
+        )
+      })
     })
   })
 })

--- a/test/cli/test-block.js
+++ b/test/cli/test-block.js
@@ -4,7 +4,7 @@
 const expect = require('chai').expect
 const repoPath = require('./index').repoPath
 const describeOnlineAndOffline = require('../utils/on-and-off')
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 
 describe('block', () => {
   describeOnlineAndOffline(repoPath, () => {

--- a/test/cli/test-bootstrap.js
+++ b/test/cli/test-bootstrap.js
@@ -4,7 +4,7 @@
 
 const expect = require('chai').expect
 const repoPath = require('./index').repoPath
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 const describeOnlineAndOffline = require('../utils/on-and-off')
 
 describe('bootstrap', () => {

--- a/test/cli/test-bootstrap.js
+++ b/test/cli/test-bootstrap.js
@@ -3,14 +3,12 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
-const _ = require('lodash')
+const repoPath = require('./index').repoPath
+const ipfs = require('../utils/ipfs')(repoPath)
+const describeOnlineAndOffline = require('../utils/on-and-off')
 
 describe('bootstrap', () => {
-  const env = _.clone(process.env)
-  env.IPFS_PATH = require('./index').repoPath
-
-  describe('api offline', () => {
+  describeOnlineAndOffline(repoPath, () => {
     const defaultList = [
       '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
       '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
@@ -33,51 +31,29 @@ describe('bootstrap', () => {
       '/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
       '/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
       '/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx',
-      '/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT'
+      '/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD'
     ]
 
-    it('list the bootstrap nodes', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'bootstrap', 'list'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(stdout).to.deep.equal(defaultList)
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          done()
-        })
+    it('list the bootstrap nodes', () => {
+      return ipfs('bootstrap list').then((out) => {
+        expect(out).to.be.eql(defaultList.join('\n'))
+      })
     })
 
-    it('add another bootstrap node', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'bootstrap', 'add', '/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'bootstrap', 'list'], {env})
-            .run((err, stdout, exitcode) => {
-              expect(stdout).to.deep.equal(updatedList)
-              expect(err).to.not.exist
-              expect(exitcode).to.equal(0)
-              done()
-            })
-        })
+    it('add another bootstrap node', () => {
+      return ipfs('bootstrap add /ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD').then((out) => {
+        return ipfs('bootstrap list')
+      }).then((out) => {
+        expect(out).to.be.eql(updatedList.join('\n'))
+      })
     })
 
-    it('rm a bootstrap node', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'bootstrap', 'rm', '/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'bootstrap', 'list'], {env})
-            .run((err, stdout, exitcode) => {
-              expect(stdout).to.deep.equal(defaultList)
-              expect(err).to.not.exist
-              expect(exitcode).to.equal(0)
-              done()
-            })
-        })
+    it('rm a bootstrap node', () => {
+      return ipfs('bootstrap rm /ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD').then((out) => {
+        return ipfs('bootstrap list')
+      }).then((out) => {
+        expect(out).to.deep.equal(defaultList.join('\n'))
+      })
     })
   })
-
-  describe('api running', () => {})
 })

--- a/test/cli/test-commands.js
+++ b/test/cli/test-commands.js
@@ -3,7 +3,7 @@
 
 const expect = require('chai').expect
 const repoPath = require('./index').repoPath
-const ipfsBase = require('../utils/ipfs')
+const ipfsBase = require('../utils/ipfs-exec')
 const ipfs = ipfsBase(repoPath)
 const describeOnlineAndOffline = require('../utils/on-and-off')
 

--- a/test/cli/test-commands.js
+++ b/test/cli/test-commands.js
@@ -2,25 +2,25 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
+const repoPath = require('./index').repoPath
+const ipfsBase = require('../utils/ipfs')
+const ipfs = ipfsBase(repoPath)
+const describeOnlineAndOffline = require('../utils/on-and-off')
 
 describe('commands', () => {
-  it('list the commands', (done) => {
-    nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'commands'])
-      .run((err, stdout, exitcode) => {
-        expect(err).to.not.exist
-        expect(exitcode).to.equal(0)
-        expect(stdout.length).to.equal(56)
-        done()
+  describeOnlineAndOffline(repoPath, () => {
+    it('list the commands', () => {
+      return ipfs('commands').then((out) => {
+        expect(out.split('\n')).to.have.length(56)
       })
+    })
   })
-  it('list the commands even if not in the same dir', (done) => {
-    nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'commands'], {cwd: '/tmp'})
-      .run((err, stdout, exitcode) => {
-        expect(err).to.not.exist
-        expect(exitcode).to.equal(0)
-        expect(stdout.length).to.equal(56)
-        done()
-      })
+
+  it('list the commands even if not in the same dir', () => {
+    return ipfsBase(repoPath, {
+      cwd: '/tmp'
+    })('commands').then((out) => {
+      expect(out.split('\n').length).to.equal(56)
+    })
   })
 })

--- a/test/cli/test-config.js
+++ b/test/cli/test-config.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect
 const fs = require('fs')
 const path = require('path')
 const repoPath = require('./index').repoPath
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 const describeOnlineAndOffline = require('../utils/on-and-off')
 
 describe('config', () => {

--- a/test/cli/test-files.js
+++ b/test/cli/test-files.js
@@ -6,7 +6,7 @@ const repoPath = require('./index').repoPath
 const fs = require('fs')
 const path = require('path')
 const describeOnlineAndOffline = require('../utils/on-and-off')
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 
 describe('files', () => {
   describeOnlineAndOffline(repoPath, () => {

--- a/test/cli/test-files.js
+++ b/test/cli/test-files.js
@@ -2,121 +2,61 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
-const HttpAPI = require('../../src/http-api')
 const repoPath = require('./index').repoPath
-const _ = require('lodash')
+const fs = require('fs')
+const path = require('path')
+const describeOnlineAndOffline = require('../utils/on-and-off')
+const ipfs = require('../utils/ipfs')(repoPath)
 
 describe('files', () => {
-  const env = _.clone(process.env)
-  env.IPFS_PATH = repoPath
-
-  describe('api offline', () => {
-    it('cat', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'files', 'cat', 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('hello world')
-          done()
-        })
-    })
-
-    it('add', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'files', 'add', 'src/init-files/init-docs/readme'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme')
-          done()
-        })
-    })
-
-    it('add recursively', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'files', 'add', '-r', 'src/init-files/init-docs'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          const expected = [
-            'added QmYE7xo6NxbHEVEHej1yzxijYaNY51BaeKxjXxn6Ssa6Bs init-docs/tour/0.0-intro',
-            'added QmciSU8hfpAXKjvK5YLUSwApomGSWN5gFbP4EpDAEzu2Te init-docs/tour',
-            'added QmTumTjvcYCAvRRwQ8sDRxh8ezmrcr88YFU7iYNroGGTBZ init-docs/security-notes',
-            'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB init-docs/readme',
-            'added QmdncfsVm2h5Kqq9hPmU7oAVX2zTSVP3L869tgTbPYnsha init-docs/quick-start',
-            'added QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7 init-docs/help',
-            'added QmQN88TEidd3RY2u3dpib49fERTDfKtDpvxnvczATNsfKT init-docs/docs/index',
-            'added QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC init-docs/docs',
-            'added QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y init-docs/contact',
-            'added QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V init-docs/about',
-            'added QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU init-docs'
-          ]
-          expect(stdout).to.deep.equal(expected)
-          done()
-        })
-    })
-  })
-
-  describe('api running', () => {
-    let httpAPI
-
-    before((done) => {
-      httpAPI = new HttpAPI(repoPath)
-      httpAPI.start((err) => {
-        expect(err).to.not.exist
-        done()
+  describeOnlineAndOffline(repoPath, () => {
+    it('cat', () => {
+      return ipfs('files cat QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o').then((out) => {
+        expect(out).to.be.eql('hello world')
       })
     })
 
-    after((done) => {
-      httpAPI.stop((err) => {
-        expect(err).to.not.exist
-        done()
+    it('get', () => {
+      return ipfs('files get QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o').then((out) => {
+        expect(out).to.be.eql(
+          'Saving file(s) to QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
+        )
+
+        const file = path.join(process.cwd(), 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o')
+        expect(
+          fs.readFileSync(file).toString()
+        ).to.be.eql(
+          'hello world\n'
+        )
+
+        fs.unlinkSync(file)
       })
     })
 
-    it('cat', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'files', 'cat', 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('hello world')
-          done()
-        })
+    it('add', () => {
+      return ipfs('files add src/init-files/init-docs/readme').then((out) => {
+        expect(out).to.be.eql(
+          'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme'
+        )
+      })
     })
 
-    it('add', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'files', 'add', 'src/init-files/init-docs/readme'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme')
-          done()
-        })
-    })
-
-    it('add recursively', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'files', 'add', '-r', 'src/init-files/init-docs'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          const expected = [
-            'added QmYE7xo6NxbHEVEHej1yzxijYaNY51BaeKxjXxn6Ssa6Bs init-docs/tour/0.0-intro',
-            'added QmciSU8hfpAXKjvK5YLUSwApomGSWN5gFbP4EpDAEzu2Te init-docs/tour',
-            'added QmTumTjvcYCAvRRwQ8sDRxh8ezmrcr88YFU7iYNroGGTBZ init-docs/security-notes',
-            'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB init-docs/readme',
-            'added QmdncfsVm2h5Kqq9hPmU7oAVX2zTSVP3L869tgTbPYnsha init-docs/quick-start',
-            'added QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7 init-docs/help',
-            'added QmQN88TEidd3RY2u3dpib49fERTDfKtDpvxnvczATNsfKT init-docs/docs/index',
-            'added QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC init-docs/docs',
-            'added QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y init-docs/contact',
-            'added QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V init-docs/about',
-            'added QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU init-docs'
-          ]
-          expect(stdout).to.deep.equal(expected)
-          done()
-        })
+    it('add recursively', () => {
+      return ipfs('files add -r src/init-files/init-docs').then((out) => {
+        expect(out).to.be.eql([
+          'added QmYE7xo6NxbHEVEHej1yzxijYaNY51BaeKxjXxn6Ssa6Bs init-docs/tour/0.0-intro',
+          'added QmciSU8hfpAXKjvK5YLUSwApomGSWN5gFbP4EpDAEzu2Te init-docs/tour',
+          'added QmTumTjvcYCAvRRwQ8sDRxh8ezmrcr88YFU7iYNroGGTBZ init-docs/security-notes',
+          'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB init-docs/readme',
+          'added QmdncfsVm2h5Kqq9hPmU7oAVX2zTSVP3L869tgTbPYnsha init-docs/quick-start',
+          'added QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7 init-docs/help',
+          'added QmQN88TEidd3RY2u3dpib49fERTDfKtDpvxnvczATNsfKT init-docs/docs/index',
+          'added QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC init-docs/docs',
+          'added QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y init-docs/contact',
+          'added QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V init-docs/about',
+          'added QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU init-docs'
+        ].join('\n'))
+      })
     })
   })
 })

--- a/test/cli/test-id.js
+++ b/test/cli/test-id.js
@@ -4,7 +4,7 @@
 const expect = require('chai').expect
 const repoPath = require('./index').repoPath
 const describeOnlineAndOffline = require('../utils/on-and-off')
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 
 describe('id', () => {
   describeOnlineAndOffline(repoPath, () => {

--- a/test/cli/test-id.js
+++ b/test/cli/test-id.js
@@ -2,62 +2,19 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
-const HttpAPI = require('../../src/http-api')
 const repoPath = require('./index').repoPath
-const _ = require('lodash')
+const describeOnlineAndOffline = require('../utils/on-and-off')
+const ipfs = require('../utils/ipfs')(repoPath)
 
 describe('id', () => {
-  const env = _.clone(process.env)
-  env.IPFS_PATH = repoPath
-
-  describe('api offline', () => {
-    it('get the id', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'id'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          const id = JSON.parse(stdout.join(''))
-          expect(id).to.have.property('id')
-          expect(id).to.have.property('publicKey')
-          expect(id).to.have.property('addresses')
-          done()
-        })
-    })
-  })
-
-  describe('api running', () => {
-    let httpAPI
-
-    before((done) => {
-      httpAPI = new HttpAPI(repoPath)
-      httpAPI.start((err) => {
-        expect(err).to.not.exist
-        done()
+  describeOnlineAndOffline(repoPath, () => {
+    it('get the id', () => {
+      return ipfs('id').then((res) => {
+        const id = JSON.parse(res)
+        expect(id).to.have.property('id')
+        expect(id).to.have.property('publicKey')
+        expect(id).to.have.property('addresses')
       })
-    })
-
-    after((done) => {
-      httpAPI.stop((err) => {
-        expect(err).to.not.exist
-        done()
-      })
-    })
-
-    it('get the id', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'id'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          const id = JSON.parse(stdout.join(''))
-          expect(id).to.have.property('id')
-          expect(id).to.have.property('publicKey')
-          expect(id).to.have.property('addresses')
-
-          done()
-        })
     })
   })
 })

--- a/test/cli/test-init.js
+++ b/test/cli/test-init.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect
 const path = require('path')
 const fs = require('fs')
 const clean = require('../utils/clean')
-const ipfsCmd = require('../utils/ipfs')
+const ipfsCmd = require('../utils/ipfs-exec')
 
 describe('init', function () {
   this.timeout(60 * 1000)

--- a/test/cli/test-init.js
+++ b/test/cli/test-init.js
@@ -2,54 +2,50 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
 const path = require('path')
 const fs = require('fs')
-const _ = require('lodash')
 const clean = require('../utils/clean')
+const ipfsCmd = require('../utils/ipfs')
 
 describe('init', function () {
   this.timeout(60 * 1000)
-  const env = _.clone(process.env)
+  let repoPath
+  let ipfs
+
   const repoExistsSync = (p) => (
-    fs.existsSync(path.join(env.IPFS_PATH, p))
+    fs.existsSync(path.join(repoPath, p))
   )
 
   beforeEach(() => {
-    env.IPFS_PATH = '/tmp/ipfs-test-' + Math.random().toString().substring(2, 8)
+    repoPath = '/tmp/ipfs-test-' + Math.random().toString().substring(2, 8)
+    ipfs = ipfsCmd(repoPath)
   })
 
   afterEach(() => {
-    clean(env.IPFS_PATH)
+    clean(repoPath)
   })
 
-  it('basic', (done) => {
-    nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'init'], {env})
-      .run((err, stdout, exitcode) => {
-        expect(err).to.not.exist
-        expect(repoExistsSync('blocks')).to.equal(true)
-        expect(repoExistsSync('config')).to.equal(true)
-        expect(repoExistsSync('version')).to.equal(true)
-        done()
-      })
+  it('basic', () => {
+    return ipfs('init').then(() => {
+      expect(repoExistsSync('blocks')).to.equal(true)
+      expect(repoExistsSync('config')).to.equal(true)
+      expect(repoExistsSync('version')).to.equal(true)
+    })
   })
 
-  it('bits', (done) => {
-    nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'init', '--bits', '64'], {env})
-      .run((err, stdout, exitcode) => {
-        expect(err).to.not.exist
-        done()
-      })
+  it('bits', () => {
+    return ipfs('init --bits 512').then(() => {
+      expect(repoExistsSync('blocks')).to.equal(true)
+      expect(repoExistsSync('config')).to.equal(true)
+      expect(repoExistsSync('version')).to.equal(true)
+    })
   })
 
-  it('empty', (done) => {
-    nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'init', '--bits', '64', '--empty-repo', 'true'], {env})
-      .run((err, stdout, exitcode) => {
-        expect(err).to.not.exist
-        expect(repoExistsSync('blocks')).to.equal(false)
-        expect(repoExistsSync('config')).to.equal(true)
-        expect(repoExistsSync('version')).to.equal(true)
-        done()
-      })
+  it('empty', () => {
+    return ipfs('init --bits 512 --empty-repo true').then(() => {
+      expect(repoExistsSync('blocks')).to.equal(false)
+      expect(repoExistsSync('config')).to.equal(true)
+      expect(repoExistsSync('version')).to.equal(true)
+    })
   })
 })

--- a/test/cli/test-object.js
+++ b/test/cli/test-object.js
@@ -5,7 +5,7 @@
 const expect = require('chai').expect
 const repoPath = require('./index').repoPath
 const describeOnlineAndOffline = require('../utils/on-and-off')
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 
 describe('object', () => {
   describeOnlineAndOffline(repoPath, () => {

--- a/test/cli/test-object.js
+++ b/test/cli/test-object.js
@@ -3,273 +3,93 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
-const HttpAPI = require('../../src/http-api')
 const repoPath = require('./index').repoPath
-const _ = require('lodash')
+const describeOnlineAndOffline = require('../utils/on-and-off')
+const ipfs = require('../utils/ipfs')(repoPath)
 
 describe('object', () => {
-  const env = _.clone(process.env)
-  env.IPFS_PATH = repoPath
-
-  describe('api offline', () => {
-    it('new', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'new'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0])
-            .to.equal('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
-          done()
-        })
+  describeOnlineAndOffline(repoPath, () => {
+    it('new', () => {
+      return ipfs('object new').then((out) => {
+        expect(out).to.be.eql(
+          'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+        )
+      })
     })
 
-    it('get', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'get', 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          const result = JSON.parse(stdout[0])
-          expect(result.Links)
-            .to.deep.equal([])
-          expect(result.Data)
-            .to.equal('')
-          done()
-        })
+    it('get', () => {
+      return ipfs('object get QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n').then((out) => {
+        const result = JSON.parse(out)
+        expect(result.Links).to.be.eql([])
+        expect(result.Data).to.be.eql('')
+      })
     })
 
-    it('put', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'put', process.cwd() + '/test/test-data/node.json'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0])
-            .to.equal('added QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm')
-          done()
-        })
+    it('put', () => {
+      return ipfs('object put test/test-data/node.json').then((out) => {
+        expect(out).to.be.eql(
+          'added QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'
+        )
+      })
     })
 
-    it('stat', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'stat', 'QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0])
-            .to.equal('NumLinks: 1')
-          expect(stdout[1])
-            .to.equal('BlockSize: 60')
-          expect(stdout[2])
-            .to.equal('LinksSize: 53')
-          expect(stdout[3])
-            .to.equal('DataSize: 7')
-          done()
-        })
+    it('stat', () => {
+      return ipfs('object stat QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm').then((out) => {
+        expect(out).to.be.eql([
+          'NumLinks: 1',
+          'BlockSize: 60',
+          'LinksSize: 53',
+          'DataSize: 7',
+          'CumulativeSize: 68'
+        ].join('\n'))
+      })
     })
 
-    it('data', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'data', 'QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('another')
-          done()
-        })
+    it('data', () => {
+      return ipfs('object data QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm').then((out) => {
+        expect(out).to.be.eql('another')
+      })
     })
 
-    it('links', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'links', 'QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V 8 some link')
-          done()
-        })
+    it('links', () => {
+      return ipfs('object links QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm').then((out) => {
+        expect(out).to.be.eql(
+          'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V 8 some link'
+        )
+      })
     })
 
     describe('patch', () => {
-      it('append-data', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'append-data', 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n', process.cwd() + '/test/test-data/badconfig'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6')
-            done()
-          })
-      })
-
-      it('set-data', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'set-data', 'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6', process.cwd() + '/test/test-data/badconfig'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6')
-            done()
-          })
-      })
-
-      it('add-link', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'add-link', 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n', 'foo', 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK')
-            done()
-          })
-      })
-
-      it('rm-link', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'rm-link', 'QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK', 'foo'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
-            done()
-          })
-      })
-    })
-  })
-
-  // Waiting for js-ipfs-api to be updated
-  describe('api running', () => {
-    let httpAPI
-
-    before((done) => {
-      httpAPI = new HttpAPI(repoPath)
-      httpAPI.start((err) => {
-        expect(err).to.not.exist
-        done()
-      })
-    })
-
-    after((done) => {
-      httpAPI.stop((err) => {
-        expect(err).to.not.exist
-        done()
-      })
-    })
-
-    it('new', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'new'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0])
-            .to.equal('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
-          done()
+      it('append-data', () => {
+        return ipfs('object patch append-data QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n test/test-data/badconfig').then((out) => {
+          expect(out).to.be.eql(
+            'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6'
+          )
         })
-    })
-
-    it('get', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'get', 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          const result = JSON.parse(stdout[0])
-          expect(result.Links)
-            .to.deep.equal([])
-          expect(result.Data)
-            .to.equal('')
-          done()
-        })
-    })
-
-    it('put', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'put', process.cwd() + '/test/test-data/node.json'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-
-          expect(stdout[0])
-            .to.equal('added QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm')
-          done()
-        })
-    })
-
-    it('stat', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'stat', 'QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0])
-            .to.equal('NumLinks: 1')
-          expect(stdout[1])
-            .to.equal('BlockSize: 60')
-          expect(stdout[2])
-            .to.equal('LinksSize: 53')
-          expect(stdout[3])
-            .to.equal('DataSize: 7')
-          done()
-        })
-    })
-
-    it('data', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'data', 'QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('another')
-          done()
-        })
-    })
-
-    it('links', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'links', 'QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V 8 some link')
-          done()
-        })
-    })
-
-    describe('patch', () => {
-      it('append-data', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'append-data', 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n', process.cwd() + '/test/test-data/badconfig'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6')
-            done()
-          })
       })
 
-      it('set-data', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'set-data', 'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6', process.cwd() + '/test/test-data/badconfig'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6')
-            done()
-          })
+      it('set-data', () => {
+        return ipfs('object patch set-data QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6 test/test-data/badconfig').then((out) => {
+          expect(out).to.be.eql(
+            'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6'
+          )
+        })
       })
 
-      it('add-link', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'add-link', 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n', 'foo', 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK')
-            done()
-          })
+      it('add-link', () => {
+        return ipfs('object patch add-link QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n foo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn').then((out) => {
+          expect(out).to.be.eql(
+            'QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK'
+          )
+        })
       })
 
-      it('rm-link', (done) => {
-        nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'object', 'patch', 'rm-link', 'QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK', 'foo'], {env})
-          .run((err, stdout, exitcode) => {
-            expect(err).to.not.exist
-            expect(exitcode).to.equal(0)
-            expect(stdout[0])
-              .to.equal('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
-            done()
-          })
+      it('rm-link', () => {
+        return ipfs('object patch rm-link QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK foo').then((out) => {
+          expect(out).to.be.eql(
+            'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+          )
+        })
       })
     })
   })

--- a/test/cli/test-swarm.js
+++ b/test/cli/test-swarm.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect
 const HttpAPI = require('../../src/http-api')
 const createTempNode = require('../utils/temp-node')
 const repoPath = require('./index').repoPath
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 
 describe('swarm', function () {
   this.timeout(30 * 1000)

--- a/test/cli/test-version.js
+++ b/test/cli/test-version.js
@@ -2,54 +2,19 @@
 'use strict'
 
 const expect = require('chai').expect
-const nexpect = require('nexpect')
-const HttpAPI = require('../../src/http-api')
-const repoPath = require('./index').repoPath
-const _ = require('lodash')
 const pkgversion = require('../../package.json').version
+const repoPath = require('./index').repoPath
+const describeOnlineAndOffline = require('../utils/on-and-off')
+const ipfs = require('../utils/ipfs')(repoPath)
 
 describe('version', () => {
-  const env = _.clone(process.env)
-  env.IPFS_PATH = repoPath
-
-  describe('api offline', () => {
-    it('get the version', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'version'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(stdout[0]).to.equal('js-ipfs version: ' + pkgversion)
-          expect(exitcode).to.equal(0)
-          done()
-        })
-    })
-  })
-
-  describe('api running', () => {
-    let httpAPI
-
-    before((done) => {
-      httpAPI = new HttpAPI(repoPath)
-      httpAPI.start((err) => {
-        expect(err).to.not.exist
-        done()
+  describeOnlineAndOffline(repoPath, () => {
+    it('get the version', () => {
+      return ipfs('version').then((out) => {
+        expect(out).to.be.eql(
+          `js-ipfs version: ${pkgversion}`
+        )
       })
-    })
-
-    after((done) => {
-      httpAPI.stop((err) => {
-        expect(err).to.not.exist
-        done()
-      })
-    })
-
-    it('get the version', (done) => {
-      nexpect.spawn('node', [process.cwd() + '/src/cli/bin.js', 'version'], {env})
-        .run((err, stdout, exitcode) => {
-          expect(err).to.not.exist
-          expect(exitcode).to.equal(0)
-          expect(stdout[0]).to.equal('js-ipfs version: ' + pkgversion)
-          done()
-        })
     })
   })
 })

--- a/test/cli/test-version.js
+++ b/test/cli/test-version.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect
 const pkgversion = require('../../package.json').version
 const repoPath = require('./index').repoPath
 const describeOnlineAndOffline = require('../utils/on-and-off')
-const ipfs = require('../utils/ipfs')(repoPath)
+const ipfs = require('../utils/ipfs-exec')(repoPath)
 
 describe('version', () => {
   describeOnlineAndOffline(repoPath, () => {

--- a/test/core/both/test-bitswap.js
+++ b/test/core/both/test-bitswap.js
@@ -4,9 +4,9 @@
 
 const expect = require('chai').expect
 const _ = require('lodash')
-const series = require('run-series')
-const waterfall = require('run-waterfall')
-const parallel = require('run-parallel')
+const series = require('async/series')
+const waterfall = require('async/waterfall')
+const parallel = require('async/parallel')
 const leftPad = require('left-pad')
 const Block = require('ipfs-block')
 const bs58 = require('bs58')

--- a/test/core/browser.js
+++ b/test/core/browser.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const series = require('run-series')
+const series = require('async/series')
 const Store = require('idb-pull-blob-store')
 const _ = require('lodash')
 const pull = require('pull-stream')

--- a/test/utils/factory-core/index.js
+++ b/test/utils/factory-core/index.js
@@ -5,7 +5,7 @@ const isNode = require('detect-node')
 const IPFSRepo = require('ipfs-repo')
 const cleanRepo = require('../clean')
 const IPFS = require('../../../src/core')
-const series = require('run-series')
+const series = require('async/series')
 const defaultConfig = require('./default-config.json')
 
 module.exports = Factory

--- a/test/utils/factory-http/index.js
+++ b/test/utils/factory-http/index.js
@@ -6,7 +6,7 @@ const IPFSAPI = require('ipfs-api')
 const IPFS = require('../../../src/core')
 const cleanRepo = require('../clean')
 const HTTPAPI = require('../../../src/http-api')
-const series = require('run-series')
+const series = require('async/series')
 const defaultConfig = require('./default-config.json')
 
 module.exports = Factory

--- a/test/utils/ipfs-exec.js
+++ b/test/utils/ipfs-exec.js
@@ -4,6 +4,17 @@ const execa = require('execa')
 const expect = require('chai').expect
 const _ = require('lodash')
 
+// This is our new test utility to easily check and execute
+// ipfs cli commands.
+//
+// The top level export is a function that can be passed a `repoPath`
+// and optional `opts` to customize the execution of the commands.
+// This function returns the actual executer, which consists of
+// `ipfs('files get <hash>')` and `ipfs.fail('files get <hash>')`
+// The first one executes and asserts that the command ran successfully
+// and returns a promise which is resolved to `stdout` of the command.
+// The `.fail` variation asserts that the command exited with `Code > 0`
+// and returns a promise that resolves to `stderr`.
 module.exports = (repoPath, opts) => {
   const env = _.clone(process.env)
   env.IPFS_PATH = repoPath

--- a/test/utils/ipfs.js
+++ b/test/utils/ipfs.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const execa = require('execa')
+const expect = require('chai').expect
+const _ = require('lodash')
+
+module.exports = (repoPath, opts) => {
+  const env = _.clone(process.env)
+  env.IPFS_PATH = repoPath
+
+  const config = Object.assign({}, {
+    stipEof: true,
+    env: env,
+    timeout: 60 * 1000
+  }, opts)
+
+  const exec = (args) => execa(`${process.cwd()}/src/cli/bin.js`, args, config)
+
+  function ipfs () {
+    let args = Array.from(arguments)
+    if (args.length === 1) {
+      args = args[0].split(' ')
+    }
+
+    return exec(args).then((res) => {
+      expect(res.stderr).to.be.eql('')
+
+      return res.stdout
+    })
+  }
+
+  ipfs.fail = function ipfsFail () {
+    let args = Array.from(arguments)
+    if (args.length === 1) {
+      args = args[0].split(' ')
+    }
+
+    return exec(args).catch((err) => {
+      expect(err).to.exist
+    })
+  }
+
+  return ipfs
+}

--- a/test/utils/on-and-off.js
+++ b/test/utils/on-and-off.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+'use strict'
+
+const HttpAPI = require('../../src/http-api')
+
+module.exports = function onlineAndOffline (repoPath, tests) {
+  describe('api offline', () => {
+    tests()
+  })
+
+  describe('api running', () => {
+    let httpAPI
+
+    before((done) => {
+      httpAPI = new HttpAPI(repoPath)
+      httpAPI.start(done)
+    })
+
+    after((done) => {
+      httpAPI.stop(done)
+    })
+
+    tests()
+  })
+}

--- a/test/utils/temp-node.js
+++ b/test/utils/temp-node.js
@@ -3,7 +3,7 @@
 
 const expect = require('chai').expect
 const leftPad = require('left-pad')
-const series = require('run-series')
+const series = require('async/series')
 
 const IPFS = require('../../src/core')
 const createTempRepo = require('./temp-repo')


### PR DESCRIPTION
- Refactor cli tests to reduce code duplication and increase covered test cases. Also better failure mode, showing stderr and stdin when a cli tests fails.
- Fix bugs revealed due to better cli tests in
  - `files get`
  - `files cat`
  - `block stat`
  - `bootstrap add`
  - `bootstrap rm`

Ref https://github.com/ipfs/js-ipfs/issues/498