### PR TITLE
Loosen up init requirements: accept already initialised repos

### DIFF
--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -47,23 +47,23 @@ module.exports = (self) => {
 
   const tasks = []
 
-  if (doInit) {
-    self.log('boot:doInit')
-    tasks.push((cb) => self.init(initOptions, cb))
+  self._repo.exists((err, repoExists) => {
+    if (err) {
+      return done(err)
+    }
+    if (doInit && !repoExists) {
+      tasks.push((cb) => self.init(initOptions, cb))
+    }
+    if (repoExists) {
+      tasks.push(maybeOpenRepo)
+    }
     next(null, true)
-  } else if (!repoOpen) {
-    self._repo.exists(next)
-  }
+  })
 
   function next (err, hasRepo) {
     self.log('boot:next')
     if (err) {
       return done(err)
-    }
-
-    if (hasRepo && !doInit) {
-      self.log('boot:maybeopenreop')
-      tasks.push(maybeOpenRepo)
     }
 
     if (setConfig) {

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -205,13 +205,18 @@ describe('create node', () => {
   })
 
   it('can start node twice without crash', (done) => {
-    const repo = createTempRepo()
-    let node = new IPFS({repo, config: {Bootstrap: []}})
+    const options = {
+      repo: createTempRepo(),
+      config: {
+        Bootstrap: []
+      }
+    }
+    let node = new IPFS(options)
     series([
       (cb) => node.once('start', cb),
       (cb) => node.stop(cb),
       (cb) => {
-        node = new IPFS({repo, config: {Bootstrap: []}})
+        node = new IPFS(options)
         node.on('error', cb)
         node.once('start', cb)
       },

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -203,4 +203,19 @@ describe('create node', () => {
       (cb) => node.stop(cb)
     ], done)
   })
+
+  it('can start node twice without crash', (done) => {
+    const repo = createTempRepo()
+    let node = new IPFS({repo, config: {Bootstrap: []}})
+    series([
+      (cb) => node.once('start', cb),
+      (cb) => node.stop(cb),
+      (cb) => {
+        node = new IPFS({repo, config: {Bootstrap: []}})
+        node.on('error', cb)
+        node.once('start', cb)
+      },
+      (cb) => node.stop(cb)
+    ], done)
+  })
 })


### PR DESCRIPTION
This PR will make it so if you start a node twice with the same path, it won't crash when trying to initialize a new repo. Synonym with doing `ipfs daemon --init` with go-ipfs in terminal.