### PR TITLE
feat: Add support for specifying hash algorithms in files.add

### DIFF
--- a/src/core/components/object.js
+++ b/src/core/components/object.js
@@ -191,7 +191,11 @@ module.exports = function object (self) {
       } catch (err) {
         return callback(err)
       }
-      const cid = new CID(mh)
+      let cid = new CID(mh)
+
+      if (options.cidVersion === 1) {
+        cid = cid.toV1()
+      }
 
       self._ipld.get(cid, (err, result) => {
         if (err) {
@@ -214,6 +218,7 @@ module.exports = function object (self) {
         if (err) {
           return callback(err)
         }
+
         callback(null, node.data)
       })
     }),

--- a/src/http/api/resources/files.js
+++ b/src/http/api/resources/files.js
@@ -207,7 +207,8 @@ exports.add = {
       cidVersion: request.query['cid-version'],
       rawLeaves: request.query['raw-leaves'],
       progress: request.query.progress ? progressHandler : null,
-      onlyHash: request.query['only-hash']
+      onlyHash: request.query['only-hash'],
+      hashAlg: request.query['hash']
     }
 
     const aborter = abortable()


### PR DESCRIPTION
Since [PR 1005](https://github.com/ipfs/js-ipfs/pull/1005/) has been blocked for a while, I went through it. 

As the PR origin is from an external organization, I created a new branch instead of rebasing it in its origin. Shortly, I got the @alanshaw (thanks :D ) implementation with `js-ipfs` master branch and made a few changes, as a consequence of the modifications that occurred meanwhile in `components/objects`, as well as in `resources` and a minor refactor. 

Finally, I added tests for several hash algorithms, since there are more than [300](https://github.com/multiformats/js-multihash/blob/master/src/constants.js). Should I add more to the tests?