### PR TITLE
Refactor printing in CLI

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -15,6 +15,18 @@ updateNotifier({
 }).notify()
 
 const cli = yargs
+  .option('q', {
+    alias: 'quiet',
+    desc: 'suppress output',
+    type: 'boolean',
+    coerce: (quiet) => { if (quiet) { utils.printLevel = 0 } }
+  })
+  .option('v', {
+    alias: 'verbose',
+    desc: 'verbose mode, multiple -v increases verbosity',
+    count: true,
+    coerce: (verbosity) => { utils.printLevel = verbosity + 1 }
+  })
   .commandDir('commands')
   .demandCommand(1)
   .fail((msg, err, yargs) => {

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -19,13 +19,7 @@ const cli = yargs
     alias: 'quiet',
     desc: 'suppress output',
     type: 'boolean',
-    coerce: (quiet) => { if (quiet) { utils.printLevel = 0 } }
-  })
-  .option('v', {
-    alias: 'verbose',
-    desc: 'verbose mode, multiple -v increases verbosity',
-    count: true,
-    coerce: (verbosity) => { utils.printLevel = verbosity + 1 }
+    coerce: (quiet) => { if (quiet) { utils.disablePrinting() } }
   })
   .commandDir('commands')
   .demandCommand(1)

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -6,6 +6,7 @@ const yargs = require('yargs')
 const updateNotifier = require('update-notifier')
 const readPkgUp = require('read-pkg-up')
 const utils = require('./utils')
+const print = utils.print
 
 const pkg = readPkgUp.sync({cwd: __dirname}).pkg
 updateNotifier({
@@ -53,7 +54,7 @@ if (args[0] === 'daemon' || args[0] === 'init') {
       .strict(false)
       .completion()
       .parse(args, { ipfs: ipfs }, (err, argv, output) => {
-        if (output) { console.log(output) }
+        if (output) { print(output) }
 
         cleanup(() => {
           if (err) { throw err }

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CID = require('cids')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'stat',
@@ -23,7 +24,7 @@ module.exports = {
       })
       stats.Peers = stats.Peers || []
 
-      console.log(`bitswap status
+      print(`bitswap status
   blocks received: ${stats.BlocksReceived}
   dup blocks received: ${stats.DupBlksReceived}
   dup data received: ${stats.DupDataReceived}B

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'wantlist',
 
@@ -20,7 +22,7 @@ module.exports = {
         throw err
       }
       res.Keys.forEach((cidStr) => {
-        console.log(cidStr)
+        print(cidStr)
       })
     })
   }

--- a/src/cli/commands/block/put.js
+++ b/src/cli/commands/block/put.js
@@ -6,6 +6,7 @@ const bl = require('bl')
 const fs = require('fs')
 const Block = require('ipfs-block')
 const waterfall = require('async/waterfall')
+const print = require('../../utils').print
 
 function addBlock (data, opts) {
   const ipfs = opts.ipfs
@@ -26,7 +27,7 @@ function addBlock (data, opts) {
     if (err) {
       throw err
     }
-    console.log(cid.toBaseEncodedString())
+    print(cid.toBaseEncodedString())
   })
 }
 

--- a/src/cli/commands/block/rm.js
+++ b/src/cli/commands/block/rm.js
@@ -2,6 +2,7 @@
 
 const utils = require('../../utils')
 const mh = require('multihashes')
+const print = utils.print
 
 module.exports = {
   command: 'rm <key>',
@@ -21,7 +22,7 @@ module.exports = {
         throw err
       }
 
-      console.log('removed', argv.key)
+      print('removed ' + argv.key)
     })
   }
 }

--- a/src/cli/commands/block/stat.js
+++ b/src/cli/commands/block/stat.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CID = require('cids')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'stat <key>',
@@ -15,8 +16,8 @@ module.exports = {
         throw err
       }
 
-      console.log('Key:', stats.key)
-      console.log('Size:', stats.size)
+      print('Key: ' + stats.key)
+      print('Size: ' + stats.size)
     })
   }
 }

--- a/src/cli/commands/bootstrap/add.js
+++ b/src/cli/commands/bootstrap/add.js
@@ -23,7 +23,7 @@ module.exports = {
         throw err
       }
 
