### PR TITLE
docs(example): show folks how to use pull-streams instead

### DIFF
--- a/examples/exchange-files-in-browser/package.json
+++ b/examples/exchange-files-in-browser/package.json
@@ -12,6 +12,9 @@
     "http-server": "^0.10.0"
   },
   "dependencies": {
+    "browserify-aes": "crypto-browserify/browserify-aes#master",
+    "pull-filereader": "^1.0.1",
+    "pull-stream": "^3.6.0",
     "stream-buffers": "^3.0.1"
   }
 }

--- a/examples/exchange-files-in-browser/public/index.html
+++ b/examples/exchange-files-in-browser/public/index.html
@@ -62,7 +62,7 @@
     </div>
 
     <!-- The IPFS node module -->
-    <script src="//unpkg.com/ipfs/dist/index.min.js"></script>
+    <!-- <script src="//unpkg.com/ipfs/dist/index.min.js"></script> -->
     <!-- <script src="js/app.js"></script> -->
     <script src="js/bundle.js"></script>
   </body>


### PR DESCRIPTION
Always stream incoming data through pull streams and use browserify-aes directly from master now. I was able to add a 300Mb sized file with this quite quickly.

Fixes most issues in https://github.com/ipfs/js-ipfs/issues/952  I believe