### PR TITLE
chore: change from pre-commit to pre-push hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "coverage": "aegir coverage",
     "coverage-publish": "aegir-coverage publish"
   },
-  "pre-commit": [
+  "pre-push": [
     "lint",
     "test"
   ],


### PR DESCRIPTION
Instead of running the linting and tests on pre-commit, do it
on pre-push. That makes it less frequent (and annoying) while
doing local development.