### PR TITLE
Fix js-ipfs daemon config params

### DIFF
--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -25,7 +25,7 @@ module.exports = {
     console.log('Initializing daemon...')
 
     const repoPath = utils.getRepoPath()
-    httpAPI = new HttpAPI(process.env.IPFS_PATH, argv)
+    httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
 
     httpAPI.start((err) => {
       if (err && err.code === 'ENOENT' && err.message.match(/Uninitalized repo/i)) {

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -16,7 +16,7 @@ module.exports = {
       default: false
     },
     'enable-pubsub-experiment': {
-      type: 'booleam',
+      type: 'boolean',
       default: false
     }
   },

--- a/src/http-api/index.js
+++ b/src/http-api/index.js
@@ -53,9 +53,8 @@ function HttpApi (repo, config) {
             repo: repo,
             init: init,
             start: true,
-            config: config,
             EXPERIMENTAL: {
-              pubsub: true,
+              pubsub: config && config.enablePubsubExperiment,
               sharding: config && config.enableShardingExperiment
             },
             libp2p: libp2p

--- a/src/http-api/index.js
+++ b/src/http-api/index.js
@@ -16,7 +16,7 @@ function uriToMultiaddr (uri) {
   return `/ip4/${ipPort[0]}/tcp/${ipPort[1]}`
 }
 
-function HttpApi (repo, config) {
+function HttpApi (repo, config, cliArgs) {
   this.node = undefined
   this.server = undefined
 
@@ -53,9 +53,10 @@ function HttpApi (repo, config) {
             repo: repo,
             init: init,
             start: true,
+            config: config,
             EXPERIMENTAL: {
-              pubsub: config && config.enablePubsubExperiment,
-              sharding: config && config.enableShardingExperiment
+              pubsub: cliArgs && cliArgs.enablePubsubExperiment,
+              sharding: cliArgs && cliArgs.enableShardingExperiment
             },
             libp2p: libp2p
           })


### PR DESCRIPTION
  - Respect `--enable-experimental-pubsub`
  - Don't overload repo config with cli args (fixes #868)
  - Typo

---

I was unable to run tests, linting or anything. Did not work on node 8.1.2 or 6.11.1