### PR TITLE
fix: init event

### DIFF
--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -32,6 +32,7 @@ module.exports = (self) => {
       (cb) => {
         self.log('initialized')
         self.state.initialized()
+        self.emit('init');
         cb(null, true)
       }
     ], (err, res) => {

--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -32,7 +32,7 @@ module.exports = (self) => {
       (cb) => {
         self.log('initialized')
         self.state.initialized()
-        self.emit('init');
+        self.emit('init')
         cb(null, true)
       }
     ], (err, res) => {

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -22,6 +22,7 @@ module.exports = function init (self) {
         return callback(err)
       }
 
+      self.log('initialized')
       self.state.initialized()
       self.emit('init')
       callback(null, res)


### PR DESCRIPTION
For https://github.com/ipfs/js-ipfs/issues/1058

The init event was only being emitted during initialization of
a new repo.  If one already existed that event was not firing.
This syncs up the behavior between these two situations so that they
log, set state, and emit identically.