### PR TITLE
feat: webrtc by default if supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ const node = new IPFS({
   // start: false,
   EXPERIMENTAL: { // enable experimental features
     pubsub: true,
-    sharding: true // enable dir sharding
+    sharding: true, // enable dir sharding
+    wrtcLinuxWindows: true // use unstable wrtc module on Linux or Windows with Node.js
   },
   config: { // overload the default config
     Addresses: {
@@ -366,6 +367,18 @@ A set of data types are exposed directly from the IPFS instance under `ipfs.type
 - [`ipfs.types.multiaddr`](https://github.com/multiformats/js-multiaddr)
 - [`ipfs.types.multihash`](https://github.com/multiformats/js-multihash)
 - [`ipfs.types.CID`](https://github.com/ipld/js-cid)
+
+## FAQ
+
+> Is there WebRTC support for js-ipfs with Node.js?
+
+Yes there is, however, Linux and Windows support is limited/unstable. For Linux users, you need to follow the install the extra packages for Linux listed on the [`wrtc` npm page](http://npmjs.org/wrtc) and then, when doing initing the repo, do:
+
+```sh
+> IPFS_WRTC_LINUX_WINDOWS=1 jsipfs init
+```
+
+This will create a repo with a config file that contains a WebRTC multiaddr.
 
 ## Packages
 

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -63,6 +63,20 @@ module.exports = function init (self) {
         opts.log('done')
         opts.log('peer identity: ' + config.Identity.PeerID)
 
+        const isWin = /^win/.test(process.platform)
+        const isLinux = /^linux/.test(process.platform)
+        const wrtcLinuxWindows = !process.env.IPFS_WRTC_LINUX_WINDOWS ||
+                                 self._options.EXPERIMENTAL.wrtcLinuxWindows
+
+        // For the lack of sane WebRTC support on Linux and Windows
+        if (wrtcLinuxWindows && (isWin || isLinux)) {
+          console.log('WARNING: Your platform does not have native WebRTC support, it won\' use any WebRTC transport')
+          const newAddrs = config.Addresses.Swarm.filter((addr) => {
+            return addr.indexOf('libp2p-webrtc-star') < 0
+          })
+          config.Addresses.Swarm = newAddrs
+        }
+
         self._repo.init(config, cb)
       },
       (_, cb) => self._repo.open(cb),

--- a/src/init-files/default-config-browser.json
+++ b/src/init-files/default-config-browser.json
@@ -1,8 +1,10 @@
 {
   "Addresses": {
-    "Swarm": [],
-    "API": "/ip4/127.0.0.1/tcp/5002",
-    "Gateway": "/ip4/127.0.0.1/tcp/9090"
+    "Swarm": [
+      "/libp2p-webrtc-star/dns4/star-signal.cloud.ipfs.team/wss"
+    ],
+    "API": "",
+    "Gateway": ""
   },
   "Discovery": {
     "MDNS": {

--- a/src/init-files/default-config-node.json
+++ b/src/init-files/default-config-node.json
@@ -2,7 +2,8 @@
   "Addresses": {
     "Swarm": [
       "/ip4/0.0.0.0/tcp/4002",
-      "/ip4/127.0.0.1/tcp/4003/ws"
+      "/ip4/127.0.0.1/tcp/4003/ws",
+      "/libp2p-webrtc-star/dns4/star-signal.cloud.ipfs.team/wss"
     ],
     "API": "/ip4/127.0.0.1/tcp/5002",
     "Gateway": "/ip4/127.0.0.1/tcp/9090"

--- a/test/core/bitswap.spec.js
+++ b/test/core/bitswap.spec.js
@@ -18,6 +18,7 @@ const multiaddr = require('multiaddr')
 const isNode = require('detect-node')
 const multihashing = require('multihashing-async')
 const CID = require('cids')
+const Buffer = require('safe-buffer').Buffer
 
 // This gets replaced by '../utils/create-repo-browser.js' in the browser
 const createTempRepo = require('../utils/create-repo-node.js')
@@ -25,7 +26,8 @@ const createTempRepo = require('../utils/create-repo-node.js')
 const IPFS = require('../../src/core')
 
 function makeBlock (cb) {
-  const d = new Buffer(`IPFS is awesome ${Math.random()}`)
+  const d = Buffer.from(`IPFS is awesome ${Math.random()}`)
+
   multihashing(d, 'sha2-256', (err, multihash) => {
     if (err) {
       return cb(err)
@@ -59,6 +61,9 @@ describe('bitswap', () => {
       inProcNode = new IPFS({
         repo: repo,
         config: {
+          Addresses: {
+            Swarm: [ '/ip4/127.0.0.1/tcp/0' ]
+          },
           Discovery: {
             MDNS: {
               Enabled: false

--- a/test/core/bootstrap.spec.js
+++ b/test/core/bootstrap.spec.js
@@ -27,6 +27,11 @@ describe('bootstrap', () => {
       },
       EXPERIMENTAL: {
         pubsub: true
+      },
+      config: {
+        Addresses: {
+          Swarm: ['/ip4/127.0.0.1/tcp/0']
+        }
       }
     })
 

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -18,7 +18,12 @@ const createTempRepo = require('../utils/create-repo-node.js')
 describe('create node', () => {
   it('custom repoPath', (done) => {
     const node = new IPFS({
-      repo: '/tmp/ipfs-repo-' + Math.random()
+      repo: '/tmp/ipfs-repo-' + Math.random(),
+      config: {
+        Addresses: {
+          Swarm: []
+        }
+      }
     })
 
     node.once('start', (err) => {
@@ -36,7 +41,12 @@ describe('create node', () => {
 
   it('custom repo', (done) => {
     const node = new IPFS({
-      repo: createTempRepo()
+      repo: createTempRepo(),
+      config: {
+        Addresses: {
+          Swarm: []
+        }
+      }
     })
 
     node.once('start', (err) => {
@@ -53,7 +63,12 @@ describe('create node', () => {
 
   it('IPFS.createNode', (done) => {
     const node = IPFS.createNode({
-      repo: createTempRepo()
+      repo: createTempRepo(),
+      config: {
+        Addresses: {
+          Swarm: []
+        }
+      }
     })
 
     node.once('start', (err) => {
@@ -76,6 +91,11 @@ describe('create node', () => {
       repo: createTempRepo(),
       init: {
         bits: 1024
+      },
+      config: {
+        Addresses: {
+          Swarm: []
+        }
       }
     })
 
@@ -94,7 +114,12 @@ describe('create node', () => {
   it('init: false errors (start default: true)', (done) => {
     const node = new IPFS({
       repo: createTempRepo(),
-      init: false
+      init: false,
+      config: {
+        Addresses: {
+          Swarm: []
+        }
+      }
     })
     node.once('error', (err) => {
       expect(err).to.exist()
@@ -106,7 +131,12 @@ describe('create node', () => {
     const node = new IPFS({
       repo: createTempRepo(),
       init: false,
-      start: false
+      start: false,
+      config: {
+        Addresses: {
+          Swarm: []
+        }
+      }
     })
 
     let happened = false
@@ -131,6 +161,9 @@ describe('create node', () => {
       init: true,
       start: false,
       config: {
+        Addresses: {
+          Swarm: []
+        },
         Bootstrap: []
       }
     })
@@ -148,6 +181,9 @@ describe('create node', () => {
       init: true,
       start: false,
       config: {
+        Addresses: {
+          Swarm: []
+        },
         Bootstrap: []
       }
     })
@@ -192,6 +228,9 @@ describe('create node', () => {
     const node = new IPFS({
       repo: createTempRepo(),
       config: {
+        Addresses: {
+          Swarm: []
+        },
         Bootstrap: []
       }
     })
@@ -208,6 +247,9 @@ describe('create node', () => {
     const options = {
       repo: createTempRepo(),
       config: {
+        Addresses: {
+          Swarm: []
+        },
         Bootstrap: []
       }
     }

--- a/test/core/files-sharding.spec.js
+++ b/test/core/files-sharding.spec.js
@@ -7,6 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const pull = require('pull-stream')
+const Buffer = require('safe-buffer').Buffer
 
 const IPFS = require('../../src/core')
 const createTempRepo = require('../utils/create-repo-node.js')
@@ -16,7 +17,7 @@ describe('files dir', () => {
   for (let i = 0; i < 1005; i++) {
     files.push({
       path: 'test-folder/' + i,
-      content: new Buffer('some content ' + i)
+      content: Buffer.from('some content ' + i)
     })
   }
 
@@ -27,15 +28,16 @@ describe('files dir', () => {
       ipfs = new IPFS({
         repo: createTempRepo(),
         config: {
+          Addresses: {
+            Swarm: []
+          },
           Bootstrap: []
         }
       })
       ipfs.once('start', done)
     })
 
-    after((done) => {
-      ipfs.stop(done)
-    })
+    after((done) => ipfs.stop(done))
 
     it('should be able to add dir without sharding', (done) => {
       pull(
@@ -63,6 +65,9 @@ describe('files dir', () => {
       ipfs = new IPFS({
         repo: createTempRepo(),
         config: {
+          Addresses: {
+            Swarm: []
+          },
           Bootstrap: []
         },
         EXPERIMENTAL: {


### PR DESCRIPTION
I want to add this in, but cope with the scenarios where there is no webrtc-support. The current way does it, but also it makes it annoying to disable webrtc only, you'd have to swap all the multiaddrs at the same time to stop supporting webrtc. Will look into a better way.