### PR TITLE
Multiplex with go

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ncp": "^2.0.0",
     "nexpect": "^0.5.0",
     "pre-commit": "^1.2.2",
+    "pretty-bytes": "^4.0.2",
     "qs": "^6.3.0",
     "rimraf": "^2.5.4",
     "stream-to-promise": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "hoek": "^4.1.0",
     "idb-pull-blob-store": "~0.5.1",
     "ipfs-api": "^12.1.7",
-    "ipfs-bitswap": "~0.9.3",
+    "ipfs-bitswap": "~0.9.4",
     "ipfs-block": "~0.5.5",
     "ipfs-block-service": "~0.8.3",
     "ipfs-multipart": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "pre-commit": "^1.2.2",
     "pretty-bytes": "^4.0.2",
     "qs": "^6.3.0",
+    "random-fs": "^1.0.3",
     "rimraf": "^2.5.4",
     "stream-to-promise": "^2.2.0",
     "transform-loader": "^0.2.3"

--- a/src/core/components/go-online.js
+++ b/src/core/components/go-online.js
@@ -20,8 +20,11 @@ module.exports = (self) => {
         self._peerInfoBook
       )
 
-      self._pubsub = new FloodSub(self._libp2pNode)
+      const pubsub = self._configOpts.EXPERIMENTAL.pubsub
 
