### PR TITLE
fix: (cli/init) use cross-platform path separator

### DIFF
--- a/src/core/components/init-assets.js
+++ b/src/core/components/init-assets.js
@@ -11,7 +11,7 @@ const CID = require('cids')
 // Add the default assets to the repo.
 module.exports = function addDefaultAssets (self, log, callback) {
   const initDocsPath = path.join(__dirname, '../../init-files/init-docs')
-  const index = initDocsPath.lastIndexOf('/')
+  const index = initDocsPath.lastIndexOf(path.sep)
 
   pull(
     pull.values([initDocsPath]),


### PR DESCRIPTION
This fixes the command "init" on windows. Before this change, none of
the files where actually added to your local repository. With this
change, files are correctly added to the repository as windows uses "\"
as the path separator instead of "/" (posix)