### PR TITLE
fix: wip

### DIFF
--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -19,7 +19,7 @@ module.exports = function libp2p (self) {
           webRTCStar: get(config, 'Discovery.webRTCStar.Enabled'),
           bootstrap: get(config, 'Bootstrap'),
           dht: get(self._options, 'EXPERIMENTAL.dht'),
-          modules: get(self._options, 'libp2p.modules')
+          modules: self._libp2pModules
         }
 
         self._libp2pNode = new Node(self._peerInfo, self._peerInfoBook, options)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -27,6 +27,7 @@ class IPFS extends EventEmitter {
     }
 
     options = options || {}
+    this._libp2pModules = options.libp2p && options.libp2p.modules
 
     extend(this._options, options)
 

--- a/src/http-api/index.js
+++ b/src/http-api/index.js
@@ -32,9 +32,7 @@ function HttpApi (repo, config) {
 
     series([
       (cb) => {
-        const libp2p = {
-          modules: {}
-        }
+        const libp2p = { modules: {} }
 
         // Attempt to use any of the WebRTC versions available globally
         let electronWebRTC
@@ -42,8 +40,8 @@ function HttpApi (repo, config) {
         try { electronWebRTC = require('electron-webrtc')() } catch (err) {}
         try { wrtc = require('wrtc') } catch (err) {}
 
-        if (electronWebRTC || wrtc) {
-          const wstar = new WStar(electronWebRTC || wrtc)
+        if (wrtc || electronWebRTC) {
+          const wstar = new WStar({ wrtc: (wrtc || electronWebRTC) })
           libp2p.modules.transport = [wstar]
           libp2p.modules.discovery = [wstar.discovery]
         }
@@ -59,7 +57,8 @@ function HttpApi (repo, config) {
             EXPERIMENTAL: {
               pubsub: true,
               sharding: config && config.enableShardingExperiment
-            }
+            },
+            libp2p: libp2p
           })
         } catch (err) {
           return cb(err)


### PR DESCRIPTION
I messed up merging #884. Fooled by the fact that Swarm prints any addr that is in Swarm.Addresses as "Listening" that are on the config. It wasn't correctly picking up the WebRTC module.

Now I found (this was a tricky one) that lodash.get messes the WebRTC Star instance. 

