### PR TITLE
fix(cli): show help for subcommands

### DIFF
--- a/src/cli/commands/bitswap.js
+++ b/src/cli/commands/bitswap.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'bitswap',
+  command: 'bitswap <command>',
 
   description: 'Interact with the bitswap agent.',
 
@@ -10,6 +10,5 @@ module.exports = {
   },
 
   handler (argv) {
-    console.log('Type `jsipfs bitswap --help` for more information about this command')
   }
 }

--- a/src/cli/commands/block.js
+++ b/src/cli/commands/block.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'block',
+  command: 'block <command>',
 
   description: 'Manipulate raw IPFS blocks.',
 

--- a/src/cli/commands/bootstrap.js
+++ b/src/cli/commands/bootstrap.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'bootstrap',
+  command: 'bootstrap <command>',
 
   description: 'Show or edit the list of bootstrap peers.',
 

--- a/src/cli/commands/dag.js
+++ b/src/cli/commands/dag.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'dag',
+  command: 'dag <command>',
 
   description: 'Interact with ipld dag objects.',
 

--- a/src/cli/commands/file.js
+++ b/src/cli/commands/file.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'file',
+  command: 'file <command>',
 
   description: 'Interact with IPFS objects representing Unix filesystems.',
 

--- a/src/cli/commands/files.js
+++ b/src/cli/commands/files.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'files',
+  command: 'files <command>',
 
   description: 'Operations over files (add, cat, get, ls, etc)',
 

--- a/src/cli/commands/object.js
+++ b/src/cli/commands/object.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'object',
+  command: 'object <command>',
 
   description: 'Interact with ipfs objects.',
 

--- a/src/cli/commands/pubsub.js
+++ b/src/cli/commands/pubsub.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'pubsub',
+  command: 'pubsub <command>',
 
   description: 'pubsub commands',
 

--- a/src/cli/commands/repo.js
+++ b/src/cli/commands/repo.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'repo',
+  command: 'repo <command>',
 
   description: 'Manipulate the IPFS repo.',
 

--- a/src/cli/commands/swarm.js
+++ b/src/cli/commands/swarm.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'swarm',
+  command: 'swarm <command>',
 
   description: 'Swarm inspection tool.',
 


### PR DESCRIPTION
If subcommands are called, e.g. `jsipfs dag` there was no output
at all. Now the help message (which you also get with `--help`
is displayed.