+      if (pubsub) {
+        self._pubsub = new FloodSub(self._libp2pNode)
+      }
       series([
         (cb) => {
           self._bitswap.start()
@@ -32,7 +35,7 @@ module.exports = (self) => {
           cb()
         },
         (cb) => {
-          if (self._configOpts.EXPERIMENTAL.pubsub) {
+          if (pubsub) {
             self._pubsub.start(cb)
           } else {
             cb()

--- a/src/core/components/go-online.js
+++ b/src/core/components/go-online.js
@@ -17,7 +17,7 @@ module.exports = (self) => {
       self._bitswap = new Bitswap(
         self._libp2pNode,
         self._repo.blockstore,
-        self._libp2pNode.peerBook
+        self._peerInfoBook
       )
 
       self._pubsub = new FloodSub(self._libp2pNode)

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -19,7 +19,7 @@ module.exports = function libp2p (self) {
           bootstrap: config.Bootstrap
         }
 
-        self._libp2pNode = new Node(self._peerInfo, undefined, options)
+        self._libp2pNode = new Node(self._peerInfo, self._peerInfoBook, options)
 
         self._libp2pNode.start((err) => {
           if (err) {
@@ -31,11 +31,11 @@ module.exports = function libp2p (self) {
           })
 
           self._libp2pNode.discovery.on('peer', (peerInfo) => {
-            self._libp2pNode.peerBook.put(peerInfo)
+            self._peerInfoBook.put(peerInfo)
             self._libp2pNode.dialByPeerInfo(peerInfo, () => {})
           })
           self._libp2pNode.swarm.on('peer-mux-established', (peerInfo) => {
-            self._libp2pNode.peerBook.put(peerInfo)
+            self._peerInfoBook.put(peerInfo)
           })
 
           callback()

--- a/src/core/components/swarm.js
+++ b/src/core/components/swarm.js
@@ -23,7 +23,7 @@ module.exports = function swarm (self) {
       // TODO: return latency and streams when verbose is set
       // we currently don't have this information
 
-      const peers = self._libp2pNode.peerBook.getAll()
+      const peers = self._peerInfoBook.getAll()
       const keys = Object.keys(peers)
 
       const peerList = flatMap(keys, (id) => {
@@ -52,7 +52,7 @@ module.exports = function swarm (self) {
         return callback(OFFLINE_ERROR)
       }
 
-      const peers = values(self._libp2pNode.peerBook.getAll())
+      const peers = values(self._peerInfoBook.getAll())
       callback(null, peers)
     }),
 

--- a/test/interop/daemons/go.js
+++ b/test/interop/daemons/go.js
@@ -3,6 +3,8 @@
 const ctl = require('ipfsd-ctl')
 const waterfall = require('async/waterfall')
 
+const flags = ['--enable-mplex-experiment']
+
 class GoDaemon {
   constructor (opts) {
     opts = opts || {
@@ -37,7 +39,7 @@ class GoDaemon {
         this.node = node
         this.node.setConfig('Bootstrap', '[]', cb)
       },
-      (res, cb) => this.node.startDaemon(cb),
+      (res, cb) => this.node.startDaemon(flags, cb),
       (api, cb) => {
         this.api = api
 

--- a/test/interop/daemons/js.js
+++ b/test/interop/daemons/js.js
@@ -23,7 +23,10 @@ function setPorts (ipfs, port, callback) {
     ),
     (cb) => ipfs.config.set(
       'Addresses.Swarm',
-      ['/ip4/0.0.0.0/tcp/' + (4002 + port)],
+      [
+        '/ip4/0.0.0.0/tcp/' + (4003 + port),
+        '/ip4/0.0.0.0/tcp/' + (4004 + port) + '/ws',
+      ],
       cb
     )
   ], callback)

--- a/test/interop/daemons/js.js
+++ b/test/interop/daemons/js.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const os = require('os')
 const IPFSAPI = require('ipfs-api')
 const series = require('async/series')
 const rimraf = require('rimraf')
@@ -26,7 +25,7 @@ function setPorts (ipfs, port, callback) {
       'Addresses.Swarm',
       [
         '/ip4/0.0.0.0/tcp/' + (4003 + port),
-        '/ip4/0.0.0.0/tcp/' + (4004 + port) + '/ws',
+        '/ip4/0.0.0.0/tcp/' + (4004 + port) + '/ws'
       ],
       cb
     )

--- a/test/interop/daemons/js.js
+++ b/test/interop/daemons/js.js
@@ -5,6 +5,7 @@ const IPFSAPI = require('ipfs-api')
 const series = require('async/series')
 const rimraf = require('rimraf')
 const IPFSRepo = require('ipfs-repo')
+const tmpDir = require('../util').tmpDir
 
 const IPFS = require('../../../src/core')
 const HTTPAPI = require('../../../src/http-api')
@@ -44,7 +45,7 @@ class JsDaemon {
     this.init = opts.init
     this.port = opts.port
 
-    this.path = opts.path || os.tmpdir() + `/${Math.ceil(Math.random() * 10000)}`
+    this.path = opts.path || tmpDir()
     if (this.init) {
       this.ipfs = new IPFS({
         repo: this.path

--- a/test/interop/daemons/js.js
+++ b/test/interop/daemons/js.js
@@ -49,7 +49,10 @@ class JsDaemon {
     } else {
       const repo = new IPFSRepo(this.path, {stores: require('fs-pull-blob-store')})
       this.ipfs = new IPFS({
-        repo: repo
+        repo: repo,
+        EXPERIMENTAL: {
+          pubsub: true
+        }
       })
     }
     this.node = null

--- a/test/interop/index.js
+++ b/test/interop/index.js
@@ -78,7 +78,7 @@ describe('basic', () => {
     ], done)
   })
 
-  it('connect js <-> js', (done) => {
+  it.skip('connect js <-> js', (done) => {
     let jsId
     let js2Id
 
@@ -133,7 +133,7 @@ describe('basic', () => {
       })
     })
 
-    it(`js -> js: ${size}bytes`, (done) => {
+    it.skip(`js -> js: ${size}bytes`, (done) => {
       const data = crypto.randomBytes(size)
       waterfall([
         (cb) => js2Daemon.api.add(data, cb),

--- a/test/interop/index.js
+++ b/test/interop/index.js
@@ -7,6 +7,7 @@ const parallel = require('async/parallel')
 const waterfall = require('async/waterfall')
 const bl = require('bl')
 const crypto = require('crypto')
+const pretty = require('pretty-bytes')
 
 const GoDaemon = require('./daemons/go')
 const JsDaemon = require('./daemons/js')
@@ -106,7 +107,7 @@ describe('basic', () => {
   })
 
   describe('cat file', () => sizes.forEach((size) => {
-    it(`go -> js: ${size}bytes`, (done) => {
+    it(`go -> js: ${pretty(size)}`, (done) => {
       const data = crypto.randomBytes(size)
       waterfall([
         (cb) => goDaemon.api.add(data, cb),
@@ -119,7 +120,7 @@ describe('basic', () => {
       })
     })
 
-    it(`js -> go: ${size}bytes`, (done) => {
+    it(`js -> go: ${pretty(size)}`, (done) => {
       const data = crypto.randomBytes(size)
       waterfall([
         (cb) => jsDaemon.api.add(data, cb),
@@ -132,7 +133,7 @@ describe('basic', () => {
       })
     })
 
-    it(`js -> js: ${size}bytes`, (done) => {
+    it(`js -> js: ${pretty(size)}`, (done) => {
       const data = crypto.randomBytes(size)
       waterfall([
         (cb) => js2Daemon.api.add(data, cb),

--- a/test/interop/index.js
+++ b/test/interop/index.js
@@ -19,7 +19,6 @@ const sizes = [
   1024 * 512,
   1024 * 768,
   1024 * 1023,
-  // starts failing with multiplex
   1024 * 1024,
   1024 * 1024 * 4,
   1024 * 1024 * 8
@@ -78,7 +77,7 @@ describe('basic', () => {
     ], done)
   })
 
-  it.skip('connect js <-> js', (done) => {
+  it('connect js <-> js', (done) => {
     let jsId
     let js2Id
 
@@ -133,7 +132,7 @@ describe('basic', () => {
       })
     })
 
-    it.skip(`js -> js: ${size}bytes`, (done) => {
+    it(`js -> js: ${size}bytes`, (done) => {
       const data = crypto.randomBytes(size)
       waterfall([
         (cb) => js2Daemon.api.add(data, cb),

--- a/test/interop/util.js
+++ b/test/interop/util.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const os = require('os')
+const crypto = require('libp2p-crypto')
+const path = require('path')
+
+exports.tmpDir = (prefix) => {
+  return path.join(
+    os.tmpdir(),
+    prefix || 'tmp',
+    crypto.randomBytes(32).toString('hex')
+  )
+}

--- a/test/node.js
+++ b/test/node.js
@@ -6,19 +6,20 @@ let testCLI = true
 
 if (process.env.TEST) {
   switch (process.env.TEST) {
-    case 'core': {
+    case 'core':
       testHTTP = false
       testCLI = false
-    } break
-    case 'http': {
+      break
+    case 'http':
       testCore = false
       testCLI = false
-    } break
-    case 'cli': {
+      break
+    case 'cli':
       testCore = false
       testHTTP = false
-    } break
-    default: break
+      break
+    default:
+      break
   }
 }
 


### PR DESCRIPTION
## Needed branches:

- go-ipfs: https://github.com/ipfs/go-ipfs/pull/3695 ✅ 
- ~~go-multiplex: https://github.com/whyrusleeping/go-multiplex/pull/4~~
- multiplex: https://github.com/dignifiedquire/multiplex ✅ 
- bitswap: https://github.com/ipfs/js-ipfs-bitswap/pull/113 ✅ 
- libp2p-multiplex: https://github.com/libp2p/js-libp2p-multiplex/pull/59 ✅ 

## Currently working

- [x] all sizes from go -> js
- [x] all sizes from js -> go
- [x] all sizes from js -> js


## Known Issues

- [x] Random identify failures, due to multiplex id reuse
- [x] Random failure to spawn the second js daemon
- [x] go -> js hangs for `1024 * 512`

## Running

```
LIBP2P_MUX_PREFS="/mplex/6.7.0" IPFS_EXEC=`which ipfs` LIBP2P_MUXER=multiplex npm run test:interop:node
```


Will fix https://github.com/ipfs/in-web-browsers/issues/19 once completed



<img width="557" alt="screen shot 2017-02-20 at 16 05 57" src="https://cloud.githubusercontent.com/assets/790842/23130374/7f71f15c-f786-11e6-8efb-d6967872a2a4.png">
