### PR TITLE
fix: Display error when using unkown cli option

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -14,6 +14,8 @@ updateNotifier({
   updateCheckInterval: 1000 * 60 * 60 * 24 * 7 // 1 week
 }).notify()
 
+const args = process.argv.slice(2)
+
 const cli = yargs
   .option('silent', {
     desc: 'Write no output',
@@ -32,6 +34,11 @@ const cli = yargs
     if (err) {
       throw err // preserve stack
     }
+
+    if (args.length > 0) {
+      print(msg)
+    }
+
     yargs.showHelp()
   })
 
@@ -46,14 +53,12 @@ aliases.forEach((alias) => {
   cli.command(alias.command, alias.describe, alias.builder, alias.handler)
 })
 
-const args = process.argv.slice(2)
-
 // Need to skip to avoid locking as these commands
 // don't require a daemon
 if (args[0] === 'daemon' || args[0] === 'init') {
   cli
     .help()
-    .strict(false)
+    .strict()
     .completion()
     .parse(args)
 } else {
@@ -69,7 +74,7 @@ if (args[0] === 'daemon' || args[0] === 'init') {
 
       cli
         .help()
-        .strict(false)
+        .strict()
         .completion()
         .parse(args, { ipfs: ipfs }, (err, argv, output) => {
           if (output) { print(output) }

--- a/src/cli/commands/files/cat.js
+++ b/src/cli/commands/files/cat.js
@@ -1,14 +1,14 @@
 'use strict'
 
 module.exports = {
-  command: 'cat <ipfs-path>',
+  command: 'cat <ipfsPath>',
 
   describe: 'Fetch and cat an IPFS path referencing a file',
 
   builder: {},
 
   handler (argv) {
-    let path = argv['ipfs-path']
+    let path = argv['ipfsPath']
     if (path.indexOf('/ipfs/') !== 1) {
       path = path.replace('/ipfs/', '')
     }

--- a/src/cli/commands/files/get.js
+++ b/src/cli/commands/files/get.js
@@ -45,7 +45,7 @@ function fileHandler (dir) {
 }
 
 module.exports = {
-  command: 'get <ipfs-path>',
+  command: 'get <ipfsPath>',
 
   describe: 'Fetch a file or directory with files references from an IPFS Path',
 
@@ -58,7 +58,8 @@ module.exports = {
   },
 
   handler (argv) {
-    const ipfsPath = argv['ipfs-path']
+    const ipfsPath = argv['ipfsPath']
+
     const dir = checkArgs(ipfsPath, argv.output)
 
     const stream = argv.ipfs.files.getReadableStream(ipfsPath)

--- a/test/cli/general.js
+++ b/test/cli/general.js
@@ -10,4 +10,12 @@ describe('general cli options', () => runOnAndOff.off((thing) => {
       expect(out).to.be.empty()
     })
   })
+
+  it('should handle unknown arguments correctly', () => {
+    return thing.ipfs('random --again').then((out) => {
+      expect(out).to.include('Unknown arguments: again, random')
+      expect(out).to.include('random')
+      expect(out).to.include('again')
+    })
+  })
 }))


### PR DESCRIPTION
I believe that the yargs strict was disabled, in order to remove some strange problems regarding fail callbacks, which were inadvertently called. After digging through the yargs validation code, I ended up finding the problem.

The yargs positional arguments validation for [positional arguments](https://github.com/yargs/yargs/blob/master/lib/validation.js#L95) does not support positional arguments in kebab-case notation ([yargs Issue](https://github.com/yargs/yargs/issues/823)). Therefore, I changed to camelCase those. With this modification and enabling strict generally in the CLI. 

And now we have errors for unknown options! 💪😎
 
Closes [563](https://github.com/ipfs/js-ipfs-api/issues/563)