### PR TITLE
Implement more bootstrap commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ncp": "^2.0.0",
     "nexpect": "^0.5.0",
     "pre-commit": "^1.2.1",
+    "qs": "^6.3.0",
     "rimraf": "^2.5.4",
     "stream-to-promise": "^2.2.0",
     "transform-loader": "^0.2.3"

--- a/src/cli/commands/bootstrap/add.js
+++ b/src/cli/commands/bootstrap/add.js
@@ -6,11 +6,17 @@ const utils = require('../../utils')
 log.error = debug('cli:bootstrap:error')
 
 module.exports = {
-  command: 'add <peer>',
+  command: 'add [<peer>]',
 
   describe: 'Add peers to the bootstrap list',
 
-  builder: {},
+  builder: {
+    default: {
+      describe: 'Add default bootstrap nodes.',
+      type: 'boolean',
+      default: false
+    }
+  },
 
   handler (argv) {
     utils.getIPFS((err, ipfs) => {
@@ -18,10 +24,12 @@ module.exports = {
         throw err
       }
 
-      ipfs.bootstrap.add(argv.peer, (err, list) => {
+      ipfs.bootstrap.add(argv.peer, {default: argv.default}, (err, list) => {
         if (err) {
           throw err
         }
+
+        list.Peers.forEach((l) => console.log(l))
       })
     })
   }

--- a/src/cli/commands/bootstrap/list.js
+++ b/src/cli/commands/bootstrap/list.js
@@ -21,7 +21,8 @@ module.exports = {
         if (err) {
           throw err
         }
-        list.forEach((node) => {
+
+        list.Peers.forEach((node) => {
           console.log(node)
         })
       })

--- a/src/cli/commands/bootstrap/rm.js
+++ b/src/cli/commands/bootstrap/rm.js
@@ -28,6 +28,8 @@ module.exports = {
         if (err) {
           throw err
         }
+
+        list.Peers.forEach((l) => console.log(l))
       })
     })
   }