-      list.Peers.forEach(peer => print(peer))
+      list.Peers.forEach((peer) => print(peer))
     })
   }
 }

--- a/src/cli/commands/bootstrap/add.js
+++ b/src/cli/commands/bootstrap/add.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'add [<peer>]',
 
@@ -21,7 +23,7 @@ module.exports = {
         throw err
       }
 
-      list.Peers.forEach((l) => console.log(l))
+      list.Peers.forEach(peer => print(peer))
     })
   }
 }

--- a/src/cli/commands/bootstrap/list.js
+++ b/src/cli/commands/bootstrap/list.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'list',
 
@@ -13,9 +15,7 @@ module.exports = {
         throw err
       }
 
-      list.Peers.forEach((node) => {
-        console.log(node)
-      })
+      list.Peers.forEach(node => print(node))
     })
   }
 }

--- a/src/cli/commands/bootstrap/list.js
+++ b/src/cli/commands/bootstrap/list.js
@@ -15,7 +15,7 @@ module.exports = {
         throw err
       }
 
-      list.Peers.forEach(node => print(node))
+      list.Peers.forEach((node) => print(node))
     })
   }
 }

--- a/src/cli/commands/bootstrap/rm.js
+++ b/src/cli/commands/bootstrap/rm.js
@@ -26,7 +26,7 @@ module.exports = {
         throw err
       }
 
-      list.Peers.forEach(peer => print(peer))
+      list.Peers.forEach((peer) => print(peer))
     })
   }
 }

--- a/src/cli/commands/bootstrap/rm.js
+++ b/src/cli/commands/bootstrap/rm.js
@@ -3,6 +3,8 @@
 const debug = require('debug')
 const log = debug('cli:bootstrap')
 log.error = debug('cli:bootstrap:error')
+const print = require('../../utils').print
+
 module.exports = {
   command: 'rm [<peer>]',
 
@@ -24,7 +26,7 @@ module.exports = {
         throw err
       }
 
-      list.Peers.forEach((l) => console.log(l))
+      list.Peers.forEach(peer => print(peer))
     })
   }
 }

--- a/src/cli/commands/commands.js
+++ b/src/cli/commands/commands.js
@@ -1,5 +1,5 @@
 'use strict'
-
+const print = require('../utils').print
 const path = require('path')
 const glob = require('glob').sync
 
@@ -23,6 +23,6 @@ module.exports = {
         .replace('.js', '')
     }).sort().map((cmd) => `ipfs ${cmd}`)
 
-    console.log(['ipfs'].concat(cmds).join('\n'))
+    print(['ipfs'].concat(cmds).join('\n'))
   }
 }

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -1,4 +1,5 @@
 'use strict'
+const print = require('../utils').print
 
 module.exports = {
   command: 'config <key> [value]',
@@ -41,9 +42,9 @@ module.exports = {
         }
 
         if (typeof value === 'object') {
-          console.log(JSON.stringify(value, null, 2))
+          print(JSON.stringify(value, null, 2))
         } else {
-          console.log(value)
+          print(value)
         }
       })
     } else {

--- a/src/cli/commands/config/show.js
+++ b/src/cli/commands/config/show.js
@@ -3,6 +3,8 @@
 const debug = require('debug')
 const log = debug('cli:config')
 log.error = debug('cli:config:error')
+const print = require('../../utils').print
+
 module.exports = {
   command: 'show',
 
@@ -19,7 +21,7 @@ module.exports = {
         throw err
       }
 
-      console.log(JSON.stringify(config, null, 4))
+      print(JSON.stringify(config, null, 4))
     })
   }
 }

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -2,6 +2,7 @@
 
 const HttpAPI = require('../../http-api')
 const utils = require('../utils')
+const print = utils.print
 
 let httpAPI
 
