### PR TITLE
[WIP] feat: adding ability to specify a key type to use

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -21,6 +21,12 @@ module.exports = {
       alias: 'e',
       type: 'boolean',
       describe: "Don't add and pin help files to the local storage"
+    },
+    type: {
+      alias: 't',
+      type: 'string',
+      default: 'RSA',
+      describe: 'Choose the key type used by your node'
     }
   },
 

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -36,6 +36,7 @@ module.exports = function init (self) {
     opts.emptyRepo = opts.emptyRepo || false
     opts.bits = Number(opts.bits) || 2048
     opts.log = opts.log || function () {}
+    opts.type = opts.type || 'RSA'
 
     waterfall([
       // Verify repo does not yet exist.
@@ -47,9 +48,9 @@ module.exports = function init (self) {
         }
 
         // Generate peer identity keypair + transform to desired format + add to config.
-        opts.log(`generating ${opts.bits}-bit RSA keypair...`, false)
+        opts.log(`generating ${opts.bits}-bit ${opts.type} keypair...`, false)
         self.log('generating peer id: %s bits', opts.bits)
-        peerId.create({bits: opts.bits}, cb)
+        peerId.create({bits: opts.bits, type: opts.type}, cb)
       },
       (keys, cb) => {
         self.log('identity generated')


### PR DESCRIPTION
Depends on libp2p/js-peer-id#65

The following PR is enabling the possibility to specify the key type to use while running the `jsipfs init` command. Even if it isn't really useful at the moment, it open the path for a more modular implementation regarding key management.