### PR TITLE
test: another 'add recursive' test

### DIFF
--- a/test/cli/test-files.js
+++ b/test/cli/test-files.js
@@ -72,7 +72,7 @@ describe('files', () => {
       })
     })
 
-    it('add recursively', () => {
+    it('add recursively test 1', () => {
       return ipfs('files add -r src/init-files/init-docs').then((out) => {
         expect(out).to.be.eql([
           'added QmYE7xo6NxbHEVEHej1yzxijYaNY51BaeKxjXxn6Ssa6Bs init-docs/tour/0.0-intro',
@@ -87,6 +87,28 @@ describe('files', () => {
           'added QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V init-docs/about',
           'added QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU init-docs'
         ].join('\n'))
+      })
+    })
+
+    it('add recursively test 2', () => {
+      return ipfs('files add -r test').then((out) => {
+        const nLines = out.split('\n').length
+        expect(nLines).to.be.above(10)
+        /*
+        expect(out).to.be.eql([
+          'added QmYE7xo6NxbHEVEHej1yzxijYaNY51BaeKxjXxn6Ssa6Bs init-docs/tour/0.0-intro',
+          'added QmciSU8hfpAXKjvK5YLUSwApomGSWN5gFbP4EpDAEzu2Te init-docs/tour',
+          'added QmTumTjvcYCAvRRwQ8sDRxh8ezmrcr88YFU7iYNroGGTBZ init-docs/security-notes',
+          'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB init-docs/readme',
+          'added QmdncfsVm2h5Kqq9hPmU7oAVX2zTSVP3L869tgTbPYnsha init-docs/quick-start',
+          'added QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7 init-docs/help',
+          'added QmQN88TEidd3RY2u3dpib49fERTDfKtDpvxnvczATNsfKT init-docs/docs/index',
+          'added QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC init-docs/docs',
+          'added QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y init-docs/contact',
+          'added QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V init-docs/about',
+          'added QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU init-docs'
+        ].join('\n'))
+        */
       })
     })
   })


### PR DESCRIPTION
Found today that `jsipfs files add -r <folder>` doesn't always succeed, taking as example folders within js-ipfs repo:

- ✔︎ `jsipfs files add -r src/init-files/init-docs`
- ✔︎ `jsipfs files add -r src/init-files`
- ✔︎ `jsipfs files add -r src`
- 𝙓 `jsipfs files add -r test`

```
» jsipfs files add -r test

assert.js:85
  throw new assert.AssertionError({
  ^
AssertionError: need one root
    at reduceToParents (/Users/ground-control/code/js-ipfs/node_modules/ipfs-unixfs-engine/src/builder/balanced/balanced-reducer.js:20:12)                                                                      at reduced (/Users/ground-control/code/js-ipfs/node_modules/ipfs-unixfs-engine/src/builder/balanced/balanced-reducer.js:44:9)
    at /Users/ground-control/code/js-ipfs/node_modules/pull-stream/sinks/reduce.js:10:5
    at /Users/ground-control/code/js-ipfs/node_modules/pull-stream/sinks/drain.js:20:24
    at /Users/ground-control/code/js-ipfs/node_modules/pull-stream/throughs/async-map.js:24:19
    at pull (/Users/ground-control/code/js-ipfs/node_modules/pull-through/index.js:46:22)
    at next (/Users/ground-control/code/js-ipfs/node_modules/pull-through/node_modules/looper/index.js:7:11)
    at /Users/ground-control/code/js-ipfs/node_modules/pull-through/node_modules/looper/index.js:9:18
    at /Users/ground-control/code/js-ipfs/node_modules/pull-through/index.js:62:13
    at pull (/Users/ground-control/code/js-ipfs/node_modules/pull-through/index.js:46:22)
```

@pgte could you check this? 