### PR TITLE
chore: remove official support for Node.js 4 (rm it from tests and docs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ language: node_js
 
 matrix:
   include:
-  - node_js: 4
-    env: CXX=g++-4.8
   - node_js: 6
-    env:
-      - CXX=g++-4.8
+  - node_js: 8
   - node_js: stable
-    env: CXX=g++-4.8
 
 # Make sure we have new NPM.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,11 @@ matrix:
   include:
   - node_js: 6
   - node_js: 8
-  - node_js: stable
-
-# Make sure we have new NPM.
-before_install:
-  - npm install -g npm@4
+  #  - node_js: stable
 
 script:
   - npm run lint
-  - npm test
+  - npm run test
   - npm run coverage
   - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ language: node_js
 matrix:
   include:
   - node_js: 6
+    env: CXX=g++-4.8
   - node_js: 8
-  #  - node_js: stable
+    env: CXX=g++-4.8
+    #  - node_js: stable
+    #    env: CXX=g++-4.8
 
 script:
   - npm run lint

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="https://github.com/feross/standard"><img src="https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square"></a>
   <a href="https://github.com/RichardLitt/standard-readme"><img src="https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square" /></a>
   <a href=""><img src="https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square" /></a>
-  <a href=""><img src="https://img.shields.io/badge/Node.js-%3E%3D4.0.0-orange.svg?style=flat-square" /></a>
+  <a href=""><img src="https://img.shields.io/badge/Node.js-%3E%3D6.0.0-orange.svg?style=flat-square" /></a>
   <br>
   <!-- Hidding this until we have SauceLabs situation figured out, right now it is just misleading
   <a href="https://saucelabs.com/u/js-ipfs"><img src="https://saucelabs.com/browser-matrix/js-ipfs.svg" /></a> -->
@@ -91,7 +91,7 @@ This project is available through [npm](https://www.npmjs.com/). To install run
 > npm install ipfs --save
 ```
 
-Requires npm@3 and node >= 4.5, tested on OSX & Linux, expected to work on Windows.
+Requires npm@3 and node@6, tested on OSX & Linux, expected to work on Windows.
 
 ### Use in Node.js
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This project is available through [npm](https://www.npmjs.com/). To install run
 > npm install ipfs --save
 ```
 
-Requires npm@3 and node@6, tested on OSX & Linux, expected to work on Windows.
+Requires npm@3 and node@6 or above, tested on OSX & Linux, expected to work on Windows.
 
 ### Use in Node.js
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "stream": "readable-stream"
   },
   "engines": {
-    "node": ">=4.0.0",
+    "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
   "scripts": {


### PR DESCRIPTION
ref: https://github.com/ipfs/js-ipfs/issues/781