### PR TITLE
docs: added some small verbage to the README for "Resolve through IPLD grap…

### DIFF
--- a/examples/traverse-ipld-graphs/README.md
+++ b/examples/traverse-ipld-graphs/README.md
@@ -18,6 +18,9 @@ This tutorial goes through several operations over IPLD graphs using the [DAG AP
 ## [traverse through a slice of the ethereum blockchain](./eth.js)
 
 ## [traverse through a git repo](./git.js)
+The example objects contained in "git-objects" have already been decompressed with zlib.  An example of how to do this:
+
+    $ cat .git/objects/7d/df25817f57c2090a9568cdb17106a76dad7d04 | zlib-flate -uncompress > 7ddf25817f57c2090a9568cdb17106a76dad7d04 
 
 ## Video of the demos
 


### PR DESCRIPTION
datafatmunger vmx & daviddias i realized the folly of my earlier attempts of the ipld git tutorial was that the files in the git-objects directory of the example have already been decompressed via zlib ... i should have cat'd those files hours ago, but since they have hash names i assumed they came strait out of .git/objects :-P
daviddias datafatmunger: oh, that should be part of the README of the example. Wanna add that step?
vmx datafatmunger: do i understand correctly that git objects or compressed by default and you need to uncompress them before you use them with ipfs/ipld?
datafatmunger yes they are compressed by default ...
...
datafatmunger and need to be decompressed before the tutorial
datafatmunger the plugin method i used from magik6k, however ... does do the zlib step
datafatmunger ipfs dag put -f git --input-enc zlib .git/objects/7d/df2..
datafatmunger in any case: cat df25817f57c2090a9568cdb17106a76dad7d04 | zlib-flate -uncompress  gitobject
datafatmunger will give a text file format that works with your tutorial
...
datafatmunger daviddias i'll try to make a pr for the readme