--- a/src/cli/commands/bootstrap/rm.js
+++ b/src/cli/commands/bootstrap/rm.js
@@ -6,18 +6,25 @@ log.error = debug('cli:bootstrap:error')
 const utils = require('../../utils')
 
 module.exports = {
-  command: 'rm <peer>',
+  command: 'rm [<peer>]',
 
   describe: 'Removes peers from the bootstrap list',
 
-  builder: {},
+  builder: {
+    all: {
+      type: 'boolean',
+      describe: 'Remove all bootstrap peers.',
+      default: false
+    }
+  },
 
   handler (argv) {
     utils.getIPFS((err, ipfs) => {
       if (err) {
         throw err
       }
-      ipfs.bootstrap.rm(argv.peer, (err, list) => {
+
+      ipfs.bootstrap.rm(argv.peer, {all: argv.all}, (err, list) => {
         if (err) {
           throw err
         }

--- a/src/core/components/bootstrap.js
+++ b/src/core/components/bootstrap.js
@@ -23,7 +23,7 @@ module.exports = function bootstrap (self) {
         }
         if (args.default) {
           config.Bootstrap = defaultNodes
-        } else {
+        } else if (multiaddr) {
           config.Bootstrap.push(multiaddr)
         }
         self._repo.config.set(config, (err) => {

--- a/src/core/components/bootstrap.js
+++ b/src/core/components/bootstrap.js
@@ -19,19 +19,21 @@ module.exports = function bootstrap (self) {
         self._repo.config.set(config, callback)
       })
     },
-    rm: (multiaddr, callback) => {
+    rm: (multiaddr, args, callback) => {
+      if (typeof args === 'function') {
+        callback = args
+        args = {all: false}
+      }
       self._repo.config.get((err, config) => {
         if (err) {
           return callback(err)
         }
+        if (args.all) {
+          config.Bootstrap = []
+        } else {
+          config.Bootstrap = config.Bootstrap.filter((mh) => mh !== multiaddr)
+        }
 
-        config.Bootstrap = config.Bootstrap.filter((mh) => {
-          if (mh === multiaddr) {
-            return false
-          } else {
-            return true
-          }
-        })
         self._repo.config.set(config, callback)
       })
     }

--- a/src/http-api/resources/bootstrap.js
+++ b/src/http-api/resources/bootstrap.js
@@ -11,21 +11,6 @@ function applyError (reply, err) {
   }).code(500).takeover()
 }
 
-// common pre request handler that parses the args and returns `key` which is assigned to `request.pre.args`
-exports.parseKey = (request, reply) => {
-  if (!request.query.arg) {
-    return applyError(reply, new Error("Argument 'multiaddr' is required"))
-  }
-
-  try {
-    return reply({
-      addr: multiaddr(request.query.arg)
-    })
-  } catch (err) {
-    return applyError(reply, new Error('Not a valid multiaddr'))
-  }
-}
-
 exports.list = (request, reply) => {
   const ipfs = request.server.app.ipfs
 

--- a/src/http-api/resources/bootstrap.js
+++ b/src/http-api/resources/bootstrap.js
@@ -1,14 +1,20 @@
 'use strict'
 
-const boom = require('boom')
 const multiaddr = require('multiaddr')
 
 exports = module.exports
 
+function applyError (reply, err) {
+  reply({
+    Message: err.message,
+    Code: 0
+  }).code(500).takeover()
+}
+
 // common pre request handler that parses the args and returns `key` which is assigned to `request.pre.args`
 exports.parseKey = (request, reply) => {
   if (!request.query.arg) {
-    return reply("Argument 'multiaddr' is required").code(400).takeover()
+    return applyError(reply, new Error("Argument 'multiaddr' is required"))
   }
 
   try {
@@ -16,50 +22,84 @@ exports.parseKey = (request, reply) => {
       addr: multiaddr(request.query.arg)
     })
   } catch (err) {
-    return reply({
-      Message: 'Not a valid multiaddr',
-      Code: 0
-    }).code(500).takeover()
+    return applyError(reply, new Error('Not a valid multiaddr'))
   }
 }
 
 exports.list = (request, reply) => {
   const ipfs = request.server.app.ipfs
+
   ipfs.bootstrap.list((err, list) => {
     if (err) {
-      return reply(boom.badRequest(err))
+      return applyError(reply, err)
     }
+
     return reply(list)
   })
 }
 
 exports.add = {
-  parseArgs: exports.parseKey,
+  parseArgs (request, reply) {
+    const q = request.query
+    const def = q.default === 'true'
+
+    if (q.arg != null) {
+      try {
+        return reply({
+          addr: multiaddr(q.arg),
+          default: def
+        })
+      } catch (err) {
+        return applyError(reply, new Error('Not a valid multiaddr'))
+      }
+    } else {
+      reply({default: def})
+    }
+  },
   handler (request, reply) {
     const ipfs = request.server.app.ipfs
     const addr = request.pre.args.addr
-    console.log('Handler is called', addr.toString())
+    const def = request.pre.args.default
 
-    ipfs.bootstrap.add(addr.toString(), (err, list) => {
+    ipfs.bootstrap.add(addr && addr.toString(), {default: def}, (err, list) => {
       if (err) {
-        return reply(boom.badRequest(err))
+        return applyError(reply, err)
       }
-      return reply()
+
+      return reply(list)
     })
   }
 }
 
 exports.rm = {
-  parseArgs: exports.parseKey,
+  parseArgs (request, reply) {
+    const q = request.query
+    const all = q.all === 'true'
+
+    if (q.arg != null) {
+      try {
+        return reply({
+          addr: multiaddr(q.arg),
+          all: all
+        })
+      } catch (err) {
+        return applyError(reply, new Error('Not a valid multiaddr'))
+      }
+    } else {
+      reply({all: all})
+    }
+  },
   handler (request, reply) {
     const ipfs = request.server.app.ipfs
     const addr = request.pre.args.addr
+    const all = request.pre.args.all
 
-    ipfs.bootstrap.rm(addr.toString(), (err, list) => {
+    ipfs.bootstrap.rm(addr && addr.toString(), {all: all}, (err, list) => {
       if (err) {
-        return reply(boom.badRequest(err))
+        return applyError(reply, err)
       }
-      return reply()
+
+      return reply(list)
     })
   }
 }

--- a/src/http-api/routes/bootstrap.js
+++ b/src/http-api/routes/bootstrap.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Joi = require('joi')
 const resources = require('./../resources')
 
 module.exports = (server) => {
@@ -21,14 +20,7 @@ module.exports = (server) => {
       pre: [
         { method: resources.bootstrap.add.parseArgs, assign: 'args' }
       ],
-      handler: resources.bootstrap.add.handler,
-      validate: {
-        query: {
-          arg: Joi.string().required(),
-          default: Joi.boolean(),
-          'stream-channels': Joi.boolean()
-        }
-      }
+      handler: resources.bootstrap.add.handler
     }
   })
 
@@ -47,14 +39,7 @@ module.exports = (server) => {
       pre: [
         { method: resources.bootstrap.rm.parseArgs, assign: 'args' }
       ],
-      handler: resources.bootstrap.rm.handler,
-      validate: {
-        query: {
-          arg: Joi.string().required(),
-          default: Joi.boolean(),
-          'stream-channels': Joi.boolean()
-        }
-      }
+      handler: resources.bootstrap.rm.handler
     }
   })
 }

--- a/src/http-api/routes/bootstrap.js
+++ b/src/http-api/routes/bootstrap.js
@@ -9,7 +9,9 @@ module.exports = (server) => {
   api.route({
     method: '*',
     path: '/api/v0/bootstrap',
-    handler: resources.bootstrap.list
+    config: {
+      handler: resources.bootstrap.list
+    }
   })
 
   // https://github.com/ipfs/http-api-spec/blob/master/apiary.apib#L866

--- a/test/cli/test-bootstrap.js
+++ b/test/cli/test-bootstrap.js
@@ -7,7 +7,7 @@ const repoPath = require('./index').repoPath
 const ipfs = require('../utils/ipfs-exec')(repoPath)
 const describeOnlineAndOffline = require('../utils/on-and-off')
 
-describe('bootstrap', () => {
+describe.only('bootstrap', () => {
   describeOnlineAndOffline(repoPath, () => {
     const defaultList = [
       '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
@@ -50,11 +50,19 @@ describe('bootstrap', () => {
       })
     })
 
-    it.skip('rm a bootstrap node', () => {
+    it('rm a bootstrap node', () => {
       return ipfs('bootstrap rm /ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD').then((out) => {
         return ipfs('bootstrap list')
       }).then((out) => {
         expect(out).to.deep.equal(defaultList.join('\n'))
+      })
+    })
+
+    it('rm all bootstrap nodes', () => {
+      return ipfs('bootstrap rm --all').then((out) => {
+        return ipfs('bootstrap list')
+      }).then((out) => {
+        expect(out).to.deep.equal('')
       })
     })
   })

--- a/test/cli/test-bootstrap.js
+++ b/test/cli/test-bootstrap.js
@@ -7,7 +7,7 @@ const repoPath = require('./index').repoPath
 const ipfs = require('../utils/ipfs-exec')(repoPath)
 const describeOnlineAndOffline = require('../utils/on-and-off')
 
-describe.only('bootstrap', () => {
+describe('bootstrap', () => {
   describeOnlineAndOffline(repoPath, () => {
     const defaultList = [
       '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
@@ -34,16 +34,21 @@ describe.only('bootstrap', () => {
       '/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD'
     ]
 
+    it('add default', () => {
+      return ipfs('bootstrap add --default').then((out) => {
+        expect(out).to.be.eql(defaultList.join('\n'))
+      })
+    })
+
     it('list the bootstrap nodes', () => {
       return ipfs('bootstrap list').then((out) => {
         expect(out).to.eql(defaultList.join('\n'))
       })
     })
 
-    // TODO need https://github.com/ipfs/interface-ipfs-core/issues/97
-    // to happen, otherwise it is a cat an mouse game
-    it.skip('add another bootstrap node', () => {
+    it('add another bootstrap node', () => {
       return ipfs('bootstrap add /ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD').then((out) => {
+        expect(out).to.be.eql('/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD')
         return ipfs('bootstrap list')
       }).then((out) => {
         expect(out).to.be.eql(updatedList.join('\n'))
@@ -52,6 +57,7 @@ describe.only('bootstrap', () => {
 
     it('rm a bootstrap node', () => {
       return ipfs('bootstrap rm /ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD').then((out) => {
+        expect(out).to.be.eql('/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD')
         return ipfs('bootstrap list')
       }).then((out) => {
         expect(out).to.deep.equal(defaultList.join('\n'))
@@ -60,6 +66,7 @@ describe.only('bootstrap', () => {
 
     it('rm all bootstrap nodes', () => {
       return ipfs('bootstrap rm --all').then((out) => {
+        expect(out).to.be.eql('')
         return ipfs('bootstrap list')
       }).then((out) => {
         expect(out).to.deep.equal('')

--- a/test/core/both/test-bootstrap.js
+++ b/test/core/both/test-bootstrap.js
@@ -41,28 +41,30 @@ describe('bootstrap', () => {
   it('get bootstrap list', (done) => {
     ipfs.bootstrap.list((err, list) => {
       expect(err).to.not.exist
-      expect(list).to.deep.equal(defaultList)
+      expect(list.Peers).to.deep.equal(defaultList)
       done()
     })
   })
 
   it('add a peer to the bootstrap list', (done) => {
-    ipfs.bootstrap.add('/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT', (err) => {
+    ipfs.bootstrap.add('/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT', (err, res) => {
       expect(err).to.not.exist
+      expect(res).to.be.eql({Peers: ['/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT']})
       ipfs.bootstrap.list((err, list) => {
         expect(err).to.not.exist
-        expect(list).to.deep.equal(updatedList)
+        expect(list.Peers).to.deep.equal(updatedList)
         done()
       })
     })
   })
 
   it('remove a peer from the bootstrap list', (done) => {
-    ipfs.bootstrap.rm('/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT', (err) => {
+    ipfs.bootstrap.rm('/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT', (err, res) => {
       expect(err).to.not.exist
+      expect(res).to.be.eql({Peers: ['/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT']})
       ipfs.bootstrap.list((err, list) => {
         expect(err).to.not.exist
-        expect(list).to.deep.equal(defaultList)
+        expect(list.Peers).to.deep.equal(defaultList)
         done()
       })
     })

--- a/test/http-api/custom-ipfs-api/test-bootstrap.js
+++ b/test/http-api/custom-ipfs-api/test-bootstrap.js
@@ -5,28 +5,86 @@ const expect = require('chai').expect
 
 module.exports = (ctl) => {
   describe('.bootstrap', () => {
-    // TODO: needs https://github.com/ipfs/js-ipfs-api/issues/217
-    it.skip('list', (done) => {
-      ctl.boostrap.list((err, result) => {
-        expect(err).to.not.exist
-        expect(result).to.deep.equal(defaultList)
-        done()
+    const invalidArg = 'this/Is/So/Invalid/'
+    const validIp4 = '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
+    let peers
+
+    describe('.add', () => {
+      it('returns an error when called with an invalid arg', (done) => {
+        ctl.bootstrap.add(invalidArg, (err) => {
+          expect(err).to.be.an.instanceof(Error)
+          done()
+        })
+      })
+
+      it('returns a list of containing the bootstrap peer when called with a valid arg (ip4)', (done) => {
+        ctl.bootstrap.add(validIp4, (err, res) => {
+          expect(err).to.not.exist
+          expect(res).to.be.eql({ Peers: [validIp4] })
+          done()
+        })
+      })
+
+      it('returns a list of bootstrap peers when called with the default option', (done) => {
+        ctl.bootstrap.add({ default: true }, (err, res) => {
+          expect(err).to.not.exist
+          peers = res.Peers
+          expect(peers).to.exist
+          console.log(peers)
+          expect(peers.length).to.be.above(1)
+          done()
+        })
       })
     })
 
-    it.skip('add', (done) => {}) // TODO
-    it.skip('rm', (done) => {}) // TODO
+    describe('.list', () => {
+      it('returns a list of peers', (done) => {
+        ctl.bootstrap.list((err, res) => {
+          expect(err).to.not.exist
+          peers = res.Peers
+          expect(peers).to.exist
+          done()
+        })
+      })
+    })
+
+    describe('.rm', () => {
+      it('returns an error when called with an invalid arg', (done) => {
+        ctl.bootstrap.rm(invalidArg, (err) => {
+          expect(err).to.be.an.instanceof(Error)
+          done()
+        })
+      })
+
+      it('returns empty list because no peers removed when called without an arg or options', (done) => {
+        ctl.bootstrap.rm(null, (err, res) => {
+          expect(err).to.not.exist
+          peers = res.Peers
+          expect(peers).to.exist
+          expect(peers.length).to.eql(0)
+          done()
+        })
+      })
+
+      it('returns list containing the peer removed when called with a valid arg (ip4)', (done) => {
+        ctl.bootstrap.rm(validIp4, (err, res) => {
+          expect(err).to.not.exist
+
+          peers = res.Peers
+          expect(peers).to.exist
+          expect(peers.length).to.eql(1)
+          done()
+        })
+      })
+
+      it('returns list of all peers removed when all option is passed', (done) => {
+        ctl.bootstrap.rm(null, { all: true }, (err, res) => {
+          expect(err).to.not.exist
+          peers = res.Peers
+          expect(peers).to.exist
+          done()
+        })
+      })
+    })
   })
 }
-
-const defaultList = [
-  '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
-  '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
-  '/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-  '/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-  '/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-  '/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
-  '/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-  '/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-  '/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx'
-]

--- a/test/http-api/custom-ipfs-api/test-bootstrap.js
+++ b/test/http-api/custom-ipfs-api/test-bootstrap.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect
 module.exports = (ctl) => {
   describe('.bootstrap', () => {
     const invalidArg = 'this/Is/So/Invalid/'
-    const validIp4 = '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
+    const validIp4 = '/ip4/101.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
     let peers
 
     describe('.add', () => {
@@ -30,7 +30,6 @@ module.exports = (ctl) => {
           expect(err).to.not.exist
           peers = res.Peers
           expect(peers).to.exist
-          console.log(peers)
           expect(peers.length).to.be.above(1)
           done()
         })

--- a/test/http-api/inject/test-bootstrap.js
+++ b/test/http-api/inject/test-bootstrap.js
@@ -2,13 +2,23 @@
 'use strict'
 
 const expect = require('chai').expect
+const qs = require('qs')
+const defaultList = require('../../../src/init-files/default-config.json').Bootstrap
 
 module.exports = (http) => {
   describe('/bootstrap', () => {
+    const validIp4 = '/ip4/101.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
     let api
 
-    before(() => {
+    before((done) => {
       api = http.api.server.select('API')
+      api.inject({
+        method: 'GET',
+        url: '/api/v0/bootstrap/add',
+        payload: {
+          default: 'true'
+        }
+      }, () => done())
     })
 
     it('/list', (done) => {
@@ -16,7 +26,8 @@ module.exports = (http) => {
         method: 'GET',
         url: '/api/v0/bootstrap/list'
       }, (res) => {
-        expect(res.result).to.deep.equal(defaultList)
+        expect(res.statusCode).to.be.eql(200)
+        expect(res.result.Peers).to.deep.equal(defaultList)
         done()
       })
     })
@@ -26,54 +37,51 @@ module.exports = (http) => {
         method: 'GET',
         url: '/api/v0/bootstrap'
       }, (res) => {
-        expect(res.result).to.deep.equal(defaultList)
+        expect(res.statusCode).to.be.eql(200)
+        expect(res.result.Peers).to.deep.equal(defaultList)
         done()
       })
     })
 
-    it.skip('/add', (done) => { // TODO
+    it('/add', (done) => {
+      const query = {
+        arg: validIp4
+      }
+
       api.inject({
         method: 'GET',
-        url: '/api/v0/bootstrap/add',
-        payload: {
-          arg: '/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT'
-        }
+        url: `/api/v0/bootstrap/add?${qs.stringify(query)}`
       }, (res) => {
-        // TODO assess
+        expect(res.statusCode).to.be.eql(200)
+        expect(res.result.Peers).to.be.eql([validIp4])
+        done()
       })
     })
 
-    it.skip('/rm', (done) => { // TODO
+    it('/rm', (done) => {
+      const query = {
+        arg: validIp4
+      }
+
       api.inject({
         method: 'GET',
-        url: '/api/v0/bootstrap/rm',
-        payload: {
-          arg: '/ip4/111.111.111.111/tcp/1001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLUVIT'
-        }
+        url: `/api/v0/bootstrap/rm?${qs.stringify(query)}`
       }, (res) => {
-        // TODO assess
+        expect(res.statusCode).to.be.eql(200)
+        expect(res.result.Peers).to.be.eql([validIp4])
+        done()
       })
     })
 
-    it.skip('/list confirm it changed', (done) => { // TODO
+    it('/list confirm it changed', (done) => {
       api.inject({
         method: 'GET',
         url: '/api/v0/bootstrap/list'
       }, (res) => {
-        // TODO assess
+        expect(res.statusCode).to.be.eql(200)
+        expect(res.result.Peers).to.be.eql(defaultList)
+        done()
       })
     })
   })
 }
-
-const defaultList = [
-  '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
-  '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
-  '/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-  '/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-  '/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-  '/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
-  '/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-  '/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-  '/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx'
-]


### PR DESCRIPTION
Fixes #668 

Available in the cli, http-api and core:

- `bootstrap add <peer>`
- `bootstrap add --default`
- `bootstrap rm <peer>`
- `bootstrap rm --all`
- `bootstrap list`

Same output and as go-ipfs  and js-ipfs-api.