### PR TITLE
fix SIG tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "temp": "~0.8.3",
     "through2": "^2.0.3",
     "update-notifier": "^2.3.0",
-    "yargs": "^10.0.3"
+    "yargs": "^10.0.3",
+    "yargs-parser": "^8.0.0"
   },
   "optionalDependencies": {
     "prom-client": "^10.2.2",

--- a/test/cli/daemon.js
+++ b/test/cli/daemon.js
@@ -71,9 +71,8 @@ describe('daemon', () => {
 
   afterEach(() => clean(repoPath))
 
-  // TODO: test fails
-  it.skip('do not crash if Addresses.Swarm is empty', function (done) {
-    this.timeout(20 * 1000)
+  it('do not crash if Addresses.Swarm is empty', function (done) {
+    this.timeout(100 * 1000)
 
     ipfs('init').then(() => {
       return ipfs('config', 'Addresses', JSON.stringify({
@@ -88,18 +87,16 @@ describe('daemon', () => {
     }).catch((err) => done(err))
   })
 
-  // TODO: test fails
-  it.skip('should handle SIGINT gracefully', function (done) {
-    this.timeout(20 * 1000)
+  it('should handle SIGINT gracefully', function (done) {
+    this.timeout(100 * 1000)
 
     testSignal(ipfs, 'SIGINT').then(() => {
       checkLock(repoPath, done)
     }).catch(done)
   })
 
-  // TODO: test fails
-  it.skip('should handle SIGTERM gracefully', function (done) {
-    this.timeout(20 * 1000)
+  it('should handle SIGTERM gracefully', function (done) {
+    this.timeout(100 * 1000)
 
     testSignal(ipfs, 'SIGTERM').then(() => {
       checkLock(repoPath, done)


### PR DESCRIPTION
Tests are failing due to timeouts. These tests are awfully slow, we might want to consider skipping them on normal runs?