### PR TITLE
feat(bitswap.unwant) expose bitswap.unwant to cli and http api

### DIFF
--- a/src/cli/commands/bitswap/unwant.js
+++ b/src/cli/commands/bitswap/unwant.js
@@ -15,7 +15,11 @@ module.exports = {
     }
   },
   handler (argv) {
-    argv.ipfs.bitswap.unwant(argv.key)
-    print(`Key ${argv.key} removed from wantlist`)
+    argv.ipfs.bitswap.unwant(argv.key, (err) => {
+      if (err) {
+        throw err
+      }
+      print(`Key ${argv.key} removed from wantlist`)
+    })
   }
 }

--- a/src/cli/commands/bitswap/unwant.js
+++ b/src/cli/commands/bitswap/unwant.js
@@ -1,11 +1,21 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'unwant <key>',
 
-  describe: 'Remove a given block from your wantlist.',
+  describe: 'Removes a given block from your wantlist.',
 
+  builder: {
+    key: {
+      alias: 'k',
+      describe: 'Key to remove from your wantlist',
+      type: 'string'
+    }
+  },
   handler (argv) {
-    throw new Error('Not implemented yet')
+    argv.ipfs.bitswap.unwant(argv.key)
+    print(`Key ${argv.key} removed from wantlist`)
   }
 }

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -21,8 +21,8 @@ module.exports = {
       if (err) {
         throw err
       }
-      res.Keys.forEach((cidStr) => {
-        print(cidStr)
+      res.Keys.forEach((cid) => {
+        print(cid['/'])
       })
     })
   }

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CID = require('cids')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'get <key>',
@@ -17,7 +18,11 @@ module.exports = {
         throw err
       }
 
-      process.stdout.write(block.data)
+      if (block) {
+        print(block.data)
+      } else {
+        print('Block was unwanted before it could be remotely retrieved')
+      }
     })
   }
 }

--- a/src/core/components/bitswap.js
+++ b/src/core/components/bitswap.js
@@ -45,7 +45,7 @@ module.exports = function bitswap (self) {
         throw new Error(OFFLINE_ERROR)
       }
 
-      // TODO: implement when https://github.com/ipfs/js-ipfs-bitswap/pull/10 is merged
+      self._bitswap.unwant(key)
     }
   }
 }

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -46,10 +46,19 @@ exports.stat = (request, reply) => {
 }
 
 exports.unwant = {
-  // uses common parseKey method that returns a `key`
+  // uses common parseKey method that assigns a `key` to request.pre.args
   parseArgs: parseKey,
 
+  // main route handler which is called after the above `parseArgs`, but only if the args were valid
   handler: (request, reply) => {
-    reply(boom.badRequest(new Error('Not implemented yet')))
+    const key = request.pre.args.key
+    const ipfs = request.server.app.ipfs
+    try {
+      ipfs.bitswap.unwant(key)
+    } catch (err) {
+      return reply(boom.badRequest(err))
+    }
+
+    reply({ Key: key })
   }
 }

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -7,16 +7,11 @@ const parseKey = require('./block').parseKey
 exports = module.exports
 
 exports.wantlist = (request, reply) => {
-  let list
-  try {
-    list = request.server.app.ipfs.bitswap.wantlist()
-    list = list.map((entry) => entry.cid.toBaseEncodedString())
-  } catch (err) {
-    return reply(boom.badRequest(err))
-  }
-
-  reply({
-    Keys: list
+  request.server.app.ipfs.bitswap.wantlist((err, list) => {
+    if (err) {
+      return reply(boom.badRequest(err))
+    }
+    reply(list)
   })
 }
 
@@ -53,12 +48,11 @@ exports.unwant = {
   handler: (request, reply) => {
     const key = request.pre.args.key
     const ipfs = request.server.app.ipfs
-    try {
-      ipfs.bitswap.unwant(key)
-    } catch (err) {
-      return reply(boom.badRequest(err))
-    }
-
-    reply({ Key: key })
+    ipfs.bitswap.unwant(key, (err) => {
+      if (err) {
+        return reply(boom.badRequest(err))
+      }
+      reply({ key: key.toBaseEncodedString() })
+    })
   }
 }

--- a/src/http/api/resources/block.js
+++ b/src/http/api/resources/block.js
@@ -48,7 +48,13 @@ exports.get = {
         }).code(500)
       }
 
-      return reply(block.data)
+      if (block) {
+        return reply(block.data)
+      }
+      return reply({
+        Message: 'Block was unwanted before it could be remotely retrieved',
+        Code: 0
+      }).code(404)
     })
   }
 }

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -23,8 +23,7 @@ describe('bitswap', () => runOn((thing) => {
     })
   })
 
