### PR TITLE
Better validation of Multiaddrs in bootstrap command

### DIFF
--- a/src/core/components/bootstrap.js
+++ b/src/core/components/bootstrap.js
@@ -1,22 +1,19 @@
 'use strict'
 
 const defaultNodes = require('../runtime/config-nodejs.json').Bootstrap
-const Multiaddr = require('multiaddr')
+const isMultiaddr = require('mafmt').IPFS.matches
 const promisify = require('promisify-es6')
 
-function isValid (ma) {
-  if (typeof ma === 'string') {
-    try {
-      ma = new Multiaddr(ma)
-      return Boolean(ma)
-    } catch (err) {
-      return false
-    }
-  } else if (ma) {
-    return Multiaddr.isMultiaddr(ma)
-  } else {
+function isValidMultiaddr (ma) {
+  try {
+    return isMultiaddr(ma)
+  } catch (err) {
     return false
   }
+}
+
+function invalidMultiaddrError (ma) {
+  return new Error(`${ma} is not a valid Multiaddr`)
 }
 
 module.exports = function bootstrap (self) {
@@ -35,8 +32,8 @@ module.exports = function bootstrap (self) {
         args = { default: false }
       }
 
-      if (multiaddr && !isValid(multiaddr)) {
-        return setImmediate(() => callback(new Error('Not valid multiaddr')))
+      if (multiaddr && !isValidMultiaddr(multiaddr)) {
+        return setImmediate(() => callback(invalidMultiaddrError(multiaddr)))
       }
 
       self._repo.config.get((err, config) => {
@@ -64,8 +61,8 @@ module.exports = function bootstrap (self) {
         callback = args
         args = {all: false}
       }
-      if (multiaddr && !isValid(multiaddr)) {
-        return setImmediate(() => callback(new Error('Not valid multiaddr')))
+      if (multiaddr && !isValidMultiaddr(multiaddr)) {
+        return setImmediate(() => callback(invalidMultiaddrError(multiaddr)))
       }
 
       self._repo.config.get((err, config) => {

--- a/test/core/bootstrap.spec.js
+++ b/test/core/bootstrap.spec.js
@@ -115,4 +115,13 @@ describe('bootstrap', () => {
       })
     })
   })
+
+  it('fails if passing in a invalid multiaddr', (done) => {
+    node.bootstrap.add('/funky/invalid/multiaddr', (err, res) => {
+      expect(err).to.match(/not a valid Multiaddr/)
+      expect(err).to.match(/funky/)
+      expect(res).to.not.exist()
+      done()
+    })
+  })
 })


### PR DESCRIPTION
mafmt handles both instances of multiaddr and multiaddrs in strings.

isMultiaddr only handles instances of multiaddr.

Demonstration:

```
> const ma = require('multiaddr')

> const mafmt = require('mafmt').IPFS.matches

> mafmt('/ip4/0.0.0.0/tcp/5001/ipfs/Qm')
true

> ma.isMultiaddr('/ip4/0.0.0.0/tcp/5001/ipfs/Qm')
false

> m = ma('/ip4/0.0.0.0/tcp/5001/ipfs/Qm')
<Multiaddr 0400000000061389a503020562 - /ip4/0.0.0.0/tcp/5001/ipfs/Qm>

> mafmt(m)
true

> ma.isMultiaddr(m)
true
```