### PR TITLE
refactor: remove duplicated code

### DIFF
--- a/src/cli/commands/stats/bitswap.js
+++ b/src/cli/commands/stats/bitswap.js
@@ -1,37 +1,8 @@
 'use strict'
 
-const CID = require('cids')
-const print = require('../../utils').print
-
-module.exports = {
-  command: 'bitswap',
-
-  describe: 'Show some diagnostic information on the bitswap agent.',
-
-  builder: {},
-
-  handler (argv) {
-    argv.ipfs.stats.bitswap((err, stats) => {
-      if (err) {
-        throw err
-      }
-
-      stats.wantlist = stats.wantlist || []
-      stats.wantlist = stats.wantlist.map((entry) => {
-        const buf = Buffer.from(entry.cid.hash.data)
-        const cid = new CID(entry.cid.version, entry.cid.codec, buf)
-        return cid.toBaseEncodedString()
-      })
-      stats.peers = stats.peers || []
-
-      print(`bitswap status
-  blocks received: ${stats.blocksReceived}
-  dup blocks received: ${stats.dupBlksReceived}
-  dup data received: ${stats.dupDataReceived}B
-  wantlist [${stats.wantlist.length} keys]
-    ${stats.wantlist.join('\n    ')}
-  partners [${stats.peers.length}]
-    ${stats.peers.join('\n    ')}`)
-    })
-  }
-}
+// This is an alias for `bitswap stat`.
+const bitswapStats = require('../bitswap/stat.js')
+// The command needs to be renamed, else it would be `stats stat` instead of
+// `stats bitswap`
+bitswapStats.command = 'bitswap'
+module.exports = bitswapStats


### PR DESCRIPTION
The `stats bitswap` command is an alias of `bitswap stat`. That should
also be reflected in the code.