### PR TITLE
chore: update ipfsd-ctl to use smaller key size for daemon tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "go-ipfs-dep": "^0.4.13",
     "hat": "0.0.3",
     "interface-ipfs-core": "~0.52.0",
-    "ipfsd-ctl": "~0.29.1",
+    "ipfsd-ctl": "~0.30.1",
     "left-pad": "^1.2.0",
     "lodash": "^4.17.5",
     "mocha": "^5.0.1",


### PR DESCRIPTION
Let's see if this -- https://github.com/ipfs/js-ipfsd-ctl/pull/215 -- makes things faster.