### PR TITLE
fix(examples): Include required modules for browser-webpack example

### DIFF
--- a/examples/browser-webpack/package.json
+++ b/examples/browser-webpack/package.json
@@ -11,8 +11,10 @@
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "json-loader": "^0.5.4",
     "react": "^15.5.4",
+    "react-dom": "^15.6.1",
     "react-hot-loader": "^1.3.1",
     "webpack": "^2.5.1",
     "webpack-dev-server": "^2.4.5"


### PR DESCRIPTION
Added react-dom and babel-preset-stage-0 to dev dependencies

Fixes #1021 