### PR TITLE
os.tmpDir has been depricated in favor of os.tmpdir

### DIFF
--- a/examples/basics/index.js
+++ b/examples/basics/index.js
@@ -13,7 +13,7 @@ const IPFS = require('../../src/core')
  * Create a new IPFS instance, using default repo (fs) on default path (~/.ipfs)
  */
 const node = new IPFS({
-  repo: path.join(os.tmpDir() + '/' + new Date().toString()),
+  repo: path.join(os.tmpdir() + '/' + new Date().toString()),
   EXPERIMENTAL: {
     pubsub: false
   }

--- a/test/cli/init.js
+++ b/test/cli/init.js
@@ -15,7 +15,7 @@ describe('init', () => {
   const repoExistsSync = (p) => fs.existsSync(path.join(repoPath, p))
 
   beforeEach(() => {
-    repoPath = os.tmpDir() + '/ipfs-' + Math.random().toString().substring(2, 8)
+    repoPath = os.tmpdir() + '/ipfs-' + Math.random().toString().substring(2, 8)
     ipfs = ipfsExec(repoPath)
   })
 

--- a/test/utils/ipfs-exec.js
+++ b/test/utils/ipfs-exec.js
@@ -35,7 +35,7 @@ module.exports = (repoPath, opts) => {
 
     const cp = exec(args)
     const res = cp.then((res) => {
-      // We can't escape the os.tmpDir warning due to:
+      // We can't escape the os.tmpdir warning due to:
       // https://github.com/shelljs/shelljs/blob/master/src/tempdir.js#L43
       // expect(res.stderr).to.be.eql('')
       return res.stdout

--- a/test/utils/ipfs-factory-daemon/index.js
+++ b/test/utils/ipfs-factory-daemon/index.js
@@ -25,7 +25,7 @@ class Factory {
       config = undefined
     }
 
-    repoPath = repoPath || os.tmpDir() +
+    repoPath = repoPath || os.tmpdir() +
       '/ipfs-' + Math.random().toString().substring(2, 8)
 
     let node

--- a/test/utils/on-and-off.js
+++ b/test/utils/on-and-off.js
@@ -13,7 +13,7 @@ function off (tests) {
     let repoPath
 
     before(() => {
-      repoPath = os.tmpDir() + '/ipfs-' + Math.random().toString().substring(2, 8)
+      repoPath = os.tmpdir() + '/ipfs-' + Math.random().toString().substring(2, 8)
       thing.ipfs = ipfsExec(repoPath)
       thing.ipfs.repoPath = repoPath
       return thing.ipfs('init')


### PR DESCRIPTION
DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

os.tmpdir was added in Node v0.9.9 and os.tmpDir deprecated in Node v7.0.0. More info:

nodejs/node#6739
https://nodejs.org/en/blog/release/v7.0.0/
https://nodejs.org/api/os.html#os_os_tmpdir