### PR TITLE
fix: added backpressure to the add stream

### DIFF
--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -190,7 +190,8 @@ class AddStreamDuplex extends Duplex {
   _read () {
     this._pullStream(null, (end, data) => {
       while (this._waitingPullFlush.length) {
-        this._waitingPullFlush.shift()()
+        const cb = this._waitingPullFlush.shift()
+        cb()
       }
       if (end) {
         if (end instanceof Error) {


### PR DESCRIPTION
`ipfs.createAddStream` stream provided no back-pressure mechanism after [this fix](4b064a166428dfd94a8d3ef1ede6f5c48948e797).
This change now makes this stream wait for a flush before invoking the`.write()` callback.