-  // TODO @hacdias fix this with https://github.com/ipfs/js-ipfs/pull/1198
-  it.skip('stat', function () {
+  it('stat', function () {
     this.timeout(20 * 1000)
 
     return ipfs('bitswap stat').then((out) => {
@@ -38,6 +37,12 @@ describe('bitswap', () => runOn((thing) => {
         '  partners [0]',
         '    '
       ].join('\n') + '\n')
+    })
+  })
+
+  it('unwant', function () {
+    return ipfs('bitswap unwant ' + key).then((out) => {
+      expect(out).to.eql(`Key ${key} removed from wantlist\n`)
     })
   })
 }))

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -13,7 +13,7 @@ describe('bitswap', () => runOn((thing) => {
     ipfs('block get ' + key)
       .then(() => {})
       .catch(() => {})
-    setTimeout(done, 800)
+    setTimeout(done, 250)
   })
 
   it('wantlist', function () {

--- a/test/core/bitswap.spec.js
+++ b/test/core/bitswap.spec.js
@@ -283,7 +283,7 @@ skipOnWindows('bitswap', function () {
         })
       })
 
-      it('throws if offline', () => {
+      it('.unwant throws if offline', () => {
         expect(() => node.bitswap.unwant('my key')).to.throw(/online/)
       })
     })

--- a/test/core/bitswap.spec.js
+++ b/test/core/bitswap.spec.js
@@ -18,9 +18,6 @@ const CID = require('cids')
 
 const IPFSFactory = require('ipfsd-ctl')
 
-// This gets replaced by '../utils/create-repo-browser.js' in the browser
-const createTempRepo = require('../utils/create-repo-nodejs.js')
-
 const IPFS = require('../../src/core')
 
 // TODO bitswap tests on windows is failing, missing proper shutdown of daemon
@@ -244,77 +241,6 @@ skipOnWindows('bitswap', function () {
         expect(err).to.not.exist()
         expect(data).to.eql(file)
         done()
-      })
-    })
-  })
-
-  describe('api', () => {
-    let node
-
-    before(function (done) {
-      this.timeout(40 * 1000)
-
-      node = new IPFS({
-        repo: createTempRepo(),
-        start: false,
-        config: {
-          Addresses: {
-            Swarm: []
-          },
-          Discovery: {
-            MDNS: {
-              Enabled: false
-            }
-          }
-        }
-      })
-      node.on('ready', () => done())
-    })
-
-    describe('while offline', () => {
-      it('.wantlist throws if offline', () => {
-        expect(() => node.bitswap.wantlist()).to.throw(/online/)
-      })
-
-      it('.stat gives error while offline', () => {
-        node.bitswap.stat((err, stats) => {
-          expect(err).to.exist()
-          expect(stats).to.not.exist()
-        })
-      })
-
-      it('.unwant throws if offline', () => {
-        expect(() => node.bitswap.unwant('my key')).to.throw(/online/)
-      })
-    })
-
-    describe('while online', () => {
-      before(function (done) {
-        this.timeout(80 * 1000)
-
-        node.start(() => done())
-      })
-
-      it('.wantlist returns an array of wanted blocks', () => {
-        expect(node.bitswap.wantlist()).to.eql([])
-      })
-
-      it('returns the stats', (done) => {
-        node.bitswap.stat((err, stats) => {
-          expect(err).to.not.exist()
-          expect(stats).to.have.keys([
-            'blocksReceived',
-            'blocksSent',
-            'dataReceived',
-            'dataSent',
-            'wantlist',
-            'peers',
-            'provideBufLen',
-            'dupDataReceived',
-            'dupBlksReceived'
-          ])
-          done()
-        })
       })
     })
   })

--- a/test/core/interface/bitswap.js
+++ b/test/core/interface/bitswap.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+'use strict'
+
+const test = require('interface-ipfs-core')
+const parallel = require('async/parallel')
+
+const IPFS = require('../../../src')
+
+const DaemonFactory = require('ipfsd-ctl')
+const df = DaemonFactory.create({ type: 'proc', exec: IPFS })
+
+const nodes = []
+const common = {
+  setup: function (callback) {
+    callback(null, {
+      spawnNode: (cb) => {
+        df.spawn({
+          initOptions: { bits: 512 }
+        }, (err, _ipfsd) => {
+          if (err) {
+            return cb(err)
+          }
+
+          nodes.push(_ipfsd)
+          cb(null, _ipfsd.api)
+        })
+      }
+    })
+  },
+  teardown: function (callback) {
+    parallel(nodes.map((node) => (cb) => node.stop(cb)), callback)
+  }
+}
+
+test.bitswap(common)

--- a/test/http-api/index.js
+++ b/test/http-api/index.js
@@ -1,11 +1,12 @@
 'use strict'
 
-require('./interface')
-require('./inject')
+require('./bitswap')
 require('./block')
 require('./bootstrap')
 require('./config')
 require('./dns')
 require('./id')
+require('./inject')
+require('./interface')
 require('./object')
 require('./version')

--- a/test/http-api/interface/bitswap.js
+++ b/test/http-api/interface/bitswap.js
@@ -1,0 +1,31 @@
+/* eslint-env mocha */
+'use strict'
+
+const test = require('interface-ipfs-core')
+const parallel = require('async/parallel')
+
+const DaemonFactory = require('ipfsd-ctl')
+const df = DaemonFactory.create({ exec: 'src/cli/bin.js' })
+
+const nodes = []
+const common = {
+  setup: function (callback) {
+    callback(null, {
+      spawnNode: (cb) => {
+        df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+          if (err) {
+            return cb(err)
+          }
+
+          nodes.push(_ipfsd)
+          cb(null, _ipfsd.api)
+        })
+      }
+    })
+  },
+  teardown: function (callback) {
+    parallel(nodes.map((node) => (cb) => node.stop(cb)), callback)
+  }
+}
+
+test.bitswap(common)


### PR DESCRIPTION
I have a few questions about this PR.
- Does this mean we want to add a bitswap spec to interface-ipfs-core?
- <strike>I don't think the `src/core/components/bitswap.js` file is being used during the tests (since they're online only they go through the http api)</strike> figured this one out, it was how I was testing.
- The go cli does not print anything on success as far as I can tell: https://github.com/ipfs/go-ipfs/blob/11ce0445cb24b6b99613223fc6d8128c6648a4df/core/commands/bitswap.go#L78

I can remove the print statement in this cli implementation and just test that no error happened instead if we want the output to match too.