### PR TITLE
CLI: --api option

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -52,19 +52,27 @@ if (args[0] === 'daemon' || args[0] === 'init') {
     .completion()
     .parse(args)
 } else {
-  utils.getIPFS((err, ipfs, cleanup) => {
-    if (err) { throw err }
+  // here we have to make a separate yargs instance with
+  // only the `api` option because we need this before doing
+  // the final yargs parse where the command handler is invoked..
+  yargs().option('api').parse(process.argv, (err, argv, output) => {
+    if (err) {
+      throw err
+    }
+    utils.getIPFS(argv.api, (err, ipfs, cleanup) => {
+      if (err) { throw err }
 
-    cli
-      .help()
-      .strict(false)
-      .completion()
-      .parse(args, { ipfs: ipfs }, (err, argv, output) => {
-        if (output) { print(output) }
+      cli
+        .help()
+        .strict(false)
+        .completion()
+        .parse(args, { ipfs: ipfs }, (err, argv, output) => {
+          if (output) { print(output) }
 
-        cleanup(() => {
-          if (err) { throw err }
+          cleanup(() => {
+            if (err) { throw err }
+          })
         })
-      })
+    })
   })
 }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -27,18 +27,20 @@ function isDaemonOn () {
 }
 
 exports.getAPICtl = getAPICtl
-function getAPICtl () {
-  if (!isDaemonOn()) {
+function getAPICtl (apiAddr) {
+  if (!apiAddr && !isDaemonOn()) {
     throw new Error('daemon is not on')
   }
-  const apiPath = path.join(exports.getRepoPath(), 'api')
-  const apiAddr = multiaddr(fs.readFileSync(apiPath).toString())
-  return APIctl(apiAddr.toString())
+  if (!apiAddr) {
+    const apiPath = path.join(exports.getRepoPath(), 'api')
+    apiAddr = multiaddr(fs.readFileSync(apiPath).toString()).toString()
+  }
+  return APIctl(apiAddr)
 }
 
-exports.getIPFS = (callback) => {
-  if (isDaemonOn()) {
-    return callback(null, getAPICtl(), (cb) => cb())
+exports.getIPFS = (apiAddr, callback) => {
+  if (apiAddr || isDaemonOn()) {
+    return callback(null, getAPICtl(apiAddr), (cb) => cb())
   }
 
   const node = new IPFS({


### PR DESCRIPTION
Mimicking go-ipfs, support the `--api=<multiaddr>` option to force being an HTTP client.