### PR TITLE
Describe when and why to use `init: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,8 @@ const repo = <IPFS Repo instance or repo path>
 const node = new IPFS({
   repo: repo,
   init: true, // default
-  // init: false, // If you have already initialized the repo via `new IPFS()`.
-  //              // Be careful using this on an IPFSRepo instance you have
-  //              // initialized yourself -- the IPFS constructor initializes
-  //              // repos with extra options, so calling `init()` on an
-  //              // IPFSRepo may not always be compatible with IPFS.
+  // init: false, // You will need to set init: false after time you start instantiate a node as
+  //              // the repo will be already initiated then.
   // init: {
   //   bits: 1024 // size of the RSA key generated
   // },

--- a/README.md
+++ b/README.md
@@ -194,7 +194,11 @@ const repo = <IPFS Repo instance or repo path>
 const node = new IPFS({
   repo: repo,
   init: true, // default
-  // init: false,
+  // init: false, // If you have already initialized the repo via `new IPFS()`.
+  //              // Be careful using this on an IPFSRepo instance you have
+  //              // initialized yourself -- the IPFS constructor initializes
+  //              // repos with extra options, so calling `init()` on an
+  //              // IPFSRepo may not always be compatible with IPFS.
   // init: {
   //   bits: 1024 // size of the RSA key generated
   // },


### PR DESCRIPTION
This adds some description to the "advanced options" documentation for the `IPFS` constructor detailing that `init: false` should really be used if a repo has already been initialized *by IPFS* and that simply calling `repoInstance.init()` doesn't init a repo with everything IPFS needs.

This partially handles #1245, but other parts of the experience (e.g. #1262) could also be improved.

Does this help clarify things? Or is it too confusing?

Is there anywhere else these options are documented that I need to update? (I couldn’t find anywhere, but I wouldn’t be surprised if I missed something.)