### PR TITLE
Fixed error message outputs/handling for help commands in CLI

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -17,7 +17,9 @@ const cli = yargs
   .commandDir('commands')
   .demandCommand(1)
   .fail((msg, err, yargs) => {
-    if (err) throw err // preserve stack
+    if (err) {
+      throw err // preserve stack
+    }
     console.error(yargs.help())
     process.exit(1)
   })
@@ -59,7 +61,9 @@ utils.getIPFS((err, ipfs, cleanup) => {
     .parse(args, {
       ipfs: ipfs
     }, (err, argv, output) => {
-      if (output) console.log(output)
+      if (output) {
+        console.log(output)
+      }
       cleanup(() => {
         if (err) {
           throw err

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -20,10 +20,8 @@ const cli = yargs
     if (err) {
       throw err // preserve stack
     }
-    console.error(yargs.help())
-    process.exit(1)
+    yargs.showHelp()
   })
-
 
 // NOTE: This creates an alias of
 // `jsipfs files {add, get, cat}` to `jsipfs {add, get, cat}`.

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -16,6 +16,12 @@ updateNotifier({
 const cli = yargs
   .commandDir('commands')
   .demandCommand(1)
+  .fail((msg, err, yargs) => {
+    if (err) throw err // preserve stack
+    console.error(yargs.help())
+    process.exit(1)
+  })
+
 
 // NOTE: This creates an alias of
 // `jsipfs files {add, get, cat}` to `jsipfs {add, get, cat}`.
@@ -53,6 +59,7 @@ utils.getIPFS((err, ipfs, cleanup) => {
     .parse(args, {
       ipfs: ipfs
     }, (err, argv, output) => {
+      if (output) console.log(output)
       cleanup(() => {
         if (err) {
           throw err


### PR DESCRIPTION
Starting jsipfs without any commands crashes it and gives a slightly unclear error message from yargs.

I changed this to have yargs display the original help message on starting jsipfs with no commands.

Also there is a fix for the --help command messages not being displayed at all.