### PR TITLE
🌟 feat: add websocket bootstrapers to the config

### DIFF
--- a/examples/transfer-files/public/js/app.js
+++ b/examples/transfer-files/public/js/app.js
@@ -187,7 +187,14 @@ function refreshPeerList () {
     }
 
     const peersAsHtml = peers
-      .map((peer) => peer.addr.toString())
+      .map((peer) => {
+        const addr = peer.addr.toString()
+        if (addr.indexOf('ipfs') >= 0) {
+          return addr
+        } else {
+          return addr + peer.peer.id.toB58String()
+        }
+      })
       .map((addr) => {
         return '<li>' + addr + '</li>'
       }).join('')

--- a/src/init-files/default-config-browser.json
+++ b/src/init-files/default-config-browser.json
@@ -13,5 +13,7 @@
       "Enabled": true
     }
   },
-  "Bootstrap": []
+  "Discovery": {},
+  "Bootstrap": [
+  ]
 }

--- a/src/init-files/default-config-browser.json
+++ b/src/init-files/default-config-browser.json
@@ -15,5 +15,7 @@
   },
   "Discovery": {},
   "Bootstrap": [
+    "/dns4/strawberry.i.ipfs.io/wss/ipfs/QmWyLSnMHW2H6bmCG9e9PQq4ARve94JduvGjbutUuzx4a8",
+    "/dns4/blueberry.i.ipfs.io/wss/ipfs/QmVcj9MATxGTAFoQSbrJvZ9Fbs4Jzvrxy9hyJeRwbW8NeA"
   ]
 }

--- a/src/init-files/default-config-browser.json
+++ b/src/init-files/default-config-browser.json
@@ -15,7 +15,13 @@
   },
   "Discovery": {},
   "Bootstrap": [
-    "/dns4/strawberry.i.ipfs.io/wss/ipfs/QmWyLSnMHW2H6bmCG9e9PQq4ARve94JduvGjbutUuzx4a8",
-    "/dns4/blueberry.i.ipfs.io/wss/ipfs/QmVcj9MATxGTAFoQSbrJvZ9Fbs4Jzvrxy9hyJeRwbW8NeA"
+    "/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+    "/dns4/sfo-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx",
+    "/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3",
+    "/dns4/sfo-2.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z",
+    "/dns4/sfo-3.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
+    "/dns4/sgp-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
+    "/dns4/nyc-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm",
+    "/dns4/nyc-2.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64"
   ]
 }

--- a/src/init-files/default-config-node.json
+++ b/src/init-files/default-config-node.json
@@ -25,6 +25,8 @@
     "/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
     "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
     "/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3",
-    "/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx"
+    "/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx",
+    "/dns4/strawberry.i.ipfs.io/wss/ipfs/QmWyLSnMHW2H6bmCG9e9PQq4ARve94JduvGjbutUuzx4a8",
+    "/dns4/blueberry.i.ipfs.io/wss/ipfs/QmVcj9MATxGTAFoQSbrJvZ9Fbs4Jzvrxy9hyJeRwbW8NeA"
   ]
 }

--- a/src/init-files/default-config-node.json
+++ b/src/init-files/default-config-node.json
@@ -25,8 +25,6 @@
     "/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
     "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
     "/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3",
-    "/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx",
-    "/dns4/strawberry.i.ipfs.io/wss/ipfs/QmWyLSnMHW2H6bmCG9e9PQq4ARve94JduvGjbutUuzx4a8",
-    "/dns4/blueberry.i.ipfs.io/wss/ipfs/QmVcj9MATxGTAFoQSbrJvZ9Fbs4Jzvrxy9hyJeRwbW8NeA"
+    "/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx"
   ]
 }

--- a/test/http-api/spec/bootstrap.js
+++ b/test/http-api/spec/bootstrap.js
@@ -27,6 +27,8 @@ module.exports = (http) => {
         url: '/api/v0/bootstrap/list'
       }, (res) => {
         expect(res.statusCode).to.be.eql(200)
+        console.log(res.result.Peers)
+        console.log(defaultList)
         expect(res.result.Peers).to.deep.equal(defaultList)
         done()
       })


### PR DESCRIPTION
Added the bootstrappers [@lgierth created](https://github.com/ipfs/pm/issues/310#issuecomment-275968934) to the Bootstraper list. This is still not 100% working as it requires some updates throughout the dialing code (DNS addrs need to be valid wss/tcp).

- [x] Make the WebSockets transport DNS aware https://github.com/libp2p/js-libp2p-websockets/pull/47
- [x] Decide if we want to loosen up CORS rules for bootstrapers https://github.com/ipfs/js-ipfs/pull/740#issuecomment-288047524

Assignee: @dryajov 