### PR TITLE
feat: files.unlink

### DIFF
--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -282,5 +282,22 @@ module.exports = function files (self) {
     },
 
     lsPullStreamImmutable: _lsPullStreamImmutable
-  }
+  },
+
+  unlink: promisify((ipfsPath, callback) => {
+    const cid = new CID(ipfsPath)
+    self._ipldResolver.get(cid, (err, node) => {
+      if (err) {
+        return callback(err)
+      }
+      pull(
+        pull.values(node.value.links),
+        pull.drain(
+          link => self._ipldResolver.bs.delete(new CID(link.multihash)),
+          () => self._ipldResolver.bs.delete(cid, callback)
+        )
+      )
+    })
+  })
+
 }


### PR DESCRIPTION
Original ref: https://github.com/ipfs/js-ipfs/pull/1043

This change adds the method `unlink` to the `files` component.

I have read the discussiones ([here](https://github.com/ipfs/faq/issues/9) & [here](https://discuss.ipfs.io/t/can-i-delete-my-content-from-the-network/301)) and understand files are not deleted from the network (if another peer has pinned them, then the files can still be distributed).

We are working on a web project where we add files to the network and we wanted to remove the files to clear some space locally. With this method the files get `unlinked` locally.