### PR TITLE
fix: Add ipfs path to cli help

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -29,6 +29,7 @@ const cli = yargs
     default: ''
   })
   .commandDir('commands')
+  .epilog(utils.ipfsPathHelp)
   .demandCommand(1)
   .fail((msg, err, yargs) => {
     if (err) {

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -11,15 +11,17 @@ module.exports = {
 
   describe: 'Start a long-running daemon process',
 
-  builder: {
-    'enable-sharding-experiment': {
-      type: 'boolean',
-      default: false
-    },
-    'enable-pubsub-experiment': {
-      type: 'boolean',
-      default: false
-    }
+  builder (yargs) {
+    return yargs
+      .epilog(utils.ipfsPathHelp)
+      .option('enable-sharding-experiment', {
+        type: 'boolean',
+        default: false
+      })
+      .option('enable-pubsub-experiment', {
+        type: 'boolean',
+        default: false
+      })
   },
 
   handler (argv) {

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -5,19 +5,14 @@ const IPFS = require('../../core')
 const utils = require('../utils')
 const print = utils.print
 
-const ipfsPathHelp = 'ipfs uses a repository in the local file system. By default, the repo is ' +
-  'located at ~/.ipfs.\nTo change the repo location, set the $IPFS_PATH environment variable:\n\n' +
-  '\texport IPFS_PATH=/path/to/ipfsrepo\n'
-
 module.exports = {
   command: 'init',
 
   describe: 'Initialize a local IPFS node',
 
   builder (yargs) {
-    print(ipfsPathHelp)
-
     return yargs
+      .epilog(utils.ipfsPathHelp)
       .option('bits', {
         type: 'number',
         alias: 'b',

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -111,3 +111,7 @@ exports.rightpad = (val, n) => {
   }
   return result
 }
+
+exports.ipfsPathHelp = 'ipfs uses a repository in the local file system. By default, the repo is ' +
+  'located at ~/.jsipfs. To change the repo location, set the $IPFS_PATH environment variable:\n\n' +
+  'export IPFS_PATH=/path/to/ipfsrepo\n'

--- a/test/cli/daemon.js
+++ b/test/cli/daemon.js
@@ -120,4 +120,13 @@ describe('daemon', () => {
       done()
     })
   })
+
+  it('should present ipfs path help when option help is received', function (done) {
+    this.timeout(100 * 1000)
+
+    ipfs('daemon --help').then((res) => {
+      expect(res).to.have.string('export IPFS_PATH=/path/to/ipfsrepo')
+      done()
+    })
+  })
 })

--- a/test/cli/init.js
+++ b/test/cli/init.js
@@ -66,4 +66,13 @@ describe('init', function () {
       expect(repoExistsSync('version')).to.equal(true)
     })
   })
+
+  it('should present ipfs path help when option help is received', function (done) {
+    this.timeout(100 * 1000)
+
+    ipfs('init --help').then((res) => {
+      expect(res).to.have.string('export IPFS_PATH=/path/to/ipfsrepo')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Aiming to have a consistent menu with `go-ipfs`, I added the `IPFS_PATH` as it is presented in Go implementation.

```
ipfs uses a repository in the local file system. By default, the repo is
located at ~/.ipfs. To change the repo location, set the $IPFS_PATH
environment variable:

    export IPFS_PATH=/path/to/ipfsrepo
```

In PR https://github.com/ipfs/js-ipfs/pull/1274, it was added to `jsipfs init --help`, but it was presented before the options description, instead of in the end.

In this solution, I changed the previous implementation. Using `yargs epilog`, I added the `IPFS_PATH` message to the epilogue which is displayed for the following cases:

- `jsipfs`
- `jsipfs --help`
- `jsipfs init --help`
- `jsipfs daemon --help`

Closes #1213 