### PR TITLE
fix: CLI should accept content from stdin #474)

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "peer-book": "~0.3.1",
     "peer-id": "~0.8.2",
     "peer-info": "~0.8.3",
+    "pipe-args": "^1.0.1",
     "promisify-es6": "^1.0.2",
     "pull-file": "^1.0.0",
     "pull-paramap": "^1.2.1",

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+require('pipe-args').load()
 const yargs = require('yargs')
 const updateNotifier = require('update-notifier')
 const readPkgUp = require('read-pkg-up')

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -127,6 +127,23 @@ describe('files', () => runOnAndOff((thing) => {
       })
   })
 
+  it('add with piped argument', () => {
+    // echo 'src/init-files/init-docs/readme' | jsipfs files add
+    return ipfs('files add', { piped: 'src/init-files/init-docs/readme' })
+      .then((out) => {
+        expect(out)
+          .to.eql('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme')
+      })
+  })
+
+  it('add with extra piped argument', () => {
+    return ipfs('files add', { piped: 'src/init-files/init-docs/readme' })
+      .then((out) => {
+        expect(out)
+          .to.eql('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme')
+      })
+  })
+
   it('cat', () => {
     return ipfs('files cat QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
       .then((out) => {

--- a/test/utils/ipfs-exec.js
+++ b/test/utils/ipfs-exec.js
@@ -29,11 +29,24 @@ module.exports = (repoPath, opts) => {
 
   function ipfs () {
     let args = Array.from(arguments)
-    if (args.length === 1) {
+    let pipedArgs
+
+    _.map(args, arg => arg.piped ? (pipedArgs = arg.piped) : '')
+
+    if (args.length === 1 || args.length === 2 && pipedArgs) {
       args = args[0].split(' ')
     }
 
     const cp = exec(args)
+
+    // Passes content of pipedArgs to childProcess as if jsipfs had been called
+    // with piped arguments
+    if (pipedArgs) {
+      cp.stdin.setEncoding('utf-8')
+      cp.stdin.write(`${pipedArgs}\n`)
+      cp.stdin.end()
+    }
+
     const res = cp.then((res) => {
       // We can't escape the os.tmpdir warning due to:
       // https://github.com/shelljs/shelljs/blob/master/src/tempdir.js#L43


### PR DESCRIPTION
Adds support for unix-like piping in js-ipfs.

e.g. `echo "hello" | IPFS_PATH=~/.ipfs-go ipfs add` is handled as expected