### PR TITLE
docs: fix a link of files API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ A complete API definition is in the works. Meanwhile, you can learn how to you u
 
 #### `Files`
 
-- [files](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/FILES)
+- [files](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md)
   - [`ipfs.files.add(data, [options], [callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/FILES.md#add)
   - [`ipfs.files.createAddStream([options], [callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/FILES.md#createaddstream)
   - [`ipfs.files.cat(multihash, [callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/FILES.md#cat)


### PR DESCRIPTION
The original link of files API was https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES. But it should be changed to https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md.