### PR TITLE
Fix linter errors

### DIFF
--- a/examples/dag/get-path-accross-formats.js
+++ b/examples/dag/get-path-accross-formats.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const createNode = require('./create-node.js')
 const series = require('async/series')
 const dagPB = require('ipld-dag-pb')

--- a/examples/dag/tree.js
+++ b/examples/dag/tree.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const createNode = require('./create-node.js')
 const series = require('async/series')
 const dagPB = require('ipld-dag-pb')

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const CID = require('cids')
 
 module.exports = {

--- a/src/cli/commands/config/edit.js
+++ b/src/cli/commands/config/edit.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const spawn = require('child_process').spawn
 const fs = require('fs')
 const temp = require('temp')

--- a/src/cli/commands/pubsub/pub.js
+++ b/src/cli/commands/pubsub/pub.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
+
 module.exports = {
   command: 'pub <topic> <data>',
 

--- a/src/core/components/object.js
+++ b/src/core/components/object.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const waterfall = require('async/waterfall')
 const promisify = require('promisify-es6')
 const dagPB = require('ipld-dag-pb')

--- a/src/http-api/resources/object.js
+++ b/src/http-api/resources/object.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const mh = require('multihashes')
 const multipart = require('ipfs-multipart')
 const dagPB = require('ipld-dag-pb')

--- a/src/http-api/resources/pubsub.js
+++ b/src/http-api/resources/pubsub.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const PassThrough = require('stream').PassThrough
 
 exports = module.exports

--- a/test/cli/dag.js
+++ b/test/cli/dag.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const expect = require('chai').expect
 const runOnAndOff = require('../utils/on-and-off')
 

--- a/test/core/init.spec.js
+++ b/test/core/init.spec.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect

--- a/test/http-api/over-ipfs-api/block.js
+++ b/test/http-api/over-ipfs-api/block.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect

--- a/test/http-api/over-ipfs-api/object.js
+++ b/test/http-api/over-ipfs-api/object.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect

--- a/test/http-api/spec/files.js
+++ b/test/http-api/spec/files.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const expect = require('chai').expect
 
 module.exports = (http) => {

--- a/test/http-api/spec/object.js
+++ b/test/http-api/spec/object.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect

--- a/test/http-api/spec/pubsub.js
+++ b/test/http-api/spec/pubsub.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect


### PR DESCRIPTION
- Use `safe-buffer` everywhere

I previously had issues with running `npm run lint`, which required me to additional eslint plugins. I can no longer reproduce that anymore. Strange..

e: Whoops, I happened to be using eslint-config-standard v10 instead of 7.. Version 7 does not yet check use of `new Buffer()`.. So this pr wont be relevant until aegir@next which will use a later version