### PR TITLE
fix: config handler should check if value is null

### DIFF
--- a/src/http/api/resources/config.js
+++ b/src/http/api/resources/config.js
@@ -59,8 +59,9 @@ exports.getOrSet = {
     const value = request.pre.args.value
     const ipfs = request.server.app.ipfs
 
-    if (typeof value === 'object' &&
-        value.type === 'Buffer') {
+    // check that value exists - typeof null === 'object'
+    if (value && (typeof value === 'object' &&
+        value.type === 'Buffer')) {
       return reply({
         Message: 'Invalid value type',
         Code: 0

--- a/test/cli/config.js
+++ b/test/cli/config.js
@@ -45,6 +45,12 @@ describe('config', () => runOnAndOff((thing) => {
       })
     })
 
+    it('set a config key with null', () => {
+      return ipfs('config foo null --json').then((out) => {
+        expect(updatedConfig().foo).to.equal(null)
+      })
+    })
+
     it('set a config key with json', () => {
       return ipfs('config foo {"bar":0} --json').then((out) => {
         expect(updatedConfig().foo).to.deep.equal({ bar: 0 })

--- a/test/utils/interop-daemon-spawner/util.js
+++ b/test/utils/interop-daemon-spawner/util.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const os = require('os')
-const crypto = require('libp2p-crypto')
 const path = require('path')
 const hat = require('hat')
 


### PR DESCRIPTION
When setting configs to null in daemon mode, the handler should check if value is defined/null since `typeof null === 'object'`