### PR TITLE
README: Fix new IPFS() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Creating an IPFS instance couldn't be easier, all you have to do is:
 
 ```JavaScript
 // Create the IPFS node instance
-const node = new IPFS()
+const node = new IPFS({})
 
 node.on('start', () => {
   // Your now is ready to use \o/


### PR DESCRIPTION
Current example is not working:

```
$ node
> const IPFS = require('ipfs')
> const node = new IPFS()
TypeError: Cannot read property 'init' of undefined
    at IPFS (/home/magik6k/mess/js-ipfs/node_modules/ipfs/src/core/index.js:31:16)
    at repl:1:14
    at ContextifyScript.Script.runInThisContext (vm.js:23:33)
    at REPLServer.defaultEval (repl.js:340:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.onLine (repl.js:537:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:189:7)
    at REPLServer.Interface._onLine (readline.js:238:10)

```