### PR TITLE
Fix typos in webRTC code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ To add WebRTC support in a IPFS node instance, do:
 ```JavaScript
 const wrtc = require('wrtc') // or require('electron-webrtc')()
 const WStar = require('libp2p-webrtc-star')
-const wstar = WStar({ wrtc: wrtc })
+const wstar = new WStar({ wrtc: wrtc })
 
 const node = new IPFS({
   repo: 'your-repo-path',
@@ -368,7 +368,7 @@ const node = new IPFS({
   },
   libp2p: {
     modules: {
-      transport: [wstar]
+      transport: [wstar],
       discovery: [wstar.discovery]
     }
   }


### PR DESCRIPTION
Noticed few typos in the README example when testing webrtc/node.