### PR TITLE
sharness: t0010- jsipfs version

### DIFF
--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -26,4 +26,50 @@ test_expect_success "ipfs version output looks good" '
 	test_fsh cat version.txt
 '
 
+test_expect_success "ipfs version --all has all required fields" '
+	ipfs version --all > version_all.txt &&
+	grep "go-ipfs version" version_all.txt &&
+	grep "Repo version" version_all.txt &&
+	grep "System version" version_all.txt &&
+	grep "Golang version" version_all.txt
+'
+
+test_expect_success "ipfs help succeeds" '
+	ipfs help >help.txt
+'
+
+test_expect_success "ipfs help output looks good" '
+	egrep -i "^Usage" help.txt >/dev/null &&
+	egrep "ipfs .* <command>" help.txt >/dev/null ||
+	test_fsh cat help.txt
+'
+
+test_expect_success "'ipfs commands' succeeds" '
+	ipfs commands >commands.txt
+'
+
+test_expect_success "'ipfs commands' output looks good" '
+	grep "ipfs add" commands.txt &&
+	grep "ipfs daemon" commands.txt &&
+	grep "ipfs update" commands.txt
+'
+
+test_expect_success "All commands accept --help" '
+	while read -r cmd
+	do
+		echo "running: $cmd --help"
+		$cmd --help </dev/null >/dev/null || return
+	done <commands.txt
+'
+
+test_expect_success "'ipfs commands --flags' succeeds" '
+	ipfs commands --flags >commands.txt
+'
+
+test_expect_success "'ipfs commands --flags' output looks good" '
+	grep "ipfs pin add --recursive / ipfs pin add -r" commands.txt &&
+	grep "ipfs id --format / ipfs id -f" commands.txt &&
+	grep "ipfs repo gc --quiet / ipfs repo gc -q" commands.txt
+'
+
 test_done

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -9,15 +9,15 @@ test_description="Test installation and some basic commands"
 . lib/test-lib.sh
 
 test_expect_success "current dir is writable" '
-	echo "It works!" >test.txt
+	echo "It works!" > test.txt
 '
 
 test_expect_success "ipfs version succeeds" '
-	ipfs version >version.txt
+	ipfs version > version.txt
 '
 
 test_expect_success "ipfs version shows js-ipfs" '
-	grep "js-ipfs" version.txt >/dev/null ||
+	grep "js-ipfs" version.txt > /dev/null ||
 	test_fsh cat version.txt
 '
 
@@ -28,48 +28,45 @@ test_expect_success "ipfs version output looks good" '
 
 test_expect_success "ipfs version --all has all required fields" '
 	ipfs version --all > version_all.txt &&
-	grep "go-ipfs version" version_all.txt &&
-	grep "Repo version" version_all.txt &&
-	grep "System version" version_all.txt &&
-	grep "Golang version" version_all.txt
+	grep "js-ipfs version" version_all.txt
 '
 
 test_expect_success "ipfs help succeeds" '
-	ipfs help >help.txt
+	ipfs help > help.txt
 '
 
-test_expect_success "ipfs help output looks good" '
-	egrep -i "^Usage" help.txt >/dev/null &&
-	egrep "ipfs .* <command>" help.txt >/dev/null ||
-	test_fsh cat help.txt
-'
+# test_expect_success "ipfs help output looks good" '
+# 	egrep -i "^Usage" help.txt > /dev/null &&
+# 	egrep "ipfs .* <command>" help.txt >/dev/null ||
+# 	test_fsh cat help.txt
+# '
 
 test_expect_success "'ipfs commands' succeeds" '
-	ipfs commands >commands.txt
+	ipfs commands > commands.txt
 '
 
 test_expect_success "'ipfs commands' output looks good" '
-	grep "ipfs add" commands.txt &&
-	grep "ipfs daemon" commands.txt &&
-	grep "ipfs update" commands.txt
+	grep "add" commands.txt &&
+	grep "daemon" commands.txt &&
+	grep "update" commands.txt
 '
 
-test_expect_success "All commands accept --help" '
-	while read -r cmd
-	do
-		echo "running: $cmd --help"
-		$cmd --help </dev/null >/dev/null || return
-	done <commands.txt
-'
+# test_expect_success "All commands accept --help" '
+# 	while read -r cmd
+# 	do
+# 		echo "running: $cmd --help"
+# 		$cmd --help </dev/null >/dev/null || return
+# 	done <commands.txt
+# '
 
-test_expect_success "'ipfs commands --flags' succeeds" '
-	ipfs commands --flags >commands.txt
-'
+# test_expect_success "'ipfs commands --flags' succeeds" '
+# 	ipfs commands --flags >commands.txt
+# '
 
-test_expect_success "'ipfs commands --flags' output looks good" '
-	grep "ipfs pin add --recursive / ipfs pin add -r" commands.txt &&
-	grep "ipfs id --format / ipfs id -f" commands.txt &&
-	grep "ipfs repo gc --quiet / ipfs repo gc -q" commands.txt
-'
+# test_expect_success "'ipfs commands --flags' output looks good" '
+# 	grep "ipfs pin add --recursive / ipfs pin add -r" commands.txt &&
+# 	grep "ipfs id --format / ipfs id -f" commands.txt &&
+# 	grep "ipfs repo gc --quiet / ipfs repo gc -q" commands.txt
+# '
 
 test_done


### PR DESCRIPTION
This add some failing tests.

The first failure is:

```
expecting success: 
        ipfs version --all > version_all.txt &&
        grep "go-ipfs version" version_all.txt &&
        grep "Repo version" version_all.txt &&
        grep "System version" version_all.txt &&
        grep "Golang version" version_all.txt

not ok 5 - ipfs version --all has all required fields
```

This is because `jsipfs version --all` returns "js-ipfs version: 0.17.0" while:

```
$ ipfs version --all
go-ipfs version: 0.4.4-dev-8830aae
Repo version: 4
System version: amd64/linux
Golang version: go1.5.3
```

I understand that jsipfs cannot give a go-ipfs version or a golang version, but it could give equivalent information about the js-ipfs version and the js engine.

In go-ipfs reports we ask users to copy paste the output of `ipfs version --all` when filling an issue. If js-ipfs also implements that you could also ask users to do the same thing. 
