### PR TITLE
feat: `ipfs version` flags + `ipfs repo version` (#1181)

### DIFF
--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const os = require('os')
 const print = require('../utils').print
 
 module.exports = {
@@ -32,22 +33,24 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.version((err, ipfs) => {
+    argv.ipfs.version((err, data) => {
       if (err) {
         throw err
       }
 
       const withCommit = argv.all || argv.commit
-      const parsedVersion = `${ipfs.version}${withCommit ? `-${ipfs.commit}` : ''}`
+      const parsedVersion = `${data.version}${withCommit ? `-${data.commit}` : ''}`
 
       if (argv.repo) {
         // go-ipfs prints only the number, even without the --number flag.
-        print(ipfs.repo)
+        print(data.repo)
       } else if (argv.number) {
         print(parsedVersion)
       } else if (argv.all) {
         print(`js-ipfs version: ${parsedVersion}`)
-        print(`Repo version: ${ipfs.repo}`)
+        print(`Repo version: ${data.repo}`)
+        print(`System version: ${os.arch()}/${os.platform()}`)
+        print(`Node.js version: ${process.version}`)
       } else {
         print(`js-ipfs version: ${parsedVersion}`)
       }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -11,26 +11,46 @@ module.exports = {
     number: {
       alias: 'n',
       type: 'boolean',
-      default: false
+      default: false,
+      describe: 'Print only the version number'
     },
     commit: {
       type: 'boolean',
-      default: false
+      default: false,
+      describe: `Include the version's commit hash`
     },
     repo: {
       type: 'boolean',
-      default: false
+      default: false,
+      describe: `Print only the repo's version number`
+    },
+    all: {
+      type: 'boolean',
+      default: false,
+      describe: 'Print everything we have'
     }
   },
 
   handler (argv) {
-    // TODO: handle argv.{repo|commit|number}
-    argv.ipfs.version((err, version) => {
+    argv.ipfs.version((err, ipfs) => {
       if (err) {
         throw err
       }
 
-      print(`js-ipfs version: ${version.version}`)
+      const withCommit = argv.all || argv.commit
+      const parsedVersion = `${ipfs.version}${withCommit ? `-${ipfs.commit}` : ''}`
+
+      if (argv.repo) {
+        // go-ipfs prints only the number, even without the --number flag.
+        print(ipfs.repo)
+      } else if (argv.number) {
+        print(parsedVersion)
+      } else if (argv.all) {
+        print(`js-ipfs version: ${parsedVersion}`)
+        print(`Repo version: ${ipfs.repo}`)
+      } else {
+        print(`js-ipfs version: ${parsedVersion}`)
+      }
     })
   }
 }

--- a/src/core/components/repo.js
+++ b/src/core/components/repo.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const repoVersion = require('ipfs-repo').repoVersion
 
 module.exports = function repo (self) {
   return {
@@ -8,8 +9,25 @@ module.exports = function repo (self) {
       // 1. check if repo already exists
     },
 
+    /**
+     * If the repo has been initialized, report the current version.
+     * Otherwise report the version that would be initialized.
+     *
+     * @param {function(Error, Number)} [callback]
+     * @returns {undefined}
+     */
     version: promisify((callback) => {
-      self._repo.version.get(callback)
+      self._repo._isInitialized(err => {
+        if (err) {
+          if (/ENOENT|not yet initialized/.test(err.message)) {
+            // this repo has not been initialized
+            return callback(null, repoVersion)
+          }
+          return callback(err)
+        }
+
+        self._repo.version.get(callback)
+      })
     }),
 
     gc: () => {},

--- a/src/core/components/version.js
+++ b/src/core/components/version.js
@@ -13,7 +13,7 @@ module.exports = function version (self) {
 
     self.repo.version((err, repoVersion) => {
       if (err) {
-        throw err
+        callback(err)
       }
 
       callback(null, {

--- a/src/core/components/version.js
+++ b/src/core/components/version.js
@@ -3,6 +3,7 @@
 const pkg = require('../../../package.json')
 const promisify = require('promisify-es6')
 
+// TODO add the commit hash of the current ipfs version to the response.
 module.exports = function version (self) {
   return promisify((opts, callback) => {
     if (typeof opts === 'function') {
@@ -10,10 +11,16 @@ module.exports = function version (self) {
       opts = {}
     }
 
-    callback(null, {
-      version: pkg.version,
-      repo: '',
-      commit: ''
+    self.repo.version((err, repoVersion) => {
+      if (err) {
+        throw err
+      }
+
+      callback(null, {
+        version: pkg.version,
+        repo: repoVersion,
+        commit: ''
+      })
     })
   })
 }

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
 const fs = require('fs')
+const expect = require('chai').expect
 const path = require('path')
 const compareDir = require('dir-compare').compareSync
 const rimraf = require('rimraf').sync

--- a/test/cli/repo.js
+++ b/test/cli/repo.js
@@ -1,23 +1,16 @@
 /* eslint-env mocha */
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const expect = require('chai').expect
-const runOnAndOff = require('../utils/on-and-off')
+const repoVersion = require('ipfs-repo').repoVersion
 
-function getRepoVersion (repoPath) {
-  const versionPath = path.join(repoPath, 'version')
-  return String(fs.readFileSync(versionPath))
-}
+const runOnAndOff = require('../utils/on-and-off')
 
 describe('repo', () => runOnAndOff((thing) => {
   let ipfs
-  let repoVersion
 
   before(() => {
     ipfs = thing.ipfs
-    repoVersion = getRepoVersion(ipfs.repoPath)
   })
 
   it('get the repo version', () => {

--- a/test/cli/repo.js
+++ b/test/cli/repo.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const expect = require('chai').expect
+const runOnAndOff = require('../utils/on-and-off')
+
+function getRepoVersion (repoPath) {
+  const versionPath = path.join(repoPath, 'version')
+  return String(fs.readFileSync(versionPath))
+}
+
+describe('repo', () => runOnAndOff((thing) => {
+  let ipfs
+  let repoVersion
+
+  before(() => {
+    ipfs = thing.ipfs
+    repoVersion = getRepoVersion(ipfs.repoPath)
+  })
+
+  it('get the repo version', () => {
+    return ipfs('repo version').then((out) => {
+      expect(out).to.eql(`${repoVersion}\n`)
+    })
+  })
+}))

--- a/test/cli/version.js
+++ b/test/cli/version.js
@@ -1,59 +1,69 @@
+/* eslint max-nested-callbacks: ["error", 5] */
 /* eslint-env mocha */
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
+const os = require('os')
 const expect = require('chai').expect
+const repoVersion = require('ipfs-repo').repoVersion
 const pkgversion = require('../../package.json').version
 const runOnAndOff = require('../utils/on-and-off')
 
-function getRepoVersion (repoPath) {
-  const versionPath = path.join(repoPath, 'version')
-  return String(fs.readFileSync(versionPath))
-}
-
 describe('version', () => runOnAndOff((thing) => {
   let ipfs
-  let repoVersion
 
   before(() => {
     ipfs = thing.ipfs
-    repoVersion = getRepoVersion(ipfs.repoPath)
   })
 
-  it('get the version', () => {
-    return ipfs('version').then((out) => {
+  it('get the version', () =>
+    ipfs('version').then(out =>
       expect(out).to.eql(
         `js-ipfs version: ${pkgversion}\n`
       )
-    })
-  })
+    )
+  )
 
-  it('handles --number', () => {
-    return ipfs('version --number').then(out =>
+  it('handles --number', () =>
+    ipfs('version --number').then(out =>
       expect(out).to.eql(`${pkgversion}\n`)
     )
-  })
+  )
 
-  it('handles --commit', () => {
-    return ipfs('version --commit').then(out =>
+  it('handles --commit', () =>
+    ipfs('version --commit').then(out =>
       expect(out).to.eql(`js-ipfs version: ${pkgversion}-\n`)
     )
-  })
+  )
 
-  it('handles --all', () => {
-    return ipfs('version --all').then(out =>
-      expect(out).to.include(
-        `js-ipfs version: ${pkgversion}-
-Repo version: ${repoVersion}
-`
-      )
+  describe('handles --all', function () {
+    it('prints js-ipfs version', () =>
+      ipfs('version --all').then(out => {
+        expect(out).to.include(`js-ipfs version: ${pkgversion}`)
+      })
+    )
+
+    it('prints repo version', () =>
+      ipfs('version --all').then(out => {
+        expect(out).to.include(`Repo version: ${repoVersion}`)
+      })
+    )
+
+    it('prints arch/platform', () =>
+      ipfs('version --all').then(out => {
+        expect(out).to.include(`System version: ${os.arch()}/${os.platform()}`)
+      })
+    )
+
+    it('prints Node.js version', () =>
+      ipfs('version --all').then(out => {
+        expect(out).to.include(`Node.js version: ${process.version}`)
+      })
     )
   })
 
-  it('handles --repo', () => {
-    return ipfs('version --repo').then(out => {
+  it('handles --repo', () =>
+    ipfs('version --repo').then(out =>
       expect(out).to.eql(`${repoVersion}\n`)
-    })
-  })
+    )
+  )
 }))

--- a/test/cli/version.js
+++ b/test/cli/version.js
@@ -1,15 +1,24 @@
 /* eslint-env mocha */
 'use strict'
 
+const fs = require('fs')
+const path = require('path')
 const expect = require('chai').expect
 const pkgversion = require('../../package.json').version
 const runOnAndOff = require('../utils/on-and-off')
 
+function getRepoVersion (repoPath) {
+  const versionPath = path.join(repoPath, 'version')
+  return String(fs.readFileSync(versionPath))
+}
+
 describe('version', () => runOnAndOff((thing) => {
   let ipfs
+  let repoVersion
 
   before(() => {
     ipfs = thing.ipfs
+    repoVersion = getRepoVersion(ipfs.repoPath)
   })
 
   it('get the version', () => {
@@ -17,6 +26,34 @@ describe('version', () => runOnAndOff((thing) => {
       expect(out).to.eql(
         `js-ipfs version: ${pkgversion}\n`
       )
+    })
+  })
+
+  it('handles --number', () => {
+    return ipfs('version --number').then(out =>
+      expect(out).to.eql(`${pkgversion}\n`)
+    )
+  })
+
+  it('handles --commit', () => {
+    return ipfs('version --commit').then(out =>
+      expect(out).to.eql(`js-ipfs version: ${pkgversion}-\n`)
+    )
+  })
+
+  it('handles --all', () => {
+    return ipfs('version --all').then(out =>
+      expect(out).to.include(
+        `js-ipfs version: ${pkgversion}-
+Repo version: ${repoVersion}
+`
+      )
+    )
+  })
+
+  it('handles --repo', () => {
+    return ipfs('version --repo').then(out => {
+      expect(out).to.eql(`${repoVersion}\n`)
     })
   })
 }))

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -28,7 +28,10 @@ test_expect_success "ipfs version output looks good" '
 
 test_expect_success "ipfs version --all has all required fields" '
 	ipfs version --all > version_all.txt &&
-	grep "js-ipfs version" version_all.txt
+	grep "js-ipfs version" version_all.txt &&
+  grep "Repo version" version_all.txt &&
+	grep "System version" version_all.txt &&
+	grep "Node.js version" version_all.txt
 '
 
 test_expect_success "ipfs help succeeds" '


### PR DESCRIPTION
@JonKrone I've found the issue, see: https://github.com/ipfs/js-ipfs/pull/1181/files#r163727102

Wanna take a stab at finishing the PR?

You can see where the error comes from if you run `make test --verbose`

```
» ./t0010-basic-commands.sh --verbose
expecting success:
        echo "It works!" > test.txt

ok 1 - current dir is writable

expecting success:
        ipfs version > version.txt

/Users/imp/code/js-ipfs/src/core/components/version.js:16
        throw err
        ^

Error: ENOENT: no such file or directory, open '/Users/imp/code/js-ipfs/test/sharness/trash directory.t0010-basic-commands.sh/.jsipfs/version'
```