### PR TITLE
Fixed path for module importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bin": {
     "jsipfs": "src/cli/bin.js"
   },
-  "main": "lib/core/index.js",
+  "main": "src/core/index.js",
   "jsnext:main": "src/core/index.js",
   "scripts": {
     "lint": "aegir-lint",


### PR DESCRIPTION
This fixes `ipfs` package import. 

Also the npm package at `0.0.2` is very outdated . It would be useful if a more recent copy was published.