### PR TITLE
feat: add config validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "is-stream": "^1.1.0",
     "joi": "^13.1.2",
     "joi-browser": "^13.0.1",
-    "joi-ipfs-config": "^1.0.2",
+    "joi-multiaddr": "^1.0.1",
     "libp2p": "~0.18.0",
     "libp2p-circuit": "~0.1.4",
     "libp2p-floodsub": "~0.14.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "./src/core/runtime/repo-nodejs.js": "./src/core/runtime/repo-browser.js",
     "./src/core/runtime/dns-nodejs.js": "./src/core/runtime/dns-browser.js",
     "./test/utils/create-repo-nodejs.js": "./test/utils/create-repo-browser.js",
-    "stream": "readable-stream"
+    "stream": "readable-stream",
+    "joi": "joi-browser"
   },
   "engines": {
     "node": ">=6.0.0",
@@ -119,6 +120,8 @@
     "is-ipfs": "^0.3.2",
     "is-stream": "^1.1.0",
     "joi": "^13.1.2",
+    "joi-browser": "^13.0.1",
+    "joi-ipfs-config": "^1.0.2",
     "libp2p": "~0.18.0",
     "libp2p-circuit": "~0.1.4",
     "libp2p-floodsub": "~0.14.1",

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,0 +1,41 @@
+const Joi = require('joi').extend(require('joi-multiaddr'))
+
+const schema = Joi.object().keys({
+    repo: Joi.alternatives().try(
+      Joi.object(), // TODO: schema for IPFS repo
+      Joi.string()
+    ).allow(null),
+    init: Joi.alternatives().try(
+      Joi.boolean(),
+      Joi.object().keys({ bits: Joi.number().integer() })
+    ).allow(null),
+    start: Joi.boolean(),
+    pass: Joi.string().allow(''),
+    EXPERIMENTAL: Joi.object().keys({
+      pubsub: Joi.boolean(),
+      sharding: Joi.boolean(),
+      dht: Joi.boolean()
+    }).allow(null),
+    config: Joi.object().keys({
+      Addresses: Joi.object().keys({
+        Swarm: Joi.array().items(Joi.multiaddr().options({ convert: false })),
+        API: Joi.multiaddr().options({ convert: false }),
+        Gateway: Joi.multiaddr().options({ convert: false })
+      }).allow(null),
+      Discovery: Joi.object().keys({
+        MDNS: Joi.object().keys({
+          Enabled: Joi.boolean(),
+          Interval: Joi.number().integer()
+        }).allow(null),
+        webRTCStar: Joi.object().keys({
+          Enabled: Joi.boolean()
+        }).allow(null)
+      }).allow(null),
+      Bootstrap: Joi.array().items(Joi.multiaddr().IPFS().options({ convert: false }))
+    }).allow(null),
+    libp2p: Joi.object().keys({
+      modules: Joi.object().allow(null) // TODO: schemas for libp2p modules?
+    }).allow(null)
+  }).options({ allowUnknown: true })
+
+module.exports.validate = (config) => Joi.attempt(config, schema)

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,41 +1,43 @@
+'use strict'
+
 const Joi = require('joi').extend(require('joi-multiaddr'))
 
 const schema = Joi.object().keys({
-    repo: Joi.alternatives().try(
-      Joi.object(), // TODO: schema for IPFS repo
-      Joi.string()
-    ).allow(null),
-    init: Joi.alternatives().try(
-      Joi.boolean(),
-      Joi.object().keys({ bits: Joi.number().integer() })
-    ).allow(null),
-    start: Joi.boolean(),
-    pass: Joi.string().allow(''),
-    EXPERIMENTAL: Joi.object().keys({
-      pubsub: Joi.boolean(),
-      sharding: Joi.boolean(),
-      dht: Joi.boolean()
+  repo: Joi.alternatives().try(
+    Joi.object(), // TODO: schema for IPFS repo
+    Joi.string()
+  ).allow(null),
+  init: Joi.alternatives().try(
+    Joi.boolean(),
+    Joi.object().keys({ bits: Joi.number().integer() })
+  ).allow(null),
+  start: Joi.boolean(),
+  pass: Joi.string().allow(''),
+  EXPERIMENTAL: Joi.object().keys({
+    pubsub: Joi.boolean(),
+    sharding: Joi.boolean(),
+    dht: Joi.boolean()
+  }).allow(null),
+  config: Joi.object().keys({
+    Addresses: Joi.object().keys({
+      Swarm: Joi.array().items(Joi.multiaddr().options({ convert: false })),
+      API: Joi.multiaddr().options({ convert: false }),
+      Gateway: Joi.multiaddr().options({ convert: false })
     }).allow(null),
-    config: Joi.object().keys({
-      Addresses: Joi.object().keys({
-        Swarm: Joi.array().items(Joi.multiaddr().options({ convert: false })),
-        API: Joi.multiaddr().options({ convert: false }),
-        Gateway: Joi.multiaddr().options({ convert: false })
+    Discovery: Joi.object().keys({
+      MDNS: Joi.object().keys({
+        Enabled: Joi.boolean(),
+        Interval: Joi.number().integer()
       }).allow(null),
-      Discovery: Joi.object().keys({
-        MDNS: Joi.object().keys({
-          Enabled: Joi.boolean(),
-          Interval: Joi.number().integer()
-        }).allow(null),
-        webRTCStar: Joi.object().keys({
-          Enabled: Joi.boolean()
-        }).allow(null)
-      }).allow(null),
-      Bootstrap: Joi.array().items(Joi.multiaddr().IPFS().options({ convert: false }))
+      webRTCStar: Joi.object().keys({
+        Enabled: Joi.boolean()
+      }).allow(null)
     }).allow(null),
-    libp2p: Joi.object().keys({
-      modules: Joi.object().allow(null) // TODO: schemas for libp2p modules?
-    }).allow(null)
-  }).options({ allowUnknown: true })
+    Bootstrap: Joi.array().items(Joi.multiaddr().IPFS().options({ convert: false }))
+  }).allow(null),
+  libp2p: Joi.object().keys({
+    modules: Joi.object().allow(null) // TODO: schemas for libp2p modules?
+  }).allow(null)
+}).options({ allowUnknown: true })
 
 module.exports.validate = (config) => Joi.attempt(config, schema)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -11,6 +11,7 @@ const CID = require('cids')
 const debug = require('debug')
 const extend = require('deep-extend')
 const EventEmitter = require('events')
+const Joi = require('joi').extend(require('joi-ipfs-config'))
 
 const boot = require('./boot')
 const components = require('./components')
@@ -27,7 +28,7 @@ class IPFS extends EventEmitter {
       EXPERIMENTAL: {}
     }
 
-    options = options || {}
+    options = Joi.attempt(options || {}, Joi.ipfsConfig())
     this._libp2pModules = options.libp2p && options.libp2p.modules
 
     extend(this._options, options)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -12,7 +12,7 @@ const debug = require('debug')
 const extend = require('deep-extend')
 const EventEmitter = require('events')
 
-const Config = require('./config')
+const config = require('./config')
 const boot = require('./boot')
 const components = require('./components')
 // replaced by repo-browser when running in the browser
@@ -28,7 +28,7 @@ class IPFS extends EventEmitter {
       EXPERIMENTAL: {}
     }
 
-    options = Config.validate(options || {})
+    options = config.validate(options || {})
     this._libp2pModules = options.libp2p && options.libp2p.modules
 
     extend(this._options, options)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -11,8 +11,8 @@ const CID = require('cids')
 const debug = require('debug')
 const extend = require('deep-extend')
 const EventEmitter = require('events')
-const Joi = require('joi').extend(require('joi-ipfs-config'))
 
+const Config = require('./config')
 const boot = require('./boot')
 const components = require('./components')
 // replaced by repo-browser when running in the browser
@@ -28,7 +28,7 @@ class IPFS extends EventEmitter {
       EXPERIMENTAL: {}
     }
 
-    options = Joi.attempt(options || {}, Joi.ipfsConfig())
+    options = Config.validate(options || {})
     this._libp2pModules = options.libp2p && options.libp2p.modules
 
     extend(this._options, options)

--- a/test/core/config.spec.js
+++ b/test/core/config.spec.js
@@ -6,45 +6,45 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
-const Config = require('../../src/core/config')
+const config = require('../../src/core/config')
 
 describe('config', () => {
   it('should allow empty config', () => {
-    const config = {}
-    expect(() => Config.validate(config)).to.not.throw()
+    const cfg = {}
+    expect(() => config.validate(cfg)).to.not.throw()
   })
 
   it('should allow undefined config', () => {
-    const config = undefined
-    expect(() => Config.validate(config)).to.not.throw()
+    const cfg = undefined
+    expect(() => config.validate(cfg)).to.not.throw()
   })
 
   it('should allow unknown key at root', () => {
-    const config = { [`${Date.now()}`]: 'test' }
-    expect(() => Config.validate(config)).to.not.throw()
+    const cfg = { [`${Date.now()}`]: 'test' }
+    expect(() => config.validate(cfg)).to.not.throw()
   })
 
   it('should validate valid repo', () => {
-    const configs = [
+    const cfgs = [
       { repo: { unknown: 'value' } },
       { repo: '/path/to-repo' },
       { repo: null },
       { repo: undefined }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.not.throw())
   })
 
   it('should validate invalid repo', () => {
-    const configs = [
+    const cfgs = [
       { repo: 138 }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.throw())
   })
 
   it('should validate valid init', () => {
-    const configs = [
+    const cfgs = [
       { init: { bits: 138 } },
       { init: { bits: 138, unknown: 'value' } },
       { init: true },
@@ -53,59 +53,59 @@ describe('config', () => {
       { init: undefined }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.not.throw())
   })
 
   it('should validate invalid init', () => {
-    const configs = [
+    const cfgs = [
       { init: 138 },
       { init: { bits: 'not an int' } }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.throw())
   })
 
   it('should validate valid start', () => {
-    const configs = [
+    const cfgs = [
       { start: true },
       { start: false },
       { start: undefined }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.not.throw())
   })
 
   it('should validate invalid start', () => {
-    const configs = [
+    const cfgs = [
       { start: 138 },
       { start: 'make it so number 1' },
       { start: null }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.throw())
   })
 
   it('should validate valid pass', () => {
-    const configs = [
+    const cfgs = [
       { pass: 'correctbatteryhorsestaple' },
       { pass: '' },
       { pass: undefined }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.not.throw())
   })
 
   it('should validate invalid pass', () => {
-    const configs = [
+    const cfgs = [
       { pass: 138 },
       { pass: null }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.throw())
   })
 
   it('should validate valid EXPERIMENTAL', () => {
-    const configs = [
+    const cfgs = [
       { EXPERIMENTAL: { pubsub: true, dht: true, sharding: true } },
       { EXPERIMENTAL: { pubsub: false, dht: false, sharding: false } },
       { EXPERIMENTAL: { unknown: 'value' } },
@@ -113,21 +113,21 @@ describe('config', () => {
       { EXPERIMENTAL: undefined }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.not.throw())
   })
 
   it('should validate invalid EXPERIMENTAL', () => {
-    const configs = [
+    const cfgs = [
       { EXPERIMENTAL: { pubsub: 138 } },
       { EXPERIMENTAL: { dht: 138 } },
       { EXPERIMENTAL: { sharding: 138 } }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.throw())
   })
 
   it('should validate valid config', () => {
-    const configs = [
+    const cfgs = [
       { config: { Addresses: { Swarm: ['/ip4/0.0.0.0/tcp/4002'] } } },
       { config: { Addresses: { Swarm: [] } } },
       { config: { Addresses: { Swarm: undefined } } },
@@ -167,11 +167,11 @@ describe('config', () => {
       { config: undefined }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.not.throw())
   })
 
   it('should validate invalid config', () => {
-    const configs = [
+    const cfgs = [
       { config: { Addresses: { Swarm: 138 } } },
       { config: { Addresses: { Swarm: null } } },
 
@@ -192,11 +192,11 @@ describe('config', () => {
       { config: 138 }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.throw())
   })
 
   it('should validate valid libp2p', () => {
-    const configs = [
+    const cfgs = [
       { libp2p: { modules: {} } },
       { libp2p: { modules: { unknown: 'value' } } },
       { libp2p: { modules: null } },
@@ -206,15 +206,15 @@ describe('config', () => {
       { libp2p: undefined }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.not.throw())
   })
 
   it('should validate invalid libp2p', () => {
-    const configs = [
+    const cfgs = [
       { libp2p: { modules: 138 } },
       { libp2p: 138 }
     ]
 
-    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+    cfgs.forEach(cfg => expect(() => config.validate(cfg)).to.throw())
   })
 })

--- a/test/core/config.spec.js
+++ b/test/core/config.spec.js
@@ -1,0 +1,220 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+const Config = require('../../src/core/config')
+
+describe.only('config', () => {
+  it('should allow empty config', () => {
+    const config = {}
+    expect(() => Config.validate(config)).to.not.throw()
+  })
+
+  it('should allow undefined config', () => {
+    const config = undefined
+    expect(() => Config.validate(config)).to.not.throw()
+  })
+
+  it('should allow unknown key at root', () => {
+    const config = { [`${Date.now()}`]: 'test' }
+    expect(() => Config.validate(config)).to.not.throw()
+  })
+
+  it('should validate valid repo', () => {
+    const configs = [
+      { repo: { unknown: 'value' } },
+      { repo: '/path/to-repo' },
+      { repo: null },
+      { repo: undefined }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+  })
+
+  it('should validate invalid repo', () => {
+    const configs = [
+      { repo: 138 }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+  })
+
+  it('should validate valid init', () => {
+    const configs = [
+      { init: { bits: 138 } },
+      { init: { bits: 138, unknown: 'value' } },
+      { init: true },
+      { init: false },
+      { init: null },
+      { init: undefined }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+  })
+
+  it('should validate invalid init', () => {
+    const configs = [
+      { init: 138 },
+      { init: { bits: 'not an int' } }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+  })
+
+  it('should validate valid start', () => {
+    const configs = [
+      { start: true },
+      { start: false },
+      { start: undefined }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+  })
+
+  it('should validate invalid start', () => {
+    const configs = [
+      { start: 138 },
+      { start: 'make it so number 1' },
+      { start: null }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+  })
+
+  it('should validate valid pass', () => {
+    const configs = [
+      { pass: 'correctbatteryhorsestaple' },
+      { pass: '' },
+      { pass: undefined }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+  })
+
+  it('should validate invalid pass', () => {
+    const configs = [
+      { pass: 138 },
+      { pass: null }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+  })
+
+  it('should validate valid EXPERIMENTAL', () => {
+    const configs = [
+      { EXPERIMENTAL: { pubsub: true, dht: true, sharding: true } },
+      { EXPERIMENTAL: { pubsub: false, dht: false, sharding: false } },
+      { EXPERIMENTAL: { unknown: 'value' } },
+      { EXPERIMENTAL: null },
+      { EXPERIMENTAL: undefined }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+  })
+
+  it('should validate invalid EXPERIMENTAL', () => {
+    const configs = [
+      { EXPERIMENTAL: { pubsub: 138 } },
+      { EXPERIMENTAL: { dht: 138 } },
+      { EXPERIMENTAL: { sharding: 138 } }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+  })
+
+  it('should validate valid config', () => {
+    const configs = [
+      { config: { Addresses: { Swarm: ['/ip4/0.0.0.0/tcp/4002'] } } },
+      { config: { Addresses: { Swarm: [] } } },
+      { config: { Addresses: { Swarm: undefined } } },
+
+      { config: { Addresses: { API: '/ip4/127.0.0.1/tcp/5002' } } },
+      { config: { Addresses: { API: undefined } } },
+
+      { config: { Addresses: { Gateway: '/ip4/127.0.0.1/tcp/9090' } } },
+      { config: { Addresses: { Gateway: undefined } } },
+
+      { config: { Addresses: { unknown: 'value' } } },
+      { config: { Addresses: null } },
+      { config: { Addresses: undefined } },
+
+      { config: { Discovery: { MDNS: { Enabled: true } } } },
+      { config: { Discovery: { MDNS: { Enabled: false } } } },
+      { config: { Discovery: { MDNS: { Interval: 138 } } } },
+      { config: { Discovery: { MDNS: { unknown: 'value' } } } },
+      { config: { Discovery: { MDNS: null } } },
+      { config: { Discovery: { MDNS: undefined } } },
+
+      { config: { Discovery: { webRTCStar: { Enabled: true } } } },
+      { config: { Discovery: { webRTCStar: { Enabled: false } } } },
+      { config: { Discovery: { webRTCStar: { unknown: 'value' } } } },
+      { config: { Discovery: { webRTCStar: null } } },
+      { config: { Discovery: { webRTCStar: undefined } } },
+
+      { config: { Discovery: { unknown: 'value' } } },
+      { config: { Discovery: null } },
+      { config: { Discovery: undefined } },
+
+      { config: { Bootstrap: ['/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'] } },
+      { config: { Bootstrap: [] } },
+
+      { config: { unknown: 'value' } },
+      { config: null },
+      { config: undefined }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+  })
+
+  it('should validate invalid config', () => {
+    const configs = [
+      { config: { Addresses: { Swarm: 138 } } },
+      { config: { Addresses: { Swarm: null } } },
+
+      { config: { Addresses: { API: 138 } } },
+      { config: { Addresses: { API: null } } },
+
+      { config: { Addresses: { Gateway: 138 } } },
+      { config: { Addresses: { Gateway: null } } },
+
+      { config: { Discovery: { MDNS: { Enabled: 138 } } } },
+      { config: { Discovery: { MDNS: { Interval: true } } } },
+
+      { config: { Discovery: { webRTCStar: { Enabled: 138 } } } },
+
+      { config: { Bootstrap: ['/ip4/0.0.0.0/tcp/4002'] } },
+      { config: { Bootstrap: 138 } },
+
+      { config: 138 }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+  })
+
+  it('should validate valid libp2p', () => {
+    const configs = [
+      { libp2p: { modules: {} } },
+      { libp2p: { modules: { unknown: 'value' } } },
+      { libp2p: { modules: null } },
+      { libp2p: { modules: undefined } },
+      { libp2p: { unknown: 'value' } },
+      { libp2p: null },
+      { libp2p: undefined }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.not.throw())
+  })
+
+  it('should validate invalid libp2p', () => {
+    const configs = [
+      { libp2p: { modules: 138 } },
+      { libp2p: 138 }
+    ]
+
+    configs.forEach(c => expect(() => Config.validate(c)).to.throw())
+  })
+})

--- a/test/core/config.spec.js
+++ b/test/core/config.spec.js
@@ -8,7 +8,7 @@ chai.use(dirtyChai)
 
 const Config = require('../../src/core/config')
 
-describe.only('config', () => {
+describe('config', () => {
   it('should allow empty config', () => {
     const config = {}
     expect(() => Config.validate(config)).to.not.throw()


### PR DESCRIPTION
This PR validates config options passed to IPFS and throws immediately if they are not as expected.

This is a proposal to fix #1193.

We use `joi` to validate config as it's expressive and already included in the project. It's also the best validation library I've come across.

I've verified the config objects used in all the tests work but **I can't say for sure if this is a breaking change or not so you should probably regard it as one when releasing**.

The idea is that the validation should be flexible and shouldn't block new features landing in JS-IPFS. Validation of values that are objects **allows for unknown keys** so that features can land, and validation for the config can be backfilled at a later date if needs be.

I've also configured the `browser` field in `package.json` to use `joi-browser`.
