### PR TITLE
fix: reinstates the non local block check in dht.provide

### DIFF
--- a/src/core/components/dht.js
+++ b/src/core/components/dht.js
@@ -121,11 +121,10 @@ module.exports = (self) => {
         if (err) {
           return callback(err)
         }
-        /* TODO reconsider this. go-ipfs provides anyway
+
         if (!has) {
-          return callback(new Error('Not all blocks exist locally, can not provide'))
+          return callback(new Error('block(s) not found locally, cannot provide'))
         }
-        */
 
         if (options.recursive) {
           // TODO: Implement recursive providing


### PR DESCRIPTION
This PR reinstates the non local block check in `dht.provide` to mirror the functionality of go-ipfs.

Please see [this discussion](https://github.com/ipfs/interface-ipfs-core/pull/221#issuecomment-370938018) for the context.