### PR TITLE
test: add interop to circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,3 +10,8 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get --only-upgrade install google-chrome-stable
     - google-chrome --version
+
+test:
+  override:
+    - npm run test
+    - npm run test:interop

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "ipfs-multipart": "~0.1.0",
     "ipfs-repo": "~0.13.0",
     "ipfs-unixfs": "~0.1.11",
-    "ipfs-unixfs-engine": "~0.19.0",
+    "ipfs-unixfs-engine": "~0.19.1",
     "ipld-resolver": "~0.11.0",
     "isstream": "^0.1.2",
     "joi": "^10.3.1",


### PR DESCRIPTION
I'm adding interop tests to circle, as I've found today that they broke with the latest unixfs-engine changes.

@pgte could you take a look? It seems that the objects that go-ipfs seems might be missing some fields that now js-ipfs expects.