### PR TITLE
feat: ping

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "progress": "^2.0.0",
     "promisify-es6": "^1.0.3",
     "pull-abortable": "^4.1.1",
+    "pull-catch": "^1.0.0",
     "pull-defer": "^0.2.2",
     "pull-file": "^1.1.0",
     "pull-ndjson": "^0.1.1",

--- a/src/cli/commands/ping.js
+++ b/src/cli/commands/ping.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const print = require('../utils').print
+
+module.exports = {
+  command: 'ping <peerId>',
+
+  describe: 'Measure the latency of a connection',
+
+  builder: {
+    count: {
+      alias: 'n',
+      type: 'integer',
+      default: 10
+    }
+  },
+
+  handler (argv) {
+    const peerId = argv.peerId
+    const count = argv.count || 10
+
+    print('PING ' + peerId)
+
+    let noOfTimes = 0
+    let totalTime = 0
+
+    const pingCb = (err, p) => {
+      if (err) {
+        throw err
+      }
+      let time = p.Time
+      totalTime = totalTime + time
+      noOfTimes = noOfTimes + 1
+      print('Pong received: time=' + time + ' ms')
+      if (noOfTimes === count) {
+        print('Average latency: ' + totalTime / count + 'ms')
+      }
+    }
+
+    for (let i = 0; i < count; i++) {
+      argv.ipfs.ping(peerId, pingCb)
+    }
+  }
+}

