### PR TITLE
Fix: Promisify stop

### DIFF
--- a/src/cli/commands/ls.js
+++ b/src/cli/commands/ls.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const utils = require('../utils')
-const Unixfs = require('ipfs-unixfs')
-const pull = require('pull-stream')
 
 module.exports = {
   command: 'ls <key>',

--- a/src/core/components/stop.js
+++ b/src/core/components/stop.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const series = require('async/series')
+const promisify = require('promisify-es6')
 
 module.exports = (self) => {
-  return (callback) => {
+  return promisify((callback) => {
     callback = callback || function noop () {}
     self.log('stop')
 
@@ -40,5 +41,5 @@ module.exports = (self) => {
       (cb) => self.libp2p.stop(cb),
       (cb) => self._repo.close(cb)
     ], done)
-  }
+  })
 }

--- a/src/http/api/resources/files.js
+++ b/src/http/api/resources/files.js
@@ -317,4 +317,3 @@ function toTypeCode (type) {
       return 0
   }
 }
-

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -244,6 +244,24 @@ describe('create node', function () {
     ], done)
   })
 
+  it('stop as promised', function (done) {
+    const node = new IPFS({
+      repo: createTempRepo(),
+      config: {
+        Addresses: {
+          Swarm: []
+        },
+        Bootstrap: []
+      }
+    })
+
+    node.once('ready', () => {
+      node.stop()
+        .then(done)
+        .catch(done)
+    })
+  })
+
   it('can start node twice without crash', function (done) {
     const options = {
       repo: createTempRepo(),


### PR DESCRIPTION
This PR will promisify stop().

Closes #1076 

The effective changes are in stop.js and in create-node.spec.js. The changes to ls and files are purely to make linter happy.