### PR TITLE
Configuration for labels-and-milestones sync tool

### DIFF
--- a/tools/labels-and-milestones/.gitignore
+++ b/tools/labels-and-milestones/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/labels-and-milestones/README.md
+++ b/tools/labels-and-milestones/README.md
@@ -1,0 +1,39 @@
+# labels-and-milestones Sync for js-ipfs
+
+> Sync labels and milestones across Github repositories
+
+This is a fork of [haadcode/labels-and-milestones](https://github.com/haadcode/labels-and-milestones). We are using it in a particular way. Check out the Readme in that repo for the "normal" usage instructions.
+
+## Requirements
+
+**IMPORTANT** This script must be run using a Github personal access token corresponding to an account that has the ability to ADD MILESTONES to all of the repositories listed in `js-ipfs-milestones.config.json`.
+
+- Set `GITHUB_TOKEN` env var to Github personal access token
+- Install node/npm
+- Clone this repo
+
+## Install
+
+First install dependencies
+
+```bash
+npm install
+```
+
+## Configure
+
+Edit `js-ipfs-milestones.config.json` to list the repositories you want to sync to along with thethe Milestones and labels you want to sync.
+
+## Run the Sync Tool
+
+Then run the sync tool, providing the config file you want to use
+
+```bash
+npm run sync-milestones
+```
+
+This command will read `js-ipfs-milestones.config.json` and sync the labels and milestones to the target repos.
+
+#### Running via CI
+
+This will need some work. See [haadcode/labels-and-milestones](https://github.com/haadcode/labels-and-milestones) for more info.

--- a/tools/labels-and-milestones/js-ipfs-milestones.config.json
+++ b/tools/labels-and-milestones/js-ipfs-milestones.config.json
@@ -1,0 +1,91 @@
+[
+  {
+    "repositories": [
+      "ipfs/js-ipfs",
+      "ipfs/js-ipfs-api",
+      "ipfs/js-ipfs-block-service",
+      "ipfs/js-ipfs-repo",
+      "ipfs/js-ipfs-block",
+      "ipfs/js-ipfs-merkle-dag",
+      "ipfs/js-ipfs-unixfs",
+      "ipfs/js-ipfs-unixfs-engine",
+      "ipfs/js-ipfs-bitswap",
+      "ipfs/js-ipfsd-ctl",
+      "dignifiedquire/aegir",
+      "ipfs/js-libp2p-ipfs",
+      "ipfs/js-libp2p-ipfs-browser",
+      "ipld/js-ipld-dag-cbor",
+      "ipld/js-ipld-resolver",
+      "multiformats/js-multiaddr",
+      "multiformats/js-multibase",
+      "multiformats/js-multicodec",
+      "multiformats/js-multihash",
+      "multiformats/js-multihashing",
+      "multiformats/js-multihashing-async",
+      "multiformats/js-multistream-select",
+      "multiformats/multistream-select"
+    ],
+    "milestones": [
+      {
+        "title": "q4a - js-ipfs on the browser",
+        "state": "closed",
+        "description": "This milestone's focus is to ship a version of js-ipfs that can be embed in browser applications, creating an IPFS node inside a browser web application.\n",
+        "due_on": "2016-08-30"
+      },
+      {
+        "title": "q4b - Quality and correctness of the JavaScript Implementation",
+        "state": "closed",
+        "description": "The focus of this milestone is quality of the JavaScript implementation so that users of the library can build their applications with confidence.\n",
+        "due_on": "2016-08-30"
+      },
+      {
+        "title": "q4c - The InterPlanetary JavaScript",
+        "state": "open",
+        "description": "Settle in what will be the 'good parts' for us to use accross JS projects\n",
+        "due_on": "2016-10-17"
+      },
+      {
+        "title": "q4d - interface-floodsub",
+        "state": "open",
+        "description": "Define an interface for floodsub, that can be implemented for js-ipfs and js-ipfs-api\n",
+        "due_on": "2016-10-17"
+      },
+      {
+        "title": "q4e - Awesome IPLD",
+        "state": "open",
+        "description": "Integration of IPLD (js-ipld and js-ipld-ipfs) into js-ipfs. Enable js-ipfs to handle both merkledag protobufs and ipld cbor objects\n",
+        "due_on": "2016-10-24"
+      },
+      {
+        "title": "q4f - Async Crypto",
+        "state": "open",
+        "description": "Move away from bundling in node-forge and use the WebCrypto browser primitives directly\n",
+        "due_on": "2016-10-24"
+      },
+      {
+        "title": "q4g - Bitswap Complete",
+        "state": "open",
+        "description": "Make js-ipfs-bitswap work at the same level go-ipfs-bitswap\n",
+        "due_on": "2016-10-31"
+      },
+      {
+        "title": "q4h - js-ipfs and js-ipfs-api bundling",
+        "state": "open",
+        "description": "Make it work with any bundler, out of the box or provide proper documentation if not possible.\n",
+        "due_on": "2016-10-31"
+      },
+      {
+        "title": "q4i - Documentation of all the modules",
+        "state": "open",
+        "description": "Document all js modules",
+        "due_on": "2016-11-21"
+      },
+      {
+        "title": "q4j - Quick Start examples for js-ipfs and js-ipfs-api",
+        "state": "open",
+        "description": "Provide quick start examples for js-ipfs and js-ipfs-api\n",
+        "due_on": "2016-11-28"
+      }
+    ]
+  }
+]

--- a/tools/labels-and-milestones/package.json
+++ b/tools/labels-and-milestones/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "js-ipfs-milestone-sync",
+  "version": "1.0.0",
+  "description": "Milestone and label sync for js-ipfs project",
+  "main": "index.js",
+  "scripts": {
+    "sync-milestones": "./node_modules/.bin/github-sync-labels-milestones -v -c js-ipfs-milestones.config.json -t $GITHUB_TOKEN",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Haad",
+  "license": "MIT",
+  "dependencies": {
+    "github-sync-labels-milestones": "0.2.1"
+  }
+}


### PR DESCRIPTION
This adds the labels-and-milestones sync tool with configs for the go-ipfs Q4 roadmap.

I'm not convinced this is the right place for these configs.

For more info, see ipfs/pm#257