### PR TITLE
Less Crashy gateway. catch stream2 error

### DIFF
--- a/src/http/gateway/resources/gateway.js
+++ b/src/http/gateway/resources/gateway.js
@@ -98,6 +98,10 @@ module.exports = {
         //  response.continue()
         let filetypeChecked = false
         let stream2 = new Stream.PassThrough({ highWaterMark: 1 })
+        stream2.on('error', (err) => {
+          log.error('stream2 err: ', err)
+        })
+
         let response = reply(stream2).hold()
 
         pull(


### PR DESCRIPTION
This catches the following error. which results in a less crashy gateway as mentioned here https://github.com/ipfs/js-ipfs/issues/804#issuecomment-369912316

```bash
 Error: write after end
    at writeAfterEnd (/media/op/w3/js-ipfs/node_modules/readable-stream/lib/_stream_writable.js:288:12)
    at PassThrough.Writable.write (/media/op/w3/js-ipfs/node_modules/readable-stream/lib/_stream_writable.js:332:20)
    at pull.through (/media/op/w3/js-ipfs/src/http/gateway/resources/gateway.js:134:21)
    at /media/op/w3/js-ipfs/node_modules/pull-stream/throughs/through.js:17:24
    at drain (/media/op/w3/js-ipfs/node_modules/stream-to-pull-stream/index.js:141:18)
    at Stream.<anonymous> (/media/op/w3/js-ipfs/node_modules/stream-to-pull-stream/index.js:150:5)
    at Stream.emit (events.js:159:13)
    at next (/media/op/w3/js-ipfs/node_modules/pull-stream-to-stream/index.js:120:13)
    at /media/op/w3/js-ipfs/node_modules/pull-stream/throughs/map.js:19:9
    at /media/op/w3/js-ipfs/node_modules/pull-traverse/index.js:42:7
```
License: MIT
Signed-off-by: Yahya <ya7yaz@gmail.com>