### PR TITLE
WIP: fix: prevent swarm peers from throwing after a peer disconnects

### DIFF
--- a/test/cli/swarm.js
+++ b/test/cli/swarm.js
@@ -78,5 +78,11 @@ describe('swarm', () => {
         )
       })
     })
+
+    it('`peers` should not throw after `disconnect`', () => {
+      return ipfsA('swarm peers').then((out) => {
+        expect(out).to.be.empty()
+      })
+    })
   })
 })


### PR DESCRIPTION
fixes - https://github.com/ipfs/js-ipfs/issues/992

tests are coming.