### PR TITLE
fix: update sharness tests to use right cli

### DIFF
--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -12,11 +12,11 @@ test_expect_success "current dir is writable" '
 	echo "It works!" >test.txt
 '
 
-test_expect_success "ipfs version succeeds" '
-	ipfs version >version.txt
+test_expect_success "jsipfs version succeeds" '
+	jsipfs version >version.txt
 '
 
-test_expect_success "ipfs version shows js-ipfs" '
+test_expect_success "jsipfs version shows js-ipfs" '
 	grep "js-ipfs" version.txt >/dev/null ||
 	test_fsh cat version.txt
 '

--- a/test/sharness/t0022-init-default.sh
+++ b/test/sharness/t0022-init-default.sh
@@ -16,7 +16,7 @@ test_expect_success "ipfs init succeeds" '
 	export IPFS_PATH="$(pwd)/.ipfs" &&
 	echo "IPFS_PATH: \"$IPFS_PATH\"" &&
 	BITS="2048" &&
-	ipfs init --bits="$BITS" >actual_init ||
+	jsipfs init --bits="$BITS" >actual_init ||
 	test_fsh cat actual_init
 '
 
@@ -26,7 +26,7 @@ test_expect_success ".ipfs/config has been created" '
 '
 
 test_expect_success "ipfs config succeeds" '
-	ipfs config $cfg_flags "$cfg_key" "$cfg_val"
+	jsipfs config $cfg_flags "$cfg_key" "$cfg_val"
 '
 
 test_expect_success "ipfs read config succeeds" '


### PR DESCRIPTION
@chriscool I've updated the sharness tests to point to `jsipfs` instead of `ipfs`. Everything seems ok to me, just wanted your confirmation.