### PR TITLE
fix: accept objects in file.add

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "hapi-set-header": "^1.0.2",
     "hoek": "^5.0.3",
     "human-to-milliseconds": "^1.0.0",
-    "ipfs-api": "^18.1.1",
+    "ipfs-api": "^18.1.2",
     "ipfs-bitswap": "~0.19.0",
     "ipfs-block": "~0.6.1",
     "ipfs-block-service": "~0.13.0",

--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -193,7 +193,8 @@ module.exports = function files (self) {
       const ok = Buffer.isBuffer(data) ||
                  isStream.readable(data) ||
                  Array.isArray(data) ||
-                 OtherBuffer.isBuffer(data)
+                 OtherBuffer.isBuffer(data) ||
+                 typeof data === 'object'
 
       if (!ok) {
         return callback(new Error('Invalid arguments, data must be an object, Buffer or readable stream'))

--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -190,8 +190,6 @@ module.exports = function files (self) {
         callback = noop
       }
 
-      console.log('typeof', typeof data)
-
       const ok = Buffer.isBuffer(data) ||
                  isStream.readable(data) ||
                  Array.isArray(data) ||

--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -190,6 +190,8 @@ module.exports = function files (self) {
         callback = noop
       }
 
+      console.log('typeof', typeof data)
+
       const ok = Buffer.isBuffer(data) ||
                  isStream.readable(data) ||
                  Array.isArray(data) ||
@@ -197,7 +199,7 @@ module.exports = function files (self) {
                  typeof data === 'object'
 
       if (!ok) {
-        return callback(new Error('Invalid arguments, data must be an object, Buffer or readable stream'))
+        return callback(new Error('first arg must be a buffer, readable stream, an object or array of objects'))
       }
 
       pull(


### PR DESCRIPTION
Adding back ability to pass objects to `files.add` - `{path: <string>, data: Buffer.from('hello')}`. This regressed in 4b79066b924b8e8bf7f8a0fde0da40c3c1b84f31