### PR TITLE
cli: add IPFS_PATH info to init command help

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -5,23 +5,30 @@ const IPFS = require('../../core')
 const utils = require('../utils')
 const print = utils.print
 
+const ipfsPathHelp = 'ipfs uses a repository in the local file system. By default, the repo is ' +
+  'located at ~/.ipfs.\nTo change the repo location, set the $IPFS_PATH environment variable:\n\n' +
+  '\texport IPFS_PATH=/path/to/ipfsrepo\n'
+
 module.exports = {
   command: 'init',
 
   describe: 'Initialize a local IPFS node',
 
-  builder: {
-    bits: {
-      type: 'number',
-      alias: 'b',
-      default: '2048',
-      describe: 'Number of bits to use in the generated RSA private key (defaults to 2048)'
-    },
-    emptyRepo: {
-      alias: 'e',
-      type: 'boolean',
-      describe: "Don't add and pin help files to the local storage"
-    }
+  builder (yargs) {
+    print(ipfsPathHelp)
+
+    return yargs
+      .option('bits', {
+        type: 'number',
+        alias: 'b',
+        default: '2048',
+        describe: 'Number of bits to use in the generated RSA private key (defaults to 2048)'
+      })
+      .option('emptyRepo', {
+        alias: 'e',
+        type: 'boolean',
+        describe: "Don't add and pin help files to the local storage"
+      })
   },
 
   handler (argv) {


### PR DESCRIPTION
Connects to https://github.com/ipfs/js-ipfs/issues/1213.

I tried using .usage() from the yargs package, but it just seems to be a different way of doing normal yargs configuration (no special ability to add a prologue).