### PR TITLE
README: node >= 4.5 is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This project is available through [npm](https://www.npmjs.com/). To install:
 > npm install ipfs --save
 ```
 
-Requires npm@3 and node >= 4, tested on OSX & Linux, expected to work on Windows.
+Requires npm@3 and node >= 4.5, tested on OSX & Linux, expected to work on Windows.
 
 ### Use in Node.js
 


### PR DESCRIPTION
With node 4.4 one gets errors like:

$ jsipfs --help
/usr/local/lib/node_modules/ipfs/node_modules/ethereumjs-util/index.js:31
exports.SHA3_NULL = Buffer.from(exports.SHA3_NULL_S, 'hex')
                           ^

TypeError: hex is not a function
    at Function.from (native)
    at Function.from (native)
    at Object.<anonymous> (/usr/local/lib/node_modules/ipfs/node_modules/ethereumjs-util/index.js:31:28)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/ipfs/node_modules/ethereumjs-block/header.js:1:77)

So it really looks like node >= 4.5 is needed.