### PR TITLE
refactor: consistent error handling in cli

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -44,8 +44,7 @@ module.exports = {
         if (err.code === 'EACCES') {
           err.message = `EACCES: permission denied, stat $IPFS_PATH/version`
         }
-        console.error(err.toString())
-        process.exit(1)
+        throw err
       }
     })
   }

--- a/src/cli/commands/repo/version.js
+++ b/src/cli/commands/repo/version.js
@@ -10,7 +10,7 @@ module.exports = {
   handler (argv) {
     argv.ipfs.repo.version(function (err, version) {
       if (err) {
-        return console.error(err)
+        throw err
       }
       console.log(version)
     })


### PR DESCRIPTION
Fixes small inconsistency in style:
Most of the commands in the CLI throws on error,
with a few exceptions that prints a message to stderr instead.
It looks at if it by random (and not intentional), 
and looked a bit odd when I was going through the code earlier,
so this pull request make them all handle errors the same way.