### PR TITLE
http-api - block - get - return value raw

### DIFF
--- a/src/http-api/resources/block.js
+++ b/src/http-api/resources/block.js
@@ -46,7 +46,7 @@ exports.get = {
         }).code(500)
       }
 
-      return reply(block.data.toString())
+      return reply(block.data)
     })
   }
 }


### PR DESCRIPTION
value may be a binary buffer, it should be returned as is instead of coerced into unicode

note: if request is sent from the browser, the requestor can set the `responseType` to get the result as an ArrayBuffer in order to accurately get the binary data
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data