### PR TITLE
Cli block get pipe fix

### DIFF
--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -18,7 +18,6 @@ module.exports = {
       }
 
       process.stdout.write(block.data)
-      process.stdout.write('\n')
     })
   }
 }

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -18,7 +18,7 @@ describe('bitswap', () => runOn((thing) => {
 
   it('wantlist', () => {
     return ipfs('bitswap wantlist').then((out) => {
-      expect(out).to.eql(key)
+      expect(out).to.eql(key + '\n')
     })
   })
 
@@ -33,7 +33,7 @@ describe('bitswap', () => runOn((thing) => {
         `    ${key}`,
         '  partners [0]',
         '    '
-      ].join('\n'))
+      ].join('\n') + '\n')
     })
   })
 }))

--- a/test/cli/block.js
+++ b/test/cli/block.js
@@ -28,6 +28,14 @@ describe('block', () => runOnAndOff((thing) => {
       .then((out) => expect(out).to.eql('hello world\n'))
   })
 
+  it('get block from file without a final newline', () => {
+    return ipfs('block put test/test-data/no-newline').then((out) => {
+      expect(out).to.eql('QmTwbQs4sGcCiPxV97SpbHS7QgmVg9SiKxcG1AcF1Ly2SL\n')
+      return ipfs('block get QmTwbQs4sGcCiPxV97SpbHS7QgmVg9SiKxcG1AcF1Ly2SL')
+    })
+    .then((out) => expect(out).to.eql('there is no newline at end of this file'))
+  })
+
   it('stat', () => {
     return ipfs('block stat QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
       .then((out) => {

--- a/test/cli/block.js
+++ b/test/cli/block.js
@@ -25,7 +25,7 @@ describe('block', () => runOnAndOff((thing) => {
 
   it('get', () => {
     return ipfs('block get QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-      .then((out) => expect(out).to.eql('hello world\n\n'))
+      .then((out) => expect(out).to.eql('hello world\n'))
   })
 
   it('stat', () => {

--- a/test/cli/block.js
+++ b/test/cli/block.js
@@ -13,19 +13,19 @@ describe('block', () => runOnAndOff((thing) => {
 
   it('put', () => {
     return ipfs('block put test/test-data/hello').then((out) => {
-      expect(out).to.eql('QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
+      expect(out).to.eql('QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp\n')
     })
   })
 
   it('put with flags, format and mhtype', () => {
     return ipfs('block put --format eth-block --mhtype keccak-256 test/test-data/eth-block')
       .then((out) =>
-        expect(out).to.eql('z43AaGF23fmvRnDP56Ub9WcJCfzSfqtmzNCCvmz5eudT8dtdCDS'))
+        expect(out).to.eql('z43AaGF23fmvRnDP56Ub9WcJCfzSfqtmzNCCvmz5eudT8dtdCDS\n'))
   })
 
   it('get', () => {
     return ipfs('block get QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
-      .then((out) => expect(out).to.eql('hello world\n'))
+      .then((out) => expect(out).to.eql('hello world\n\n'))
   })
 
   it('stat', () => {
@@ -34,7 +34,7 @@ describe('block', () => runOnAndOff((thing) => {
         expect(out).to.eql([
           'Key: QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp',
           'Size: 12'
-        ].join('\n'))
+        ].join('\n') + '\n')
       })
   })
 
@@ -42,7 +42,7 @@ describe('block', () => runOnAndOff((thing) => {
     return ipfs('block rm QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp')
       .then((out) => {
         expect(out).to.eql(
-          'removed QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp'
+          'removed QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp\n'
         )
       })
   })

--- a/test/cli/bootstrap.js
+++ b/test/cli/bootstrap.js
@@ -39,31 +39,31 @@ describe('bootstrap', () => runOnAndOff((thing) => {
 
   it('add default', () => {
     return ipfs('bootstrap add --default').then((out) => {
-      expect(out).to.be.eql(defaultList.join('\n'))
+      expect(out).to.be.eql(defaultList.join('\n') + '\n')
     })
   })
 
   it('list the bootstrap nodes', () => {
     return ipfs('bootstrap list').then((out) => {
-      expect(out).to.eql(defaultList.join('\n'))
+      expect(out).to.eql(defaultList.join('\n') + '\n')
     })
   })
 
   it('add another bootstrap node', () => {
     return ipfs('bootstrap add /ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD').then((out) => {
-      expect(out).to.be.eql('/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD')
+      expect(out).to.be.eql('/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD\n')
       return ipfs('bootstrap list')
     }).then((out) => {
-      expect(out).to.be.eql(updatedList.join('\n'))
+      expect(out).to.be.eql(updatedList.join('\n') + '\n')
     })
   })
 
   it('rm a bootstrap node', () => {
     return ipfs('bootstrap rm /ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD').then((out) => {
-      expect(out).to.be.eql('/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD')
+      expect(out).to.be.eql('/ip4/111.111.111.111/tcp/1001/ipfs/QmcyFFKfLDGJKwufn2GeitxvhricsBQyNKTkrD14psikoD\n')
       return ipfs('bootstrap list')
     }).then((out) => {
-      expect(out).to.deep.equal(defaultList.join('\n'))
+      expect(out).to.deep.equal(defaultList.join('\n') + '\n')
     })
   })
 

--- a/test/cli/commands.js
+++ b/test/cli/commands.js
@@ -15,7 +15,7 @@ describe('commands', () => runOnAndOff((thing) => {
 
   it('list the commands', () => {
     return ipfs('commands').then((out) => {
-      expect(out.split('\n')).to.have.length(commandCount)
+      expect(out.split('\n')).to.have.length(commandCount + 1)
     })
   })
 }))

--- a/test/cli/dag.js
+++ b/test/cli/dag.js
@@ -14,12 +14,12 @@ describe('dag', () => runOnAndOff.off((thing) => {
   it('get', () => {
     // put test eth-block
     return ipfs('block put --format eth-block --mhtype keccak-256 test/test-data/eth-block').then((out) => {
-      expect(out).to.eql('z43AaGF23fmvRnDP56Ub9WcJCfzSfqtmzNCCvmz5eudT8dtdCDS')
+      expect(out).to.eql('z43AaGF23fmvRnDP56Ub9WcJCfzSfqtmzNCCvmz5eudT8dtdCDS\n')
       // lookup path on eth-block
       return ipfs('dag get z43AaGF23fmvRnDP56Ub9WcJCfzSfqtmzNCCvmz5eudT8dtdCDS/parentHash')
     }).then((out) => {
       let expectHash = new Buffer('c8c0a17305adea9bbb4b98a52d44f0c1478f5c48fc4b64739ee805242501b256', 'hex')
-      expect(out).to.be.eql('0x' + expectHash.toString('hex'))
+      expect(out).to.be.eql('0x' + expectHash.toString('hex') + '\n')
     })
   })
 }))

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -11,7 +11,7 @@ const runOnAndOff = require('../utils/on-and-off')
 describe('files', () => runOnAndOff((thing) => {
   let ipfs
   const readme = fs.readFileSync(path.join(process.cwd(), '/src/init-files/init-docs/readme'))
-                   .toString('utf-8').slice(0, -1)
+                   .toString('utf-8')
 
   before(() => {
     ipfs = thing.ipfs
@@ -21,7 +21,7 @@ describe('files', () => runOnAndOff((thing) => {
     return ipfs('files add src/init-files/init-docs/readme')
       .then((out) => {
         expect(out)
-          .to.eql('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme')
+          .to.eql('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme\n')
       })
   })
 
@@ -29,7 +29,7 @@ describe('files', () => runOnAndOff((thing) => {
     return ipfs('add src/init-files/init-docs/readme')
       .then((out) => {
         expect(out)
-          .to.eql('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme')
+          .to.eql('added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme\n')
       })
   })
 
@@ -123,7 +123,7 @@ describe('files', () => runOnAndOff((thing) => {
           'added QmYwUkwNwJN2cevwXKL48DRpbbjbdLWyyLANG3BKTtsTZ8 recursive-get-dir/blocks/CIQBE',
           'added QmQQHYDwAQms78fPcvx1uFFsfho23YJNoewfLbi9AtdyJ9 recursive-get-dir/blocks',
           'added QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2 recursive-get-dir'
-        ].join('\n'))
+        ].join('\n') + '\n')
       })
   })
 
@@ -132,7 +132,7 @@ describe('files', () => runOnAndOff((thing) => {
       expect(out).to.be.eql([
         'added QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB readme',
         'added QmapdaVPjHXdcswef82FnGQUauMNpk9xYFkLDZKgAxhMwq'
-      ].join('\n'))
+      ].join('\n') + '\n')
     })
   })
 
@@ -154,11 +154,11 @@ describe('files', () => runOnAndOff((thing) => {
     return ipfs('files get QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
       .then((out) => {
         expect(out)
-          .to.eql('Saving file(s) QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
+          .to.eql('Saving file(s) QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB\n')
 
         const file = path.join(process.cwd(), 'QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
 
-        expect(fs.readFileSync(file).toString().slice(0, -1)).to.eql(readme)
+        expect(fs.readFileSync(file).toString()).to.eql(readme)
 
         rimraf(file)
       })
@@ -168,11 +168,11 @@ describe('files', () => runOnAndOff((thing) => {
     return ipfs('get QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
       .then((out) => {
         expect(out)
-          .to.eql('Saving file(s) QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
+          .to.eql('Saving file(s) QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB\n')
 
         const file = path.join(process.cwd(), 'QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
 
-        expect(fs.readFileSync(file).toString().slice(0, -1)).to.eql(readme)
+        expect(fs.readFileSync(file).toString()).to.eql(readme)
 
         rimraf(file)
       })
@@ -185,7 +185,7 @@ describe('files', () => runOnAndOff((thing) => {
     return ipfs('files get QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2')
       .then((out) => {
         expect(out).to.eql(
-          'Saving file(s) QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2'
+          'Saving file(s) QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2\n'
         )
 
         const outDir = path.join(process.cwd(), 'QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2')

--- a/test/cli/object.js
+++ b/test/cli/object.js
@@ -15,7 +15,7 @@ describe('object', () => runOnAndOff((thing) => {
   it('new', () => {
     return ipfs('object new').then((out) => {
       expect(out).to.eql(
-        'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+        'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n\n'
       )
     })
   })
@@ -23,7 +23,7 @@ describe('object', () => runOnAndOff((thing) => {
   it('new unixfs-dir', () => {
     return ipfs('object new unixfs-dir').then((out) => {
       expect(out).to.eql(
-        'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'
+        'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn\n'
       )
     })
   })
@@ -39,7 +39,7 @@ describe('object', () => runOnAndOff((thing) => {
   it('put', () => {
     return ipfs('object put test/test-data/node.json').then((out) => {
       expect(out).to.eql(
-        'added QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm'
+        'added QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm\n'
       )
     })
   })
@@ -52,20 +52,20 @@ describe('object', () => runOnAndOff((thing) => {
         'LinksSize: 53',
         'DataSize: 7',
         'CumulativeSize: 68'
-      ].join('\n'))
+      ].join('\n') + '\n')
     })
   })
 
   it('data', () => {
     return ipfs('object data QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm').then((out) => {
-      expect(out).to.eql('another')
+      expect(out).to.eql('another\n')
     })
   })
 
   it('links', () => {
     return ipfs('object links QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm').then((out) => {
       expect(out).to.eql(
-        'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V 8 some link'
+        'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V 8 some link\n'
       )
     })
   })
@@ -74,7 +74,7 @@ describe('object', () => runOnAndOff((thing) => {
     it('append-data', () => {
       return ipfs('object patch append-data QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n test/test-data/badconfig').then((out) => {
         expect(out).to.eql(
-          'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6'
+          'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6\n'
         )
       })
     })
@@ -82,7 +82,7 @@ describe('object', () => runOnAndOff((thing) => {
     it('set-data', () => {
       return ipfs('object patch set-data QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6 test/test-data/badconfig').then((out) => {
         expect(out).to.eql(
-          'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6'
+          'QmfY37rjbPCZRnhvvJuQ46htW3VCAWziVB991P79h6WSv6\n'
         )
       })
     })
@@ -90,7 +90,7 @@ describe('object', () => runOnAndOff((thing) => {
     it('add-link', () => {
       return ipfs('object patch add-link QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n foo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn').then((out) => {
         expect(out).to.eql(
-          'QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK'
+          'QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK\n'
         )
       })
     })
@@ -98,7 +98,7 @@ describe('object', () => runOnAndOff((thing) => {
     it('rm-link', () => {
       return ipfs('object patch rm-link QmdVHE8fUD6FLNLugtNxqDFyhaCgdob372hs6BYEe75VAK foo').then((out) => {
         expect(out).to.eql(
-          'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+          'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n\n'
         )
       })
     })

--- a/test/cli/swarm.js
+++ b/test/cli/swarm.js
@@ -49,32 +49,32 @@ describe('swarm', () => {
   describe('daemon on (through http-api)', () => {
     it('connect', () => {
       return ipfsA('swarm', 'connect', bMultiaddr).then((out) => {
-        expect(out).to.eql(`connect ${bMultiaddr} success`)
+        expect(out).to.eql(`connect ${bMultiaddr} success\n`)
       })
     })
 
     it('peers', () => {
       return ipfsA('swarm peers').then((out) => {
-        expect(out).to.be.eql(bMultiaddr)
+        expect(out).to.be.eql(bMultiaddr + '\n')
       })
     })
 
     it('addrs', () => {
       return ipfsA('swarm addrs').then((out) => {
-        expect(out).to.have.length.above(0)
+        expect(out).to.have.length.above(1)
       })
     })
 
     it('addrs local', () => {
       return ipfsA('swarm addrs local').then((out) => {
-        expect(out).to.have.length.above(0)
+        expect(out).to.have.length.above(1)
       })
     })
 
     it('disconnect', () => {
       return ipfsA('swarm', 'disconnect', bMultiaddr).then((out) => {
         expect(out).to.eql(
-          `disconnect ${bMultiaddr} success`
+          `disconnect ${bMultiaddr} success\n`
         )
       })
     })

--- a/test/cli/version.js
+++ b/test/cli/version.js
@@ -15,7 +15,7 @@ describe('version', () => runOnAndOff((thing) => {
   it('get the version', () => {
     return ipfs('version').then((out) => {
       expect(out).to.be.eql(
-        `js-ipfs version: ${pkgversion}`
+        `js-ipfs version: ${pkgversion}\n`
       )
     })
   })

--- a/test/test-data/no-newline
+++ b/test/test-data/no-newline
@@ -1,0 +1,1 @@
+there is no newline at end of this file

--- a/test/utils/ipfs-exec.js
+++ b/test/utils/ipfs-exec.js
@@ -24,7 +24,7 @@ module.exports = (repoPath, opts) => {
   env.IPFS_PATH = repoPath
 
   const config = Object.assign({}, {
-    stripEof: true,
+    stripEof: false,
     env: env,
     timeout: 60 * 1000
   }, opts)


### PR DESCRIPTION
- disables execas's newline trimming for explicit newline testing
- changes the cli `block.get` to not append an additional newline
- adds an additional test for a block without a final newline