### PR TITLE
feat(bitswap.unwatch) expose bitswap.unwatch to cli and http api

### DIFF
--- a/src/cli/commands/bitswap/unwant.js
+++ b/src/cli/commands/bitswap/unwant.js
@@ -1,11 +1,25 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'unwant <key>',
 
-  describe: 'Remove a given block from your wantlist.',
+  describe: 'Removes a given block from your wantlist.',
 
+  builder: {
+    key: {
+      alias: 'k',
+      describe: 'Key to remove from your wantlist',
+      type: 'string'
+    }
+  },
   handler (argv) {
-    throw new Error('Not implemented yet')
+    argv.ipfs.bitswap.unwant(argv.key, (err, res) => {
+      if (err) {
+        throw err
+      }
+      print(`Key ${argv.key} removed from wantlist`)
+    })
   }
 }

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -46,10 +46,19 @@ exports.stat = (request, reply) => {
 }
 
 exports.unwant = {
-  // uses common parseKey method that returns a `key`
+  // uses common parseKey method that assigns a `key` to request.pre.args
   parseArgs: parseKey,
 
+  // main route handler which is called after the above `parseArgs`, but only if the args were valid
   handler: (request, reply) => {
-    reply(boom.badRequest(new Error('Not implemented yet')))
+    const key = request.pre.args.key
+    const ipfs = request.server.app.ipfs
+    try {
+      ipfs.bitswap.unwant(key)
+    } catch(err) {
+      return reply(boom.badRequest(err))
+    }
+
+    reply({ Key: key })
   }
 }

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -23,8 +23,7 @@ describe('bitswap', () => runOn((thing) => {
     })
   })
 
-  // TODO @hacdias fix this with https://github.com/ipfs/js-ipfs/pull/1198
-  it.skip('stat', function () {
+  it('stat', function () {
     this.timeout(20 * 1000)
 
     return ipfs('bitswap stat').then((out) => {
@@ -39,5 +38,11 @@ describe('bitswap', () => runOn((thing) => {
         '    '
       ].join('\n') + '\n')
     })
+  })
+
+  it('unwant', function () {
+    return ipfs('bitswap unwant ' + key).then((out) => {
+      expect(out).to.eql(`Key ${key} removed from wantlist\n`)
+    });
   })
 }))


### PR DESCRIPTION
Does this mean we want to add a bitswap spec to interface-ipfs-core?

The go cli does not print anything on success as far as I can tell: https://github.com/ipfs/go-ipfs/blob/11ce0445cb24b6b99613223fc6d8128c6648a4df/core/commands/bitswap.go#L78

I can remove the print statement in this cli implementation and just test that no error happened instead if we want the output to match too.