### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf


### PR DESCRIPTION
(I made this as a PR rather than an issue because it’s so minimal. If we decide we don’t want it and just close the PR, that’s fine!)

As a follow-on to #1324, I thought it might be helpful to have a `.editorconfig` file in this repo. If you aren’t familiar with it, [Editorconfig](http://editorconfig.org) is a standardized file name & format for auto-configuring common text editor settings. It has built-in support in many editors and plug-in based support in pretty much all other major editors out there (the idea is you’d commit this *instead* of several configs for all the various editors contributors use). It’s a useful addition to a linter, since it silently and automatically configures your editor to do the right things, and is especially helpful when you work across several repos or languages that use different styles.

Disclosure: I maintain the TextMate plugin, so I may be biased on the value of this ;)