### PR TITLE
fix bug: node.files.add do not accept object

### DIFF
--- a/examples/ipfs-101/1.js
+++ b/examples/ipfs-101/1.js
@@ -9,22 +9,26 @@ let fileMultihash
 series([
   (cb) => node.on('ready', cb),
   (cb) => node.version((err, version) => {
-    if (err) { return cb(err) }
+    if (err) {
+      return cb(err)
+    }
     console.log('Version:', version.version)
     cb()
   }),
-  (cb) => node.files.add({
-    path: 'hello.txt',
-    content: Buffer.from('Hello World 101')
-  }, (err, filesAdded) => {
-    if (err) { return cb(err) }
-
-    console.log('\nAdded file:', filesAdded[0].path, filesAdded[0].hash)
-    fileMultihash = filesAdded[0].hash
-    cb()
-  }),
+  (cb) => node.files.add(
+    Buffer.from('Hello World 101'),
+    (err, filesAdded) => {
+      if (err) {
+        return cb(err)
+      }
+      console.log('\nAdded file:', filesAdded[0].path, filesAdded[0].hash)
+      fileMultihash = filesAdded[0].hash
+      cb()
+    }),
   (cb) => node.files.cat(fileMultihash, (err, data) => {
-    if (err) { return cb(err) }
+    if (err) {
+      return cb(err)
+    }
 
     console.log('\nFile content:')
     process.stdout.write(data)


### PR DESCRIPTION
file: src\core\components\files.js
line: 199
api: add
problem: add api's param do not accept object, use Buffer instead