### PR TITLE
docs(examples): fix a link of eth-stuffs in README.md

### DIFF
--- a/examples/explore-ethereum-blockchain/README.md
+++ b/examples/explore-ethereum-blockchain/README.md
@@ -18,7 +18,7 @@ If this is the first time you use js-ipfs, make sure to init your repo with
 
 ## Load ethereum chain data into ipfs
 
-We've some ethereum blocks available at [eth-stuffs](/eth-stuffs) folder, you can add them to ipfs by running:
+We've some ethereum blocks available at [eth-stuffs](./eth-stuffs) folder, you can add them to ipfs by running:
 
 ```sh
 > ./load-eth-stuffs.sh


### PR DESCRIPTION
The eth-stuffs folder is located in the explore-ethereum-blockchain folder, which is a same level of README.md, so the link of eth-stuffs folder should be changed to ./eth-stuffs.