### PR TITLE
fix(files.add): directory with odd name

### DIFF
--- a/src/cli/commands/files/add.js
+++ b/src/cli/commands/files/add.js
@@ -206,12 +206,20 @@ module.exports = {
     }
     const ipfs = argv.ipfs
 
-    let list = []
+    let list
     waterfall([
-      (next) => glob(path.join(inPath, '/**/*'), next),
+      (next) => {
+        if (fs.statSync(inPath).isDirectory()) {
+          return glob('**/*', { cwd: inPath }, next)
+        }
+        next(null, [])
+      },
       (globResult, next) => {
-        list = globResult.length === 0 ? [inPath] : globResult
-
+        if (globResult.length === 0) {
+          list = [inPath]
+        } else {
+          list = globResult.map((f) => inPath + '/' + f)
+        }
         getTotalBytes(inPath, argv.recursive, next)
       },
       (totalBytes, next) => {

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -154,6 +154,20 @@ describe('files', () => runOnAndOff((thing) => {
       })
   })
 
+  it('add directory with odd name', function () {
+    this.timeout(30 * 1000)
+    const expected = [
+      'added QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o odd-name-[v0]/odd name [v1]/hello',
+      'added QmYRMUVULBfj7WrdPESnwnyZmtayN6Sdrwh1nKcQ9QgQeZ odd-name-[v0]/odd name [v1]',
+      'added QmXJGoo27bg7ExNAtr9vRcivxDwcfHtkxatGno9HrUdR16 odd-name-[v0]'
+    ]
+
+    return ipfs('files add -r test/fixtures/odd-name-[v0]')
+      .then((out) => {
+        expect(out).to.eql(expected.join('\n') + '\n')
+      })
+  })
+
   it('add and wrap with a directory', function () {
     this.timeout(30 * 1000)
 

--- a/test/fixtures/odd-name-[v0]/odd name [v1]/hello
+++ b/test/fixtures/odd-name-[v0]/odd name [v1]/hello
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
`glob` was interpreting the '[' as a special magic character.  According to its documentation, a caller should be able to escape it with `\`; but it does not work.

See the [glob issue](https://github.com/isaacs/node-glob/issues/277).