### PR TITLE
Allow IPFS object to be created without supplying configOpts

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -10,7 +10,7 @@ const defaultRepo = require('./default-repo')
 const components = require('./components')
 
 class IPFS {
-  constructor (configOpts) {
+  constructor (configOpts = {}) {
     let repoInstance
     if (typeof configOpts.repo === 'string' || configOpts.repo === undefined) {
       repoInstance = defaultRepo(configOpts.repo)


### PR DESCRIPTION
Allow IPFS object to be created without supplying configOpts to prevent the following code, from the readme, from failing:

```Javascript
const IPFS = require('ipfs')

const node = new IPFS()
```