### PR TITLE
Fixed broken link referencing IPFS-Core API docs in example project

### DIFF
--- a/examples/browser-script-tag/index.html
+++ b/examples/browser-script-tag/index.html
@@ -13,7 +13,7 @@
 
       // You can write more code here to use it. Use methods like 
       // node.files.add, node.files.get. See the API docs here:
-      // https://github.com/ipfs/interface-ipfs-core/tree/master/API
+      // https://github.com/ipfs/interface-ipfs-core
     })
   </script>
 </head>


### PR DESCRIPTION
Since this link is not using IPFS, it's broken 😩 . Here is the correct one.