### PR TITLE
feat: dag get cli

### DIFF
--- a/src/cli/commands/dag.js
+++ b/src/cli/commands/dag.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  command: 'dag',
+
+  description: 'Interact with ipld dag objects.',
+
+  builder (yargs) {
+    return yargs
+      .commandDir('dag')
+  },
+
+  handler (argv) {
+  }
+}

--- a/src/cli/commands/dag/get.js
+++ b/src/cli/commands/dag/get.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const utils = require('../../utils')
+const CID = require('cids')
+const debug = require('debug')
+const log = debug('cli:block')
+log.error = debug('cli:block:error')
+
+module.exports = {
+  command: 'get <ref>',
+
+  describe: 'Get a dag node from ipfs.',
+
+  builder: {},
+
+  handler (argv) {
+    utils.getIPFS((err, ipfs) => {
+      if (err) {
+        throw err
+      }
+
+      const refParts = argv.ref.split('/')
+      const cidString = refParts[0]
+      const pathString = refParts.slice(1).join('/')
+      const cid = new CID(cidString)
+
+      let lookupFn
+      if (pathString) {
+        lookupFn = () => ipfs.dag.resolve(cid, pathString)
+      } else {
+        lookupFn = () => ipfs.dag.get(cid)
+      }
+
+      lookupFn()
+      .then((obj) => {
+        console.log(obj)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+    })
+  }
+}

--- a/test/cli/test-dag.js
+++ b/test/cli/test-dag.js
@@ -1,0 +1,18 @@
+/* eslint-env mocha */
+'use strict'
+
+const expect = require('chai').expect
+const repoPath = require('./index').repoPath
+const describeOnlineAndOffline = require('../utils/on-and-off')
+const ipfs = require('../utils/ipfs-exec')(repoPath)
+
+describe('dag', () => {
+  describeOnlineAndOffline(repoPath, () => {
+    it('get', () => {
+      return ipfs('dag get z43AaGF23fmvRnDP56Ub9WcJCfzSfqtmzNCCvmz5eudT8dtdCDS/parentHash').then((out) => {
+        let expectHash = new Buffer('c8c0a17305adea9bbb4b98a52d44f0c1478f5c48fc4b64739ee805242501b256', 'hex')
+        expect(out).to.be.eql(expectHash)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Here is the skeleton for the `dag` cli command, and an implementation of `dag get <ref>` where `ref` is { `<cid>` or `<cid>/<path>` }.

Not sure what the formatting for output should be, just logging the result as-in for now.

Was unable to run the test due to some unrelated bug on test start, but should be correct.