@@ -22,25 +23,25 @@ module.exports = {
   },
 
   handler (argv) {
-    console.log('Initializing daemon...')
+    print('Initializing daemon...')
 
     const repoPath = utils.getRepoPath()
     httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
 
     httpAPI.start((err) => {
       if (err && err.code === 'ENOENT' && err.message.match(/Uninitalized repo/i)) {
-        console.log('Error: no initialized ipfs repo found in ' + repoPath)
-        console.log('please run: jsipfs init')
+        print('Error: no initialized ipfs repo found in ' + repoPath)
+        print('please run: jsipfs init')
         process.exit(1)
       }
       if (err) {
         throw err
       }
-      console.log('Daemon is ready')
+      print('Daemon is ready')
     })
 
     process.on('SIGINT', () => {
-      console.log('Received interrupt signal, shutting down..')
+      print('Received interrupt signal, shutting down..')
       httpAPI.stop((err) => {
         if (err) {
           throw err

--- a/src/cli/commands/dag/get.js
+++ b/src/cli/commands/dag/get.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CID = require('cids')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'get <cid path>',
@@ -26,12 +27,12 @@ module.exports = {
 
     argv.ipfs.dag.get(cid, path, options, (err, result) => {
       if (err) {
-        return console.log('dag get failed:', err.message)
+        return print(`dag get failed: ${err.message}`)
       }
 
       if (options.localResolve) {
-        console.log('resolving path within the node only')
-        console.log('remainder path:', result.remainderPath || 'n/a', '\n')
+        print('resolving path within the node only')
+        print(`remainder path: ${result.remainderPath || 'n/a'}\n`)
       }
 
       const node = result.value
@@ -41,19 +42,19 @@ module.exports = {
       if (node._json) {
         delete node._json.multihash
         node._json.data = '0x' + node._json.data.toString('hex')
-        console.log(node._json)
+        print(node._json)
         return
       }
 
       if (Buffer.isBuffer(node)) {
-        console.log('0x' + node.toString('hex'))
+        print('0x' + node.toString('hex'))
         return
       }
 
       if (node.raw) {
-        console.log(node.raw)
+        print(node.raw)
       } else {
-        console.log(node)
+        print(node)
       }
     })
   }

--- a/src/cli/commands/files/add.js
+++ b/src/cli/commands/files/add.js
@@ -9,6 +9,7 @@ const paramap = require('pull-paramap')
 const zip = require('pull-zip')
 const toPull = require('stream-to-pull-stream')
 const utils = require('../../utils')
+const print = require('../../utils').print
 
 const WRAPPER = 'wrapper/'
 
@@ -77,7 +78,7 @@ function addPipeline (index, addStream, list, wrapWithDirectory) {
 
           return log.join(' ')
         })
-        .forEach((msg) => console.log(msg))
+        .forEach((msg) => print(msg))
     })
   )
 }

--- a/src/cli/commands/files/get.js
+++ b/src/cli/commands/files/get.js
@@ -5,6 +5,7 @@ const path = require('path')
 const mkdirp = require('mkdirp')
 const pull = require('pull-stream')
 const toPull = require('stream-to-pull-stream')
+const print = require('../../utils').print
 
 function checkArgs (hash, outPath) {
   // format the output directory
@@ -68,7 +69,7 @@ module.exports = {
       if (err) {
         throw err
       }
-      console.log(`Saving file(s) ${ipfsPath}`)
+      print(`Saving file(s) ${ipfsPath}`)
       pull(
         toPull.source(stream),
         pull.asyncMap(fileHandler(dir)),

--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -1,4 +1,5 @@
 'use strict'
+const print = require('../utils').print
 
 module.exports = {
   command: 'id',
@@ -19,7 +20,7 @@ module.exports = {
         throw err
       }
 
-      console.log(JSON.stringify(id, '', 2))
+      print(JSON.stringify(id, '', 2))
     })
   }
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -3,6 +3,7 @@
 const Repo = require('ipfs-repo')
 const IPFS = require('../../core')
 const utils = require('../utils')
+const print = utils.print
 
 module.exports = {
   command: 'init',
@@ -26,8 +27,7 @@ module.exports = {
   handler (argv) {
     const path = utils.getRepoPath()
 
-    const log = utils.createLogger(true)
-    log(`initializing ipfs node at ${path}`)
+    print(`initializing ipfs node at ${path}`)
 
     const node = new IPFS({
       repo: new Repo(path),
@@ -38,7 +38,7 @@ module.exports = {
     node.init({
       bits: argv.bits,
       emptyRepo: argv.emptyRepo,
-      log: log
+      log: print
     }, (err) => {
       if (err) {
         if (err.code === 'EACCES') {

--- a/src/cli/commands/object/data.js
+++ b/src/cli/commands/object/data.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'data <key>',
 
@@ -15,7 +17,7 @@ module.exports = {
         throw err
       }
 
-      console.log(data.toString())
+      print(data.toString())
     })
   }
 }

--- a/src/cli/commands/object/get.js
+++ b/src/cli/commands/object/get.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'get <key>',
 
@@ -29,7 +31,7 @@ module.exports = {
         })
       }
 
-      console.log(JSON.stringify(answer))
+      print(JSON.stringify(answer))
     })
   }
 }

--- a/src/cli/commands/object/links.js
+++ b/src/cli/commands/object/links.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'links <key>',
 
@@ -18,11 +20,7 @@ module.exports = {
       links.forEach((link) => {
         link = link.toJSON()
 
-        console.log(
-          link.multihash,
-          link.size,
-          link.name
-        )
+        print(`${link.multihash} ${link.size} ${link.name}`)
       })
     })
   }

--- a/src/cli/commands/object/new.js
+++ b/src/cli/commands/object/new.js
@@ -3,6 +3,7 @@
 const debug = require('debug')
 const log = debug('cli:object')
 log.error = debug('cli:object:error')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'new [<template>]',
@@ -19,7 +20,7 @@ module.exports = {
 
       const nodeJSON = node.toJSON()
 
-      console.log(nodeJSON.multihash)
+      print(nodeJSON.multihash)
     })
   }
 }

