### PR TITLE
clean up , working builds on node v8.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "multihashes": "~0.4.5",
     "once": "^1.4.0",
     "path-exists": "^3.0.0",
-    "promised-for": "^1.0.0",
     "peer-book": "^0.5.0",
     "peer-id": "^0.9.0",
     "peer-info": "^0.10.0",

--- a/src/http/gateway/resources/gateway.js
+++ b/src/http/gateway/resources/gateway.js
@@ -1,23 +1,15 @@
 'use strict'
 
-// const mh = require('multihashes')
-// const multipart = require('ipfs-multipart')
 const debug = require('debug')
-// const tar = require('tar-stream')
 const log = debug('jsipfs:http-gateway')
 log.error = debug('jsipfs:http-gateway:error')
 const pull = require('pull-stream')
 const toPull = require('stream-to-pull-stream')
-// const pushable = require('pull-pushable')
-// const EOL = require('os').EOL
-// const toStream = require('pull-stream-to-stream')
 const fileType = require('file-type')
 const mime = require('mime-types')
 const GatewayResolver = require('../resolver')
 const PathUtils = require('../utils/path')
 const Stream = require('stream')
-
-exports = module.exports
 
 module.exports = {
   checkHash: (request, reply) => {

--- a/src/http/gateway/resources/index.js
+++ b/src/http/gateway/resources/index.js
@@ -1,3 +1,5 @@
 'use strict'
 
-exports.gateway = require('./gateway')
+module.exports = {
+  gateway: require('./gateway')
+}


### PR DESCRIPTION
Some clean up for gateway (tested on node v6 and v8.4.0).

Current Todo:
- [ ] port `go-ipfs` gateway tests to `js-ipfs`

License: MIT
Signed-off-by: Yahya <ya7yaz@gmail.com>