--- a/src/cli/commands/ping.js
+++ b/src/cli/commands/ping.js
@@ -26,7 +26,7 @@ module.exports = {
     pull(
       argv.ipfs.pingPullStream(peerId, { count }),
       pullCatch(err => {
-        throw err 
+        throw err
       }),
       drain(({ Time, Text }) => {
         // Check if it's a pong

--- a/src/cli/commands/ping.js
+++ b/src/cli/commands/ping.js
@@ -22,7 +22,6 @@ module.exports = {
   handler (argv) {
     const peerId = argv.peerId
     const count = argv.count || 10
-
     pull(
       argv.ipfs.pingPullStream(peerId, { count }),
       pullCatch(err => {

--- a/src/cli/commands/ping.js
+++ b/src/cli/commands/ping.js
@@ -9,7 +9,7 @@ const print = require('../utils').print
 module.exports = {
   command: 'ping <peerId>',
 
-  describe: 'Measure the latency of a connection',
+  description: 'Measure the latency of a connection',
 
   builder: {
     count: {

--- a/src/core/components/ping.js
+++ b/src/core/components/ping.js
@@ -1,9 +1,35 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const OFFLINE_ERROR = require('../utils').OFFLINE_ERROR
+const PeerId = require('peer-id')
+const PeerInfo = require('peer-info')
+var Readable = require('stream').Readable
 
 module.exports = function ping (self) {
-  return promisify((callback) => {
-    callback(new Error('Not implemented'))
+  return promisify((peerId, cb) => {
+    if (!self.isOnline()) {
+      return cb(new Error(OFFLINE_ERROR))
+    }
+
+    var outputStream = new Readable()
+    outputStream._read = function (size) {
+    }
+
+    let peer
+    try {
+      peer = self._libp2pNode.peerBook.get(peerId)
+    } catch (err) {
+      peer = new PeerInfo(PeerId.createFromB58String(peerId))
+    }
+
+    self._libp2pNode.ping(peer, (err, p) => {
+      p.once('ping', (time) => {
+        outputStream.push(JSON.stringify([{}, { Success: true, Time: time }, { Text: 'Average latency: ' + time + ' ms' }]))
+        outputStream.push(null)
+        p.stop()
+        cb(err, outputStream)
+      })
+    })
   })
 }

--- a/src/core/components/ping.js
+++ b/src/core/components/ping.js
@@ -50,12 +50,10 @@ function getPeer (libp2pNode, statusStream, peerId, cb) {
     console.log(peer)
     return cb(null, peer)
   } catch (err) {
-    // Check if we have support for peerRouting
-    if (!libp2pNode.peerRouting) {
-      return cb(new Error('Peer not found in peer book and no peer routing mechanism enabled'))
-    }
+    log('Peer not found in peer book, trying peer routing')
     // Share lookup status just as in the go implemmentation
     statusStream.push(getPacket({Success: true, Text: `Looking up peer ${peerId}`}))
+    // Try to use peerRouting
     libp2pNode.peerRouting.findPeer(peerId, cb)
   }
 }

--- a/src/core/components/ping.js
+++ b/src/core/components/ping.js
@@ -48,7 +48,7 @@ module.exports = function ping (self) {
         return source.end(err)
       }
 
-      let packetCount = 0 
+      let packetCount = 0
       let totalTime = 0
       source.push(getPacket({Success: true, Text: `PING ${peerId}`}))
 
@@ -57,7 +57,7 @@ module.exports = function ping (self) {
         totalTime += time
         packetCount++
         if (packetCount >= count) {
-          const average = totalTime/count
+          const average = totalTime / count
           p.stop()
           source.push(getPacket({ Success: true, Text: `Average latency: ${average}ms` }))
           source.end()
@@ -73,7 +73,7 @@ module.exports = function ping (self) {
 
       p.start()
     })
-    
+
     cb(null, response)
   })
 }

--- a/src/core/components/ping.js
+++ b/src/core/components/ping.js
@@ -4,32 +4,51 @@ const promisify = require('promisify-es6')
 const OFFLINE_ERROR = require('../utils').OFFLINE_ERROR
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-var Readable = require('stream').Readable
+const Readable = require('readable-stream').Readable
+
+function getPacket (msg) {
+  // Default msg
+  const basePacket = {Success: false, Time: 0, Text: ''}
+  // ndjson
+  return `${JSON.stringify(Object.assign({}, basePacket, msg))}\n`
+}
 
 module.exports = function ping (self) {
-  return promisify((peerId, cb) => {
+  return promisify((peerId, count, cb) => {
     if (!self.isOnline()) {
       return cb(new Error(OFFLINE_ERROR))
     }
 
-    var outputStream = new Readable()
-    outputStream._read = function (size) {
-    }
+    const source = new Readable({
+      read: function () {}
+    })
 
     let peer
     try {
       peer = self._libp2pNode.peerBook.get(peerId)
     } catch (err) {
+      // Conforming with go implemmentation, not sure if makes sense to log this
+      // since we perform no `findPeer`
+      source.push(getPacket({Success: true, Text: `Looking up peer ${peerId}`}))
       peer = new PeerInfo(PeerId.createFromB58String(peerId))
     }
 
     self._libp2pNode.ping(peer, (err, p) => {
-      p.once('ping', (time) => {
-        outputStream.push(JSON.stringify([{}, { Success: true, Time: time }, { Text: 'Average latency: ' + time + ' ms' }]))
-        outputStream.push(null)
-        p.stop()
-        cb(err, outputStream)
+      let packetCount = 0 
+      let totalTime = 0
+      source.push(getPacket({Success: true, Text: `PING ${peerId}`}))
+      p.on('ping', (time) => {
+        source.push(getPacket({ Success: true, Time: time }))
+        totalTime += time
+        packetCount++
+        if (packetCount >= count) {
+          const average = totalTime/count
+          p.stop()
+          source.push(getPacket({ Success: false, Text: `Average latency: ${average}ms`}))
+          source.push(null)
+        }
       })
     })
+    cb(null, source)
   })
 }

--- a/src/http/api/resources/index.js
+++ b/src/http/api/resources/index.js
@@ -3,6 +3,7 @@
 exports.version = require('./version')
 exports.shutdown = require('./shutdown')
 exports.id = require('./id')
+exports.ping = require('./ping')
 exports.bootstrap = require('./bootstrap')
 exports.repo = require('./repo')
 exports.object = require('./object')

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const boom = require('boom')
+
+exports = module.exports
+
+exports.get = (request, reply) => {
+  const ipfs = request.server.app.ipfs
+  const peerId = request.query.arg
+
+  ipfs.ping(peerId, (err, outputStream) => {
+    if (err) {
+      return reply(boom.badRequest(err))
+    }
+
+    return reply(outputStream).type('application/json').header('x-chunked-output', '1')
+  })
+}

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -37,7 +37,7 @@ exports.get = {
       const responseStream = toStream.source(pullStream)
       const stream2 = new PassThrough()
       pump(responseStream, stream2)
-      return reply(stream2).type('application/json').header('x-chunked-output', '1')
+      return reply(stream2).type('application/json').header('X-Chunked-Output', '1')
     })
   }
 }

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -13,7 +13,8 @@ exports.get = {
     query: Joi.object().keys({
       n: Joi.alternatives()
         .when('count', {
-          is: true, then: Joi.any().forbidden(),
+          is: true,
+          then: Joi.any().forbidden(),
           otherwise: Joi.number().greater(0)
         }),
       count: Joi.number().greater(0),

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -19,7 +19,7 @@ exports.get = {
         }),
       count: Joi.number().greater(0),
       arg: Joi.string()
-    })
+    }).unknown()
   },
   handler: (request, reply) => {
     const ipfs = request.server.app.ipfs

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -1,18 +1,36 @@
 'use strict'
 
+const Joi = require('joi')
 const boom = require('boom')
+const toStream = require('pull-stream-to-stream')
 
 exports = module.exports
 
-exports.get = (request, reply) => {
-  const ipfs = request.server.app.ipfs
-  const peerId = request.query.arg
+exports.get = {
+  validate: {
+    query: Joi.object().keys({
+      n: Joi.alternatives()
+        .when('count', {
+          is: true, then: Joi.any().forbidden(),
+          otherwise: Joi.number().greater(0)
+        }),
+      count: Joi.number().greater(0),
+      arg: Joi.string()
+    })
+  },
+  handler: (request, reply) => {
+    const ipfs = request.server.app.ipfs
+    const peerId = request.query.arg
+    // Default count to 10
+    const count = request.query.n || request.query.count || 10
 
-  ipfs.ping(peerId, (err, outputStream) => {
-    if (err) {
-      return reply(boom.badRequest(err))
-    }
+    ipfs.ping(peerId, count, (err, sourceStream) => {
+      if (err) {
+        return reply(boom.badRequest(err))
+      }
+      console.log(sourceStream)
 
-    return reply(outputStream).type('application/json').header('x-chunked-output', '1')
-  })
+      return reply(sourceStream).type('application/json').header('x-chunked-output', '1')
+    })
+  }
 }

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -13,12 +13,12 @@ exports.get = {
     query: Joi.object().keys({
       n: Joi.alternatives()
         .when('count', {
-          is: true,
+          is: Joi.any().exist(),
           then: Joi.any().forbidden(),
           otherwise: Joi.number().greater(0)
         }),
       count: Joi.number().greater(0),
-      arg: Joi.string()
+      arg: Joi.string().required()
     }).unknown()
   },
   handler: (request, reply) => {
@@ -26,7 +26,6 @@ exports.get = {
     const peerId = request.query.arg
     // Default count to 10
     const count = request.query.n || request.query.count || 10
-
     ipfs.ping(peerId, count, (err, pullStream) => {
       if (err) {
         return reply(boom.badRequest(err))

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -11,15 +11,10 @@ exports = module.exports
 exports.get = {
   validate: {
     query: Joi.object().keys({
-      n: Joi.alternatives()
-        .when('count', {
-          is: Joi.any().exist(),
-          then: Joi.any().forbidden(),
-          otherwise: Joi.number().greater(0)
-        }),
+      n: Joi.number().greater(0),
       count: Joi.number().greater(0),
       arg: Joi.string().required()
-    }).unknown()
+    }).xor('n', 'count').unknown()
   },
   handler: (request, reply) => {
     const ipfs = request.server.app.ipfs

--- a/src/http/api/resources/ping.js
+++ b/src/http/api/resources/ping.js
@@ -3,6 +3,8 @@
 const Joi = require('joi')
 const boom = require('boom')
 const toStream = require('pull-stream-to-stream')
+const PassThrough = require('readable-stream').PassThrough
+const pump = require('pump')
 
 exports = module.exports
 
@@ -24,13 +26,18 @@ exports.get = {
     // Default count to 10
     const count = request.query.n || request.query.count || 10
 
-    ipfs.ping(peerId, count, (err, sourceStream) => {
+    ipfs.ping(peerId, count, (err, pullStream) => {
       if (err) {
         return reply(boom.badRequest(err))
       }
-      console.log(sourceStream)
-
-      return reply(sourceStream).type('application/json').header('x-chunked-output', '1')
+      // Streams from pull-stream-to-stream don't seem to be compatible
+      // with the stream2 readable interface
+      // see: https://github.com/hapijs/hapi/blob/c23070a3de1b328876d5e64e679a147fafb04b38/lib/response.js#L533
+      // and: https://github.com/pull-stream/pull-stream-to-stream/blob/e436acee18b71af8e71d1b5d32eee642351517c7/index.js#L28
+      const responseStream = toStream.source(pullStream)
+      const stream2 = new PassThrough()
+      pump(responseStream, stream2)
+      return reply(stream2).type('application/json').header('x-chunked-output', '1')
     })
   }
 }

--- a/src/http/api/routes/index.js
+++ b/src/http/api/routes/index.js
@@ -9,6 +9,7 @@ module.exports = (server) => {
   require('./object')(server)
   require('./repo')(server)
   require('./config')(server)
+  require('./ping')(server)
   require('./swarm')(server)
   require('./bitswap')(server)
   require('./file')(server)

--- a/src/http/api/routes/ping.js
+++ b/src/http/api/routes/ping.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const resources = require('./../resources')
+
+module.exports = (server) => {
+  const api = server.select('API')
+
+  api.route({
+    method: '*',
+    path: '/api/v0/ping',
+    config: {
+      payload: {
+        parse: false,
+        output: 'stream'
+      },
+      handler: resources.ping.get
+    }
+  })
+}

--- a/src/http/api/routes/ping.js
+++ b/src/http/api/routes/ping.js
@@ -9,10 +9,6 @@ module.exports = (server) => {
     method: '*',
     path: '/api/v0/ping',
     config: {
-      payload: {
-        parse: false,
-        output: 'stream'
-      },
       handler: resources.ping.get.handler,
       validate: resources.ping.get.validate
     }

--- a/src/http/api/routes/ping.js
+++ b/src/http/api/routes/ping.js
@@ -13,7 +13,8 @@ module.exports = (server) => {
         parse: false,
         output: 'stream'
       },
-      handler: resources.ping.get
+      handler: resources.ping.get.handler,
+      validate: resources.ping.get.validate
     }
   })
 }

--- a/test/cli/commands.js
+++ b/test/cli/commands.js
@@ -14,7 +14,7 @@ describe('commands', () => runOnAndOff((thing) => {
     ipfs = thing.ipfs
   })
 
-  it.only('list the commands', () => {
+  it('list the commands', () => {
     return ipfs('commands').then((out) => {
       expect(out.split('\n')).to.have.length(commandCount + 1)
     })

--- a/test/cli/commands.js
+++ b/test/cli/commands.js
@@ -4,7 +4,8 @@
 const expect = require('chai').expect
 const runOnAndOff = require('../utils/on-and-off')
 
-const commandCount = 73
+const commandCount = 74
+
 describe('commands', () => runOnAndOff((thing) => {
   let ipfs
 
@@ -13,7 +14,7 @@ describe('commands', () => runOnAndOff((thing) => {
     ipfs = thing.ipfs
   })
 
-  it('list the commands', () => {
+  it.only('list the commands', () => {
     return ipfs('commands').then((out) => {
       expect(out.split('\n')).to.have.length(commandCount + 1)
     })

--- a/test/cli/ping.js
+++ b/test/cli/ping.js
@@ -1,0 +1,99 @@
+/* eslint max-nested-callbacks: ["error", 8] */
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const delay = require('delay')
+const series = require('async/series')
+const ipfsExec = require('../utils/ipfs-exec')
+
+const DaemonFactory = require('ipfsd-ctl')
+const df = DaemonFactory.create({ type: 'js' })
+
+const config = {
+  Bootstrap: [],
+  Discovery: {
+    MDNS: {
+      Enabled:
+        false
+    }
+  }
+}
+
+describe.only('ping', function () {
+  this.timeout(80 * 1000)
+
+  let ipfsdA
+  let ipfsdB
+  let ipfsdBId
+  let cli
+
+  before(function (done) {
+    this.timeout(60 * 1000)
+
+    df.spawn({
+      exec: './src/cli/bin.js',
+      config,
+      initoptions: { bits: 512 }
+    }, (err, _ipfsd) => {
+      expect(err).to.not.exist()
+      ipfsdA = _ipfsd
+      done()
+    })
+  })
+
+  before((done) => {
+    this.timeout(60 * 1000)
+    series([
+      (cb) => {
+        df.spawn({
+          exec: `./src/cli/bin.js`,
+          config,
+          initOptions: { bits: 512 }
+        }, (err, _ipfsd) => {
+          expect(err).to.not.exist()
+          ipfsdB = _ipfsd
+          cb()
+        })
+      },
+      (cb) => {
+        ipfsdB.api.id((err, peerInfo) => {
+          expect(err).to.not.exist()
+          console.log(peerInfo)
+          ipfsdBId = peerInfo.id
+          cb()
+        })
+      }
+    ], done)
+  })
+
+  after((done) => ipfsdA.stop(done))
+  after((done) => ipfsdB.stop(done))
+
+  before((done) => {
+    cli = ipfsExec(ipfsdA.repoPath)
+    done()
+  })
+
+  it('ping host', (done) => {
+    const ping = cli(`ping ${ipfsdBId}`)
+    const result = []
+    ping.stdout.on('data', (packet) => {
+      console.log('ON DATA')
+      result.push(packet.toString())
+    })
+
+    ping.stdout.on('end', (c) => {
+      console.log('END', result)
+      done()
+    })
+
+    ping.catch((err) => {
+      expect(err).to.not.exist()
+      done()
+    })
+  })
+})

--- a/test/cli/ping.js
+++ b/test/cli/ping.js
@@ -4,14 +4,13 @@
 
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-const delay = require('delay')
 const series = require('async/series')
+const DaemonFactory = require('ipfsd-ctl')
 const ipfsExec = require('../utils/ipfs-exec')
 
-const DaemonFactory = require('ipfsd-ctl')
 const df = DaemonFactory.create({ type: 'js' })
+const expect = chai.expect
+chai.use(dirtyChai)
 
 const config = {
   Bootstrap: [],
@@ -66,6 +65,7 @@ describe('ping', function () {
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsdA = _ipfsd
+      // Without DHT we need to have an already established connection
       ipfsdA.api.swarm.connect(bMultiaddr, done)
     })
   })
@@ -91,7 +91,7 @@ describe('ping', function () {
     ping.stdout.on('end', () => {
       expect(result).to.have.lengthOf(12)
       expect(result[0]).to.equal(`PING ${ipfsdBId}`)
-      for(let i = 1; i < 11; i++) {
+      for (let i = 1; i < 11; i++) {
         expect(result[i]).to.match(/^Pong received: time=\d+ ms$/)
       }
       expect(result[11]).to.match(/^Average latency: \d+(.\d+)?ms$/)

--- a/test/cli/ping.js
+++ b/test/cli/ping.js
@@ -23,7 +23,7 @@ const config = {
   }
 }
 
-describe.only('ping', function () {
+describe('ping', function () {
   this.timeout(60 * 1000)
   let ipfsdA
   let ipfsdB

--- a/test/core/ping.spec.js
+++ b/test/core/ping.spec.js
@@ -1,0 +1,220 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const pull = require('pull-stream/pull')
+const drain = require('pull-stream/sinks/drain')
+const pullCatch = require('pull-catch')
+const parallel = require('async/parallel')
+const DaemonFactory = require('ipfsd-ctl')
+const isNode = require('detect-node')
+
+const expect = chai.expect
+chai.use(dirtyChai)
+const df = DaemonFactory.create({ exec: 'src/cli/bin.js' })
+
+const config = {
+  Bootstrap: [],
+  Discovery: {
+    MDNS: {
+      Enabled:
+        false
+    }
+  }
+}
+
+function spawnNode ({ dht = false }, cb) {
+  const args = dht ? ['--enable-dht-experiment'] : []
+  df.spawn({
+    args,
+    config,
+    initOptions: { bits: 512 }
+  }, cb)
+}
+
+describe('ping', function () {
+  this.timeout(60 * 1000)
+
+  if (!isNode) return
+
+  describe('DHT disabled', function () {
+    // Without DHT nodes need to be previously connected
+    let ipfsdA
+    let ipfsdB
+    let bMultiaddr
+    let ipfsdBId
+
+    // Spawn nodes
+    before(function (done) {
+      this.timeout(60 * 1000)
+
+      parallel([
+        spawnNode.bind(null, { dht: false }),
+        spawnNode.bind(null, { dht: false })
+      ], (err, ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsdA = ipfsd[0]
+        ipfsdB = ipfsd[1]
+        done()
+      })
+    })
+
+    // Get the peer info object
+    before(function (done) {
+      this.timeout(60 * 1000)
+
+      ipfsdB.api.id((err, peerInfo) => {
+        expect(err).to.not.exist()
+        ipfsdBId = peerInfo.id
+        bMultiaddr = peerInfo.addresses[0]
+        done()
+      })
+    })
+
+    // Connect the nodes
+    before(function (done) {
+      this.timeout(60 * 1000)
+      ipfsdA.api.swarm.connect(bMultiaddr, done)
+    })
+
+    after((done) => ipfsdA.stop(done))
+    after((done) => ipfsdB.stop(done))
+
+    it('sends the specified number of packets', (done) => {
+      let packetNum = 0
+      const count = 3
+      pull(
+        ipfsdA.api.pingPullStream(ipfsdBId, { count }),
+        pullCatch(err => {
+          expect(err).to.not.exist()
+        }),
+        drain(({ Success, Time, Text }) => {
+          expect(Success).to.be.true()
+          // It's a pong
+          if (Time) {
+            packetNum++
+          }
+        }, () => {
+          expect(packetNum).to.equal(count)
+          done()
+        })
+      )
+    })
+
+    it('pinging an unknown peer will fail accordingly', (done) => {
+      let messageNum = 0
+      const count = 2
+      pull(
+        ipfsdA.api.pingPullStream('unknown', { count }),
+        pullCatch(err => {
+          expect(err).to.not.exist()
+        }),
+        drain(({ Success, Time, Text }) => {
+          messageNum++
+          // Assert that the ping command falls back to the peerRouting
+          if (messageNum === 1) {
+            expect(Text).to.include('Looking up')
+          }
+
+          // Fails accordingly while trying to use peerRouting
+          if (messageNum === 2) {
+            expect(Success).to.be.false()
+          }
+        }, () => {
+          expect(messageNum).to.equal(count)
+          done()
+        })
+      )
+    })
+  })
+
+  describe('DHT enabled', function () {
+    // Our bootstrap process will run 3 IPFS daemons where
+    // A ----> B ----> C
+    // Allowing us to test the ping command using the DHT peer routing
+    let ipfsdA
+    let ipfsdB
+    let ipfsdC
+    let bMultiaddr
+    let cMultiaddr
+    let ipfsdCId
+
+    // Spawn nodes
+    before(function (done) {
+      this.timeout(60 * 1000)
+
+      parallel([
+        spawnNode.bind(null, { dht: true }),
+        spawnNode.bind(null, { dht: true }),
+        spawnNode.bind(null, { dht: true })
+      ], (err, ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsdA = ipfsd[0]
+        ipfsdB = ipfsd[1]
+        ipfsdC = ipfsd[2]
+        done()
+      })
+    })
+
+    // Get the peer info objects
+    before(function (done) {
+      this.timeout(60 * 1000)
+
+      parallel([
+        ipfsdB.api.id.bind(ipfsdB.api),
+        ipfsdC.api.id.bind(ipfsdC.api)
+      ], (err, peerInfo) => {
+        expect(err).to.not.exist()
+        bMultiaddr = peerInfo[0].addresses[0]
+        ipfsdCId = peerInfo[1].id
+        cMultiaddr = peerInfo[1].addresses[0]
+        done()
+      })
+    })
+
+    // Connect the nodes
+    before(function (done) {
+      this.timeout(60 * 1000)
+
+      parallel([
+        ipfsdA.api.swarm.connect.bind(ipfsdA.api, bMultiaddr),
+        ipfsdB.api.swarm.connect.bind(ipfsdB.api, cMultiaddr)
+      ], done)
+    })
+
+    // FIXME timeout needed for connections to succeed
+    before((done) => setTimeout(done, 100))
+
+    after((done) => ipfsdA.stop(done))
+    after((done) => ipfsdB.stop(done))
+    after((done) => ipfsdC.stop(done))
+
+    it('if enabled uses the DHT peer routing to find peer', (done) => {
+      let messageNum = 0
+      let packetNum = 0
+      const count = 3
+      pull(
+        ipfsdA.api.pingPullStream(ipfsdCId, { count }),
+        pullCatch(err => {
+          expect(err).to.not.exist()
+        }),
+        drain(({ Success, Time, Text }) => {
+          messageNum++
+          expect(Success).to.be.true()
+          // Assert that the ping command falls back to the peerRouting
+          if (messageNum === 1) {
+            expect(Text).to.include('Looking up')
+          }
+          // It's a pong
+          if (Time) {
+            packetNum++
+          }
+        }, () => {
+          expect(packetNum).to.equal(count)
+          done()
+        })
+      )
+    })
+  })
+})

--- a/test/http-api/inject/ping.js
+++ b/test/http-api/inject/ping.js
@@ -1,0 +1,52 @@
+/* eslint max-nested-callbacks: ["error", 8] */
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+
+const expect = chai.expect
+chai.use(dirtyChai)
+
+module.exports = (http) => {
+  describe('/ping', function () {
+    let api
+
+    before(() => {
+      api = http.api.server.select('API')
+    })
+
+    it('returns 400 if both n and count are provided', (done) => {
+      api.inject({
+        method: 'GET',
+        url: `/api/v0/ping?arg=someRandomId&n=1&count=1`
+      }, (res) => {
+        expect(res.statusCode).to.equal(400)
+        done()
+      })
+    })
+
+    it('returns 400 if arg is not provided', (done) => {
+      api.inject({
+        method: 'GET',
+        url: `/api/v0/ping?count=1`
+      }, (res) => {
+        expect(res.statusCode).to.equal(400)
+        done()
+      })
+    })
+
+    it('returns 200 and the response stream with the ping result', (done) => {
+      api.inject({
+        method: 'GET',
+        url: `/api/v0/ping?arg=someRandomId`
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        expect(res.headers['x-chunked-output']).to.equal('1')
+        expect(res.headers['transfer-encoding']).to.equal('chunked')
+        expect(res.headers['content-type']).to.include('application/json')
+        done()
+      })
+    })
+  })
+}


### PR DESCRIPTION
Just opening this for visibility, working on finishing the ping endeavour started at #1202.

- [x]  Dependant on https://github.com/libp2p/js-libp2p-ping/pull/69
- [x]  Missing tests

Also, some relevant notes. Seems like hapijs has compression enabled by default, which means responses  will take into account the `Accept-Encoding` header and will use gzip to compress responses (it seems hapi has no way of disabling compression for a specific route only also). From what I've seen the `go-ipfs` http api doesn't gzip responses by default AFAIK. Anyway, there seems to be an issue when compression is enabled and we're streaming responses - https://github.com/hapijs/hapi/issues/3599 - as it seems the response is actually buffered, compressed and only then it is sent to the client. This results in the actual "streaming" capabilities being lost (the response all at once and only when it is complete). Not sure if this is a relevant issue or not, but though it was worth mentioning since when using the http API from a browser, the `Accept-Encoding` headers will be set and the resulting response will not be streamed.

Closes #928.