### PR TITLE
Uncomment node_modules from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ build
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
-# node_modules
+node_modules
 
 lib
 dist


### PR DESCRIPTION
This crept in from my last merged PR (https://github.com/ipfs/js-ipfs/pull/1032). I had commented out `node_modules` to make my IDE detect them. Apologies for the silly slip.