### PR TITLE
fix(pubsub): subscribe promises

### DIFF
--- a/src/core/components/pubsub.js
+++ b/src/core/components/pubsub.js
@@ -24,7 +24,7 @@ module.exports = function pubsub (self) {
         }
 
         self._pubsub.on(topic, handler)
-        setImmediate(() => callback())
+        setImmediate(cb)
       }
 
       if (!callback) {


### PR DESCRIPTION
`Pubsub.subscribe` was not returning a `Promise` when the callback argument was not specified.

Tests are in https://github.com/ipfs/interface-ipfs-core/pull/181

Should resolve https://github.com/ipfs/interface-ipfs-core/issues/174, https://github.com/ipfs/js-ipfs/issues/1137 and https://github.com/ipfs/js-ipfs/issues/1129