### PR TITLE
feat: show which link does not exist on ipfs.cat

### DIFF
--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -131,7 +131,7 @@ module.exports = function files (self) {
       throw new Error('You must supply an ipfsPath')
     }
 
-    let bestMatch = 0
+    let bestMatch = { depth: -1 }
 
     ipfsPath = normalizePath(ipfsPath)
     const pathComponents = ipfsPath.split('/')
@@ -139,10 +139,8 @@ module.exports = function files (self) {
     const restPath = normalizePath(pathComponents.slice(1).join('/'))
     const filterFile = (file) => {
       if (file.path === ipfsPath.substring(0, file.path.length)) {
-        const matchedNodes = file.path.split('/').length
-
-        if (matchedNodes > bestMatch) {
-          bestMatch = matchedNodes
+        if (file.depth > bestMatch.depth) {
+          bestMatch = file
         }
       }
 
@@ -159,9 +157,9 @@ module.exports = function files (self) {
           files = files.filter(filterFile)
         }
         if (!files || !files.length) {
-          const parent = pathComponents.slice(0, bestMatch).join('/')
-          const link = pathComponents.slice(bestMatch).join('/')
-          return d.abort(new Error(`no link named "${link}" under ${parent}`))
+          const hash = toB58String(bestMatch.hash)
+          const link = pathComponents[bestMatch.depth + 1]
+          return d.abort(new Error(`no link named "${link}" under ${hash}`))
         }
 
         const file = files[0]

--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -146,7 +146,7 @@ module.exports = function files (self) {
           files = files.filter(filterFile)
         }
         if (!files || !files.length) {
-          return d.abort(new Error('No such file'))
+          return d.abort(new Error(`no link named "${restPath}" under ${pathComponents[0]}`))
         }
 
         const file = files[0]

--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -135,6 +135,7 @@ module.exports = function files (self) {
 
     ipfsPath = normalizePath(ipfsPath)
     const pathComponents = ipfsPath.split('/')
+    const prePath = normalizePath(pathComponents.slice(0, 1).join('/'))
     const restPath = normalizePath(pathComponents.slice(1).join('/'))
     const filterFile = (file) => {
       if (file.path === ipfsPath.substring(0, file.path.length)) {
@@ -151,10 +152,10 @@ module.exports = function files (self) {
     const d = deferred.source()
 
     pull(
-      exporter(pathComponents[0], self._ipld),
+      exporter(prePath, self._ipld),
       pull.collect((err, files) => {
         if (err) { return d.abort(err) }
-        if (files && files.length > 1) {
+        if (files) {
           files = files.filter(filterFile)
         }
         if (!files || !files.length) {

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -319,13 +319,13 @@ describe('files', () => runOnAndOff((thing) => {
   })
 
   it('cat non-existent file', () => {
-    return ipfs('cat QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB/dummy')
+    return ipfs('cat QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU/dummy')
       .then(() => expect.fail(0, 1, 'Should have thrown an error'))
       .catch((err) => {
         const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
         expect(err).to.exist()
         expect(message).to.eql(
-          'no link named "dummy" under QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB'
+          'no file named "dummy" under QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU'
         )
       })
   })
@@ -336,7 +336,7 @@ describe('files', () => runOnAndOff((thing) => {
       .catch((err) => {
         const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
         expect(message).to.eql(
-          'no link named "wrong-dir" under QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC'
+          'no directory named "wrong-dir" under QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2/init-docs/docs'
         )
       })
   })
@@ -347,7 +347,18 @@ describe('files', () => runOnAndOff((thing) => {
       .catch((err) => {
         const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
         expect(message).to.eql(
-          'no link named "dummy" under QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC'
+          'no file named "dummy" under QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2/init-docs/docs'
+        )
+      })
+  })
+
+  it('cat specifies a link is not a directory', () => {
+    return ipfs('cat QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2/init-docs/docs/index/dummy')
+      .then(() => expect.fail(0, 1, 'Should have thrown an error'))
+      .catch((err) => {
+        const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
+        expect(message).to.eql(
+          '"index" is a file not a directory under QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2/init-docs/docs'
         )
       })
   })

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -322,7 +322,11 @@ describe('files', () => runOnAndOff((thing) => {
     return ipfs('cat QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB/dummy')
       .then(() => expect.fail(0, 1, 'Should have thrown an error'))
       .catch((err) => {
+        const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
         expect(err).to.exist()
+        expect(message).to.eql(
+          'no link named "dummy" under QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB'
+        )
       })
   })
 

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -330,6 +330,20 @@ describe('files', () => runOnAndOff((thing) => {
       })
   })
 
+  it('cat specifies missing link in a nested directory', function () {
+    this.timeout(20 * 1000)
+    
+    return ipfs('cat QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU/docs/wrongdir/dummy')
+      .then(() => expect.fail(0, 1, 'Should have thrown an error'))
+      .catch((err) => {
+        const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
+        expect(err).to.exist()
+        expect(message).to.eql(
+          'no link named "wrongdir/dummy" under QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU/docs'
+        )
+      })
+  })
+
   it('get', function () {
     this.timeout(20 * 1000)
 

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -330,16 +330,24 @@ describe('files', () => runOnAndOff((thing) => {
       })
   })
 
-  it('cat specifies missing link in a nested directory', function () {
-    this.timeout(20 * 1000)
-    
-    return ipfs('cat QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU/docs/wrongdir/dummy')
+  it('cat specifies missing directory in a nested link', () => {
+    return ipfs('cat QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2/init-docs/docs/wrong-dir/dummy')
       .then(() => expect.fail(0, 1, 'Should have thrown an error'))
       .catch((err) => {
         const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
-        expect(err).to.exist()
         expect(message).to.eql(
-          'no link named "wrongdir/dummy" under QmUhUuiTKkkK8J6JZ9zmj8iNHPuNfGYcszgRumzhHBxEEU/docs'
+          'no link named "wrong-dir" under QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC'
+        )
+      })
+  })
+
+  it('cat specifies missing file in a nested link', () => {
+    return ipfs('cat QmYmW4HiZhotsoSqnv2o1oUusvkRM8b9RweBoH7ao5nki2/init-docs/docs/dummy')
+      .then(() => expect.fail(0, 1, 'Should have thrown an error'))
+      .catch((err) => {
+        const message = err.stderr.match(/^Error:(?: Failed to cat file: Error:)? (.*)$/m)[1]
+        expect(message).to.eql(
+          'no link named "dummy" under QmegvLXxpVKiZ4b57Xs1syfBVRd8CbucVHAp7KpLQdGieC'
         )
       })
   })


### PR DESCRIPTION
Closes #1145.

For `interface-ipfs-core` test to pass, the corresponding test there needs to be updated to be similar to below as one version of running tests has an error message prepended with `Failed to cat file: Error:`, causing the test to fail.

```javascript
expect(err.message).to.contain(
  'no link named "does-not-exist" under Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'
)
```