### PR TITLE
fix: Return swarm http errors as json

### DIFF
--- a/src/http/api/resources/swarm.js
+++ b/src/http/api/resources/swarm.js
@@ -10,7 +10,7 @@ exports = module.exports
 // common pre request handler that parses the args and returns `addr` which is assigned to `request.pre.args`
 exports.parseAddrs = (request, reply) => {
   if (!request.query.arg) {
-    const err = 'Argument \'addr\' is required'
+    const err = 'Argument `addr` is required'
     log.error(err)
     return reply({
       Code: 0,

--- a/src/http/api/resources/swarm.js
+++ b/src/http/api/resources/swarm.js
@@ -10,13 +10,22 @@ exports = module.exports
 // common pre request handler that parses the args and returns `addr` which is assigned to `request.pre.args`
 exports.parseAddrs = (request, reply) => {
   if (!request.query.arg) {
-    return reply("Argument 'addr' is required").code(400).takeover()
+    const err = 'Argument \'addr\' is required'
+    log.error(err)
+    return reply({
+      Code: 0,
+      Message: err
+    }).code(400).takeover()
   }
 
   try {
     multiaddr(request.query.arg)
   } catch (err) {
-    return reply("Argument 'addr' is invalid").code(500).takeover()
+    log.error(err)
+    return reply({
+      Code: 0,
+      Message: err.message
+    }).code(500).takeover()
   }
 
   return reply({


### PR DESCRIPTION
Closes #1176 

Returning errors as json the cli now receives treated messages as bellow:

```
/Users/paulogr/dev/js-ipfs/src/cli/commands/swarm/connect.js:20
        throw err
        ^

Error: no protocol with name: libp2p-webrtc-star
    at parseError (/Users/paulogr/dev/js-ipfs/node_modules/ipfs-api/src/utils/send-request.js:16:17)
    at ClientRequest.<anonymous> (/Users/paulogr/dev/js-ipfs/node_modules/ipfs-api/src/utils/send-request.js:39:14)
    at Object.onceWrapper (events.js:255:19)
    at ClientRequest.emit (events.js:160:13)
```