### PR TITLE
docs: add a npm header in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ You can check the development status at the [Waffle Board](https://waffle.io/ipf
 
 ## Install
 
+### npm
+
 This project is available through [npm](https://www.npmjs.com/). To install run
 
 ```bash


### PR DESCRIPTION
In the Table of Contents, there is a link of npm.
But it did't work, because npm wasn't a header.
It's necessary to add a npm header to work a link of it well.