--- a/src/cli/commands/object/patch/add-link.js
+++ b/src/cli/commands/object/patch/add-link.js
@@ -2,6 +2,7 @@
 
 const dagPB = require('ipld-dag-pb')
 const DAGLink = dagPB.DAGLink
+const print = require('../../../utils').print
 
 module.exports = {
   command: 'add-link <root> <name> <ref>',
@@ -28,7 +29,7 @@ module.exports = {
           throw err
         }
 
-        console.log(nodeB.toJSON().multihash)
+        print(nodeB.toJSON().multihash)
       })
     })
   }

--- a/src/cli/commands/object/patch/append-data.js
+++ b/src/cli/commands/object/patch/append-data.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const debug = require('debug')
 const log = debug('cli:object')
 log.error = debug('cli:object:error')
+const print = require('../../../utils').print
 
 function appendData (key, data, ipfs) {
   ipfs.object.patch.appendData(key, data, {
@@ -15,7 +16,7 @@ function appendData (key, data, ipfs) {
     }
     const nodeJSON = node.toJSON()
 
-    console.log(nodeJSON.multihash)
+    print(nodeJSON.multihash)
   })
 }
 

--- a/src/cli/commands/object/patch/rm-link.js
+++ b/src/cli/commands/object/patch/rm-link.js
@@ -4,6 +4,7 @@ const DAGLink = require('ipld-dag-pb').DAGLink
 const debug = require('debug')
 const log = debug('cli:object')
 log.error = debug('cli:object:error')
+const print = require('../../../utils').print
 
 module.exports = {
   command: 'rm-link <root> <link>',
@@ -27,7 +28,7 @@ module.exports = {
 
       const nodeJSON = node.toJSON()
 
-      console.log(nodeJSON.multihash)
+      print(nodeJSON.multihash)
     })
   }
 }

--- a/src/cli/commands/object/patch/set-data.js
+++ b/src/cli/commands/object/patch/set-data.js
@@ -5,6 +5,7 @@ const bl = require('bl')
 const debug = require('debug')
 const log = debug('cli:object')
 log.error = debug('cli:object:error')
+const print = require('../../../utils').print
 
 function parseAndAddNode (key, data, ipfs) {
   ipfs.object.patch.setData(key, data, {
@@ -15,7 +16,7 @@ function parseAndAddNode (key, data, ipfs) {
     }
     const nodeJSON = node.toJSON()
 
-    console.log(nodeJSON.multihash)
+    print(nodeJSON.multihash)
   })
 }
 

--- a/src/cli/commands/object/put.js
+++ b/src/cli/commands/object/put.js
@@ -2,6 +2,7 @@
 
 const bl = require('bl')
 const fs = require('fs')
+const print = require('../../utils').print
 
 function putNode (buf, enc, ipfs) {
   ipfs.object.put(buf, {enc: enc}, (err, node) => {
@@ -11,7 +12,7 @@ function putNode (buf, enc, ipfs) {
 
     const nodeJSON = node.toJSON()
 
-    console.log('added', nodeJSON.multihash)
+    print(`added ${nodeJSON.multihash}`)
   })
 }
 

--- a/src/cli/commands/object/stat.js
+++ b/src/cli/commands/object/stat.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'stat <key>',
 
@@ -18,7 +20,7 @@ module.exports = {
       delete stats.Hash // only for js-ipfs-api output
 
       Object.keys(stats).forEach((key) => {
-        console.log(`${key}: ${stats[key]}`)
+        print(`${key}: ${stats[key]}`)
       })
     })
   }

--- a/src/cli/commands/pubsub/ls.js
+++ b/src/cli/commands/pubsub/ls.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'ls',
 
@@ -14,7 +16,7 @@ module.exports = {
       }
 
       subscriptions.forEach((sub) => {
-        console.log(sub)
+        print(sub)
       })
     })
   }

--- a/src/cli/commands/pubsub/peers.js
+++ b/src/cli/commands/pubsub/peers.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'peers <topic>',
 
@@ -13,9 +15,7 @@ module.exports = {
         throw err
       }
 
-      peers.forEach((peer) => {
-        console.log(peer)
-      })
+      peers.forEach(print)
     })
   }
 }

--- a/src/cli/commands/pubsub/peers.js
+++ b/src/cli/commands/pubsub/peers.js
@@ -15,7 +15,7 @@ module.exports = {
         throw err
       }
 
-      peers.forEach(print)
+      peers.forEach((peer) => print(peer))
     })
   }
 }

--- a/src/cli/commands/pubsub/sub.js
+++ b/src/cli/commands/pubsub/sub.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'sub <topic>',
 
@@ -9,7 +11,7 @@ module.exports = {
 
   handler (argv) {
     const handler = (msg) => {
-      console.log(msg.data.toString())
+      print(msg.data.toString())
     }
 
     argv.ipfs.pubsub.subscribe(argv.topic, handler, (err) => {

--- a/src/cli/commands/repo/version.js
+++ b/src/cli/commands/repo/version.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'version',
 
@@ -12,7 +14,7 @@ module.exports = {
       if (err) {
         return console.error(err)
       }
-      console.log(version)
+      print(version)
     })
   }
 }

--- a/src/cli/commands/swarm/addrs.js
+++ b/src/cli/commands/swarm/addrs.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'addrs',
 
@@ -18,11 +20,11 @@ module.exports = {
 
       res.forEach((peer) => {
         const count = peer.multiaddrs.size
-        console.log(`${peer.id.toB58String()} (${count})`)
+        print(`${peer.id.toB58String()} (${count})`)
 
         peer.multiaddrs.forEach((addr) => {
           const res = addr.decapsulate('ipfs').toString()
-          console.log(`\t${res}`)
+          print(`\t${res}`)
         })
       })
     })

--- a/src/cli/commands/swarm/addrs/local.js
+++ b/src/cli/commands/swarm/addrs/local.js
@@ -4,6 +4,7 @@ const utils = require('../../../utils')
 const debug = require('debug')
 const log = debug('cli:object')
 log.error = debug('cli:object:error')
+const print = require('../../../utils').print
 
 module.exports = {
   command: 'local',
@@ -23,7 +24,7 @@ module.exports = {
       }
 
       res.forEach((addr) => {
-        console.log(addr.toString())
+        print(addr.toString())
       })
     })
   }

--- a/src/cli/commands/swarm/connect.js
+++ b/src/cli/commands/swarm/connect.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const utils = require('../../utils')
+const print = utils.print
 
 module.exports = {
   command: 'connect <address>',
@@ -19,7 +20,7 @@ module.exports = {
         throw err
       }
 
-      console.log(res.Strings[0])
+      print(res.Strings[0])
     })
   }
 }

--- a/src/cli/commands/swarm/disconnect.js
+++ b/src/cli/commands/swarm/disconnect.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const utils = require('../../utils')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'disconnect <address>',
@@ -19,7 +20,7 @@ module.exports = {
         throw err
       }
 
-      console.log(res.Strings[0])
+      print(res.Strings[0])
     })
   }
 }

--- a/src/cli/commands/swarm/peers.js
+++ b/src/cli/commands/swarm/peers.js
@@ -3,6 +3,7 @@
 const mafmt = require('mafmt')
 const multiaddr = require('multiaddr')
 const utils = require('../../utils')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'peers',
@@ -27,7 +28,7 @@ module.exports = {
           ma = ma.encapsulate('/ipfs/' + item.peer.toB58String())
         }
         const addr = ma.toString()
-        console.log(addr)
+        print(addr)
       })
     })
   }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const print = require('../utils').print
+
 module.exports = {
   command: 'version',
 
@@ -28,7 +30,7 @@ module.exports = {
         throw err
       }
 
-      console.log(`js-ipfs version: ${version.version}`)
+      print(`js-ipfs version: ${version.version}`)
     })
   }
 }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -69,18 +69,15 @@ exports.getRepoPath = () => {
   return process.env.IPFS_PATH || os.homedir() + '/.jsipfs'
 }
 
-exports.createLogger = (visible) => {
-  return (msg, newline) => {
-    if (newline === undefined) {
-      newline = true
-    }
-    if (visible) {
-      if (msg === undefined) {
-        msg = ''
-      }
-      msg = newline ? msg + '\n' : msg
-      process.stdout.write(msg)
-    }
+exports.printLevel = 1
+
+exports.print = (msg, options) => {
+  msg = msg || ''
+  if (typeof options === 'boolean') { options = { newline: options } }
+  options = Object.assign({ newline: true, printLevel: 1 }, options || {})
+
+  if (options.printLevel <= exports.printLevel) {
+    msg = options.newline ? msg + '\n' : msg
+    process.stdout.write(msg)
   }
 }
-exports.print = exports.createLogger(true) // TODO refactor/remove createLogger?

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -69,15 +69,19 @@ exports.getRepoPath = () => {
   return process.env.IPFS_PATH || os.homedir() + '/.jsipfs'
 }
 
-exports.printLevel = 1
+let visible = true
+exports.disablePrinting = () => { visible = false }
 
-exports.print = (msg, options) => {
-  msg = msg || ''
-  if (typeof options === 'boolean') { options = { newline: options } }
-  options = Object.assign({ newline: true, printLevel: 1 }, options || {})
+exports.print = (msg, newline) => {
+  if (newline === undefined) {
+    newline = true
+  }
 
-  if (options.printLevel <= exports.printLevel) {
-    msg = options.newline ? msg + '\n' : msg
+  if (visible) {
+    if (msg === undefined) {
+      msg = ''
+    }
+    msg = newline ? msg + '\n' : msg
     process.stdout.write(msg)
   }
 }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -83,3 +83,4 @@ exports.createLogger = (visible) => {
     }
   }
 }
+exports.print = exports.createLogger(true) // TODO refactor/remove createLogger?

--- a/test/cli/general.js
+++ b/test/cli/general.js
@@ -1,0 +1,13 @@
+/* eslint-env mocha */
+'use strict'
+
+const expect = require('chai').expect
+const runOnAndOff = require('../utils/on-and-off')
+
+describe('general cli options', () => runOnAndOff((thing) => {
+  it('should handle --quiet flag', () => {
+    return thing.ipfs('help --quiet').then((out) => {
+      expect(out).to.be.empty()
+    })
+  })
+}))


### PR DESCRIPTION
This changes the CLI to use a logger instead of console.out, as discussed in #495

There is a design decision about how we instantiate the logger: originally there was a logger instantiated in command/init, but I think that instantiating it in every command, will add too much boilerplate. Instead I just took the simplest approach, i.e. to instantiate an instance in the `utils` module, - and have a print function exported there. 

If we want to have a quiet option, it could then be parsed once in `bin.js`, and then the logger might be instantiated from there. Also if we intend always only have a single logger instance(?), we could remove `createLogger `, and just have the print function, plus the ability to configure whether to silence it or not.