### PR TITLE
`ipfs version` flags and `ipfs repo version`

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ipfs-block": "~0.6.1",
     "ipfs-block-service": "~0.13.0",
     "ipfs-multipart": "~0.1.0",
-    "ipfs-repo": "~0.18.5",
+    "ipfs-repo": "^0.18.6",
     "ipfs-unixfs": "~0.1.14",
     "ipfs-unixfs-engine": "~0.24.2",
     "ipld-resolver": "~0.14.1",

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -32,22 +32,22 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.version((err, ipfs) => {
+    argv.ipfs.version((err, data) => {
       if (err) {
         throw err
       }
 
       const withCommit = argv.all || argv.commit
-      const parsedVersion = `${ipfs.version}${withCommit ? `-${ipfs.commit}` : ''}`
+      const parsedVersion = `${data.version}${withCommit ? `-${data.commit}` : ''}`
 
       if (argv.repo) {
         // go-ipfs prints only the number, even without the --number flag.
-        print(ipfs.repo)
+        print(data.repo)
       } else if (argv.number) {
         print(parsedVersion)
       } else if (argv.all) {
         print(`js-ipfs version: ${parsedVersion}`)
-        print(`Repo version: ${ipfs.repo}`)
+        print(`Repo version: ${data.repo}`)
       } else {
         print(`js-ipfs version: ${parsedVersion}`)
       }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const os = require('os')
 const print = require('../utils').print
 
 module.exports = {
@@ -48,6 +49,8 @@ module.exports = {
       } else if (argv.all) {
         print(`js-ipfs version: ${parsedVersion}`)
         print(`Repo version: ${data.repo}`)
+        print(`System version: ${os.arch()}/${os.platform()}`)
+        print(`Node.js version: ${process.version}`)
       } else {
         print(`js-ipfs version: ${parsedVersion}`)
       }

--- a/src/core/components/repo.js
+++ b/src/core/components/repo.js
@@ -1,13 +1,29 @@
 'use strict'
 
+const repoVersion = require('ipfs-repo').repoVersion
+
 module.exports = function repo (self) {
   return {
     init: (bits, empty, callback) => {
       // 1. check if repo already exists
     },
 
+    /**
+     * If the repo has been initialized, report the current version.
+     * Otherwise report the version that would be initialized.
+     */
     version: (callback) => {
-      self._repo.version.get(callback)
+      self._repo._isInitialized(err => {
+        if (err) {
+          if (/ENOENT|not yet initialized/.test(err.message)) {
+            // this repo has not been initialized
+            return callback(null, repoVersion)
+          }
+          return callback(err)
+        }
+
+        self._repo.version.get(callback)
+      })
     },
 
     gc: function () {},

--- a/src/core/components/repo.js
+++ b/src/core/components/repo.js
@@ -11,6 +11,9 @@ module.exports = function repo (self) {
     /**
      * If the repo has been initialized, report the current version.
      * Otherwise report the version that would be initialized.
+     *
+     * @param {function(Error, Number)} [callback]
+     * @returns {undefined}
      */
     version: (callback) => {
       self._repo._isInitialized(err => {

--- a/src/core/components/version.js
+++ b/src/core/components/version.js
@@ -13,7 +13,7 @@ module.exports = function version (self) {
 
     self.repo.version((err, repoVersion) => {
       if (err) {
-        throw err
+        callback(err)
       }
 
       callback(null, {

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
 const fs = require('fs')
+const expect = require('chai').expect
 const path = require('path')
 const compareDir = require('dir-compare').compareSync
 const rimraf = require('rimraf').sync

--- a/test/cli/repo.js
+++ b/test/cli/repo.js
@@ -1,8 +1,6 @@
 /* eslint-env mocha */
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const expect = require('chai').expect
 const repoVersion = require('ipfs-repo').repoVersion
 

--- a/test/cli/repo.js
+++ b/test/cli/repo.js
@@ -4,20 +4,15 @@
 const fs = require('fs')
 const path = require('path')
 const expect = require('chai').expect
-const runOnAndOff = require('../utils/on-and-off')
+const repoVersion = require('ipfs-repo').repoVersion
 
-function getRepoVersion (repoPath) {
-  const versionPath = path.join(repoPath, 'version')
-  return String(fs.readFileSync(versionPath))
-}
+const runOnAndOff = require('../utils/on-and-off')
 
 describe('repo', () => runOnAndOff((thing) => {
   let ipfs
-  let repoVersion
 
   before(() => {
     ipfs = thing.ipfs
-    repoVersion = getRepoVersion(ipfs.repoPath)
   })
 
   it('get the repo version', () => {

--- a/test/cli/version.js
+++ b/test/cli/version.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const expect = require('chai').expect
 const repoVersion = require('ipfs-repo').repoVersion
@@ -15,39 +16,55 @@ describe('version', () => runOnAndOff((thing) => {
     ipfs = thing.ipfs
   })
 
-  it('get the version', () => {
-    return ipfs('version').then((out) => {
+  it('get the version', () =>
+    ipfs('version').then(out =>
       expect(out).to.eql(
         `js-ipfs version: ${pkgversion}\n`
       )
-    })
-  })
+    )
+  )
 
-  it('handles --number', () => {
-    return ipfs('version --number').then(out =>
+  it('handles --number', () =>
+    ipfs('version --number').then(out =>
       expect(out).to.eql(`${pkgversion}\n`)
     )
-  })
+  )
 
-  it('handles --commit', () => {
-    return ipfs('version --commit').then(out =>
+  it('handles --commit', () =>
+    ipfs('version --commit').then(out =>
       expect(out).to.eql(`js-ipfs version: ${pkgversion}-\n`)
     )
-  })
+  )
 
-  it('handles --all', () => {
-    return ipfs('version --all').then(out =>
-      expect(out).to.include(
-        `js-ipfs version: ${pkgversion}-
-Repo version: ${repoVersion}
-`
+  describe('handles --all', function() {
+    it('prints js-ipfs version', () =>
+      ipfs('version --all').then(out =>
+        expect(out).to.include(`js-ipfs version: ${pkgversion}`)
+      )
+    )
+
+    it('prints repo version', () =>
+      ipfs('version --all').then(out =>
+        expect(out).to.include(`Repo version: ${repoVersion}`)
+      )
+    )
+
+    it('prints arch/platform', () =>
+      ipfs('version --all').then(out =>
+        expect(out).to.include(`System version: ${os.arch()}/${os.platform()}`)
+      )
+    )
+
+    it('prints Node.js version', () =>
+      ipfs('version --all').then(out =>
+        expect(out).to.include(`Node.js version: ${process.version}`)
       )
     )
   })
 
-  it('handles --repo', () => {
-    return ipfs('version --repo').then(out => {
+  it('handles --repo', () =>
+    ipfs('version --repo').then(out =>
       expect(out).to.eql(`${repoVersion}\n`)
-    })
-  })
+    )
+  )
 }))

--- a/test/cli/version.js
+++ b/test/cli/version.js
@@ -4,21 +4,15 @@
 const fs = require('fs')
 const path = require('path')
 const expect = require('chai').expect
+const repoVersion = require('ipfs-repo').repoVersion
 const pkgversion = require('../../package.json').version
 const runOnAndOff = require('../utils/on-and-off')
 
-function getRepoVersion (repoPath) {
-  const versionPath = path.join(repoPath, 'version')
-  return String(fs.readFileSync(versionPath))
-}
-
 describe('version', () => runOnAndOff((thing) => {
   let ipfs
-  let repoVersion
 
   before(() => {
     ipfs = thing.ipfs
-    repoVersion = getRepoVersion(ipfs.repoPath)
   })
 
   it('get the version', () => {

--- a/test/cli/version.js
+++ b/test/cli/version.js
@@ -1,3 +1,4 @@
+/* eslint max-nested-callbacks: ["error", 5] */
 /* eslint-env mocha */
 'use strict'
 
@@ -36,27 +37,27 @@ describe('version', () => runOnAndOff((thing) => {
 
   describe('handles --all', function () {
     it('prints js-ipfs version', () =>
-      ipfs('version --all').then(out =>
+      ipfs('version --all').then(out => {
         expect(out).to.include(`js-ipfs version: ${pkgversion}`)
-      )
+      })
     )
 
     it('prints repo version', () =>
-      ipfs('version --all').then(out =>
+      ipfs('version --all').then(out => {
         expect(out).to.include(`Repo version: ${repoVersion}`)
-      )
+      })
     )
 
     it('prints arch/platform', () =>
-      ipfs('version --all').then(out =>
+      ipfs('version --all').then(out => {
         expect(out).to.include(`System version: ${os.arch()}/${os.platform()}`)
-      )
+      })
     )
 
     it('prints Node.js version', () =>
-      ipfs('version --all').then(out =>
+      ipfs('version --all').then(out => {
         expect(out).to.include(`Node.js version: ${process.version}`)
-      )
+      })
     )
   })
 

--- a/test/cli/version.js
+++ b/test/cli/version.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const fs = require('fs')
 const os = require('os')
-const path = require('path')
 const expect = require('chai').expect
 const repoVersion = require('ipfs-repo').repoVersion
 const pkgversion = require('../../package.json').version
@@ -36,7 +34,7 @@ describe('version', () => runOnAndOff((thing) => {
     )
   )
 
-  describe('handles --all', function() {
+  describe('handles --all', function () {
     it('prints js-ipfs version', () =>
       ipfs('version --all').then(out =>
         expect(out).to.include(`js-ipfs version: ${pkgversion}`)

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -28,7 +28,8 @@ test_expect_success "ipfs version output looks good" '
 
 test_expect_success "ipfs version --all has all required fields" '
 	ipfs version --all > version_all.txt &&
-	grep "js-ipfs version" version_all.txt
+	grep "js-ipfs version" version_all.txt &&
+  grep "Repo version" version_all.txt
 '
 
 test_expect_success "ipfs help succeeds" '

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -29,7 +29,9 @@ test_expect_success "ipfs version output looks good" '
 test_expect_success "ipfs version --all has all required fields" '
 	ipfs version --all > version_all.txt &&
 	grep "js-ipfs version" version_all.txt &&
-  grep "Repo version" version_all.txt
+  grep "Repo version" version_all.txt &&
+	grep "System version" version_all.txt &&
+	grep "Node.js version" version_all.txt
 '
 
 test_expect_success "ipfs help succeeds" '


### PR DESCRIPTION
original: https://github.com/ipfs/js-ipfs/pull/1181

This implements `ipfs repo version` and the `--all`, `--repo`, `--number`, and `--commit` (partially) flags for `ipfs version`.

`ipfs version --all` output looks like:
```
$ js-ipfs version --all
js-ipfs version: 0.27.7-
Repo version: 6
System version: x64/win32
Node.js version: v8.5.0
````

I'm having trouble running sharness tests, am hoping that CI will point out any issues there.

Would love any feedback :)