### PR TITLE
fix(dag): print data in a readable way if it is JSON

### DIFF
--- a/src/cli/commands/dag/get.js
+++ b/src/cli/commands/dag/get.js
@@ -42,7 +42,7 @@ module.exports = {
       if (node._json) {
         delete node._json.multihash
         node._json.data = '0x' + node._json.data.toString('hex')
-        print(node._json)
+        print(JSON.stringify(node._json))
         return
       }
 


### PR DESCRIPTION
If a dag node is JSON, print the stringified version of it, so that
it shows the actual JSON and not just `[object Object]`.