### PR TITLE
feat: improved error handling on the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 test/repo-tests*
 **/bundle.js
 docs
+.vscode
+.eslintrc
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ipfs-block": "~0.7.1",
     "ipfs-block-service": "~0.14.0",
     "ipfs-multipart": "~0.1.0",
-    "ipfs-repo": "0.20.0",
+    "ipfs-repo": "~0.21.0",
     "ipfs-unixfs": "~0.1.14",
     "ipfs-unixfs-engine": "~0.29.0",
     "ipld": "~0.17.0",

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -77,7 +77,7 @@ let cli = yargs(argv)
   // .recommendCommands()
   .completion()
 
-if (argv[0] === 'daemon' || argv[0] === 'init' || argv[0] === 'id') {
+if (['daemon', 'init', 'id', 'version'].includes(argv[0])) {
   args = cli.fail((msg, err, yargs) => {
     if (err instanceof Error && err.message && !msg) {
       msg = err.message

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -2,104 +2,144 @@
 
 'use strict'
 
-const yargs = require('yargs')
+const yargs = require('yargs/yargs')
 const updateNotifier = require('update-notifier')
 const readPkgUp = require('read-pkg-up')
-const fs = require('fs')
-const path = require('path')
-const utils = require('./utils')
-const print = utils.print
+const { disablePrinting, print, getNodeOrAPI } = require('./utils')
+const addCmd = require('./commands/files/add')
+const catCmd = require('./commands/files/cat')
+const getCmd = require('./commands/files/get')
 
 const pkg = readPkgUp.sync({cwd: __dirname}).pkg
+
 updateNotifier({
   pkg,
   updateCheckInterval: 1000 * 60 * 60 * 24 * 7 // 1 week
 }).notify()
 
-const args = process.argv.slice(2)
+const MSG_USAGE = `Usage:
+  ipfs - Global p2p merkle-dag filesystem.
 
-// Determine if the first argument is a sub-system command
-const commandNames = fs.readdirSync(path.join(__dirname, 'commands'))
-const isCommand = commandNames.includes(`${args[0]}.js`)
+  ipfs [options] <command> ...`
+const MSG_EPILOGUE = `Use 'ipfs <command> --help' to learn more about each command.
 
-const cli = yargs
+ipfs uses a repository in the local file system. By default, the repo is
+located at ~/.ipfs. To change the repo location, set the $IPFS_PATH
+environment variable:
+
+  export IPFS_PATH=/path/to/ipfsrepo
+
+EXIT STATUS
+
+The CLI will exit with one of the following values:
+
+0     Successful execution.
+1     Failed executions.
+`
+const MSG_NO_CMD = 'You need at least one command before moving on'
+
+const argv = process.argv.slice(2)
+let args = {}
+let cli = yargs(argv)
+  .usage(MSG_USAGE)
   .option('silent', {
     desc: 'Write no output',
     type: 'boolean',
     default: false,
-    coerce: ('silent', silent => silent ? utils.disablePrinting() : silent)
+    coerce: disablePrinting
+  })
+  .option('debug', {
+    desc: 'Show debug output',
+    type: 'boolean',
+    default: false,
+    alias: 'D'
   })
   .option('pass', {
     desc: 'Pass phrase for the keys',
     type: 'string',
     default: ''
   })
-  .commandDir('commands', {
-    // Only include the commands for the sub-system we're using, or include all
-    // if no sub-system command has been passed.
-    include (path, filename) {
-      if (!isCommand) return true
-      return `${args[0]}.js` === filename
-    }
+  .option('api', {
+    desc: 'Use a specific API instance.',
+    type: 'string'
   })
-  .epilog(utils.ipfsPathHelp)
-  .demandCommand(1)
-  .fail((msg, err, yargs) => {
-    if (err) {
-      throw err // preserve stack
-    }
-
-    if (args.length > 0) {
-      print(msg)
-    }
-
-    yargs.showHelp()
-  })
-
-// If not a sub-system command then load the top level aliases
-if (!isCommand) {
+  .commandDir('commands')
   // NOTE: This creates an alias of
   // `jsipfs files {add, get, cat}` to `jsipfs {add, get, cat}`.
   // This will stay until https://github.com/ipfs/specs/issues/98 is resolved.
-  const addCmd = require('./commands/files/add')
-  const catCmd = require('./commands/files/cat')
-  const getCmd = require('./commands/files/get')
-  const aliases = [addCmd, catCmd, getCmd]
-  aliases.forEach((alias) => {
-    cli.command(alias.command, alias.describe, alias.builder, alias.handler)
-  })
-}
+  .command(addCmd)
+  .command(catCmd)
+  .command(getCmd)
+  .demandCommand(1, MSG_NO_CMD)
+  .alias('help', 'h')
+  .epilogue(MSG_EPILOGUE)
+  .strict()
+  // .recommendCommands()
+  .completion()
 
-// Need to skip to avoid locking as these commands
-// don't require a daemon
-if (args[0] === 'daemon' || args[0] === 'init') {
-  cli
-    .help()
-    .strict()
-    .completion()
-    .parse(args)
-} else {
-  // here we have to make a separate yargs instance with
-  // only the `api` option because we need this before doing
-  // the final yargs parse where the command handler is invoked..
-  yargs().option('api').parse(process.argv, (err, argv, output) => {
-    if (err) {
-      throw err
+if (argv[0] === 'daemon' || argv[0] === 'init' || argv[0] === 'id') {
+  args = cli.fail((msg, err, yargs) => {
+    if (err instanceof Error && err.message && !msg) {
+      msg = err.message
     }
-    utils.getIPFS(argv, (err, ipfs, cleanup) => {
-      if (err) { throw err }
 
-      cli
-        .help()
-        .strict()
-        .completion()
-        .parse(args, { ipfs: ipfs }, (err, argv, output) => {
-          if (output) { print(output) }
+    // Cli specific error messages
+    if (err && err.code === 'ERR_REPO_NOT_INITIALIZED') {
+      msg = `No IPFS repo found in ${err.path}.
+please run: 'ipfs init'`
+    }
 
-          cleanup(() => {
-            if (err) { throw err }
-          })
-        })
+    // Show help and error message
+    if (!args.silent) {
+      yargs.showHelp()
+      console.error('Error: ' + msg)
+    }
+
+    // Write to stderr when debug is on
+    if (err && args.debug) {
+      console.error(err)
+    }
+
+    process.exit(1)
+  }).argv
+} else {
+  yargs()
+    .option('pass', {
+      desc: 'Pass phrase for the keys',
+      type: 'string',
+      default: ''
     })
-  })
+    .option('api', {
+      desc: 'Use a specific API instance.',
+      type: 'string'
+    })
+    .parse(argv, (err, parsedArgv, output) => {
+      if (err) {
+        console.error(err)
+      } else {
+        getNodeOrAPI(parsedArgv)
+          .then(node => {
+            args = cli
+              .parse(argv, { ipfs: node }, (err, parsedArgv, output) => {
+                if (output) {
+                  print(output)
+                }
+                if (node && node._repo && !node._repo.closed) {
+                  node._repo.close(err => {
+                    if (err) {
+                      console.error(err)
+                    }
+                  })
+                }
+                if (err && parsedArgv.debug) {
+                  console.error(err)
+                }
+              })
+          })
+          .catch(err => {
+            console.error(err)
+            process.exit(1)
+          })
+      }
+    })
 }

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -8,9 +8,6 @@ const yargs = require('yargs/yargs')
 const updateNotifier = require('update-notifier')
 const readPkgUp = require('read-pkg-up')
 const { disablePrinting, print, getNodeOrAPI } = require('./utils')
-const addCmd = require('./commands/files/add')
-const catCmd = require('./commands/files/cat')
-const getCmd = require('./commands/files/get')
 
 const pkg = readPkgUp.sync({cwd: __dirname}).pkg
 
@@ -23,7 +20,8 @@ const MSG_USAGE = `Usage:
 ipfs - Global p2p merkle-dag filesystem.
 
   ipfs [options] <command> ...`
-  const MSG_EPILOGUE = `Use 'ipfs <command> --help' to learn more about each command.
+
+const MSG_EPILOGUE = `Use 'ipfs <command> --help' to learn more about each command.
 
 ipfs uses a repository in the local file system. By default, the repo is
 located at ~/.ipfs. To change the repo location, set the $IPFS_PATH
@@ -82,9 +80,9 @@ let cli = yargs(argv)
     // NOTE: This creates an alias of
     // `jsipfs files {add, get, cat}` to `jsipfs {add, get, cat}`.
     // This will stay until https://github.com/ipfs/specs/issues/98 is resolved.
-    .command(addCmd)
-    .command(catCmd)
-    .command(getCmd)
+    .command(require('./commands/files/add'))
+    .command(require('./commands/files/cat'))
+    .command(require('./commands/files/get'))
   }
   cli
   .demandCommand(1, MSG_NO_CMD)

--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -1,5 +1,6 @@
 'use strict'
-const print = require('../utils').print
+
+const {print, getNodeOrAPI} = require('../utils')
 
 module.exports = {
   command: 'id',
@@ -15,12 +16,11 @@ module.exports = {
 
   handler (argv) {
     // TODO: handle argv.format
-    argv.ipfs.id((err, id) => {
-      if (err) {
-        throw err
-      }
-
-      print(JSON.stringify(id, '', 2))
-    })
+    return getNodeOrAPI(argv)
+      .then(node => Promise.all([Promise.resolve(node), node.id()]))
+      .then(([node, id]) => {
+        print(JSON.stringify(id, '', 2))
+        node.stop()
+      })
   }
 }

--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -20,7 +20,7 @@ module.exports = {
       .then(node => Promise.all([node, node.id()]))
       .then(([node, id]) => {
         print(JSON.stringify(id, '', 2))
-        node.stop()
+        node.clean()
       })
   }
 }

--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -17,7 +17,7 @@ module.exports = {
   handler (argv) {
     // TODO: handle argv.format
     return getNodeOrAPI(argv)
-      .then(node => Promise.all([Promise.resolve(node), node.id()]))
+      .then(node => Promise.all([node, node.id()]))
       .then(([node, id]) => {
         print(JSON.stringify(id, '', 2))
         node.stop()

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -2,8 +2,7 @@
 
 const Repo = require('ipfs-repo')
 const IPFS = require('../../core')
-const utils = require('../utils')
-const print = utils.print
+const { ipfsPathHelp, getRepoPath, print } = require('../utils')
 
 module.exports = {
   command: 'init',
@@ -12,7 +11,7 @@ module.exports = {
 
   builder (yargs) {
     return yargs
-      .epilog(utils.ipfsPathHelp)
+      .epilog(ipfsPathHelp)
       .option('bits', {
         type: 'number',
         alias: 'b',
@@ -22,33 +21,26 @@ module.exports = {
       .option('emptyRepo', {
         alias: 'e',
         type: 'boolean',
-        describe: "Don't add and pin help files to the local storage"
+        describe: 'Don\'t add and pin help files to the local storage'
       })
   },
 
   handler (argv) {
-    const path = utils.getRepoPath()
+    const path = getRepoPath()
 
     print(`initializing ipfs node at ${path}`)
 
-    const node = new IPFS({
+    return IPFS.createNodePromise({
       repo: new Repo(path),
       init: false,
       start: false
-    })
-
-    node.init({
-      bits: argv.bits,
-      emptyRepo: argv.emptyRepo,
-      pass: argv.pass,
-      log: print
-    }, (err) => {
-      if (err) {
-        if (err.code === 'EACCES') {
-          err.message = `EACCES: permission denied, stat $IPFS_PATH/version`
-        }
-        throw err
-      }
+    }).then(node => {
+      return node.init({
+        bits: argv.bits,
+        emptyRepo: argv.emptyRepo,
+        pass: argv.pass,
+        log: print
+      })
     })
   }
 }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const os = require('os')
-const print = require('../utils').print
+const {print, getNodeOrAPI} = require('../utils')
 
 module.exports = {
   command: 'version',
@@ -33,27 +33,25 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.version((err, data) => {
-      if (err) {
-        throw err
-      }
+    return getNodeOrAPI(argv, {forceInitialized: false})
+      .then(node => node.version())
+      .then(data => {
+        const withCommit = argv.all || argv.commit
+        const parsedVersion = `${data.version}${withCommit ? `-${data.commit}` : ''}`
 
-      const withCommit = argv.all || argv.commit
-      const parsedVersion = `${data.version}${withCommit ? `-${data.commit}` : ''}`
-
-      if (argv.repo) {
+        if (argv.repo) {
         // go-ipfs prints only the number, even without the --number flag.
-        print(data.repo)
-      } else if (argv.number) {
-        print(parsedVersion)
-      } else if (argv.all) {
-        print(`js-ipfs version: ${parsedVersion}`)
-        print(`Repo version: ${data.repo}`)
-        print(`System version: ${os.arch()}/${os.platform()}`)
-        print(`Node.js version: ${process.version}`)
-      } else {
-        print(`js-ipfs version: ${parsedVersion}`)
-      }
-    })
+          print(data.repo)
+        } else if (argv.number) {
+          print(parsedVersion)
+        } else if (argv.all) {
+          print(`js-ipfs version: ${parsedVersion}`)
+          print(`Repo version: ${data.repo}`)
+          print(`System version: ${os.arch()}/${os.platform()}`)
+          print(`Node.js version: ${process.version}`)
+        } else {
+          print(`js-ipfs version: ${parsedVersion}`)
+        }
+      })
   }
 }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -33,9 +33,9 @@ module.exports = {
   },
 
   handler (argv) {
-    return getNodeOrAPI(argv, {forceInitialized: false})
-      .then(node => node.version())
-      .then(data => {
+    return getNodeOrAPI(argv, {forceRepoInitialized: false})
+      .then(node => Promise.all([node, node.version()]))
+      .then(([node, data])=> {
         const withCommit = argv.all || argv.commit
         const parsedVersion = `${data.version}${withCommit ? `-${data.commit}` : ''}`
 

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -52,6 +52,8 @@ module.exports = {
         } else {
           print(`js-ipfs version: ${parsedVersion}`)
         }
+
+        node.clean();
       })
   }
 }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -44,6 +44,7 @@ exports.getNodeOrAPI = (argv, stateOptions = {forceInitialized: true}) => {
     return Promise.resolve(getAPICtl(argv.api))
   }
 
+  // Required inline to reduce startup time
   const IPFS = require('../core')
   return IPFS.createNodePromise({
     repo: exports.getRepoPath(),

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -38,7 +38,7 @@ function getAPICtl (apiAddr) {
   return APIctl(apiAddr)
 }
 
-exports.getNodeOrAPI = (argv, stateOptions = {forceInitialized: true}) => {
+exports.getNodeOrAPI = (argv, stateOptions = {forceRepoInitialized: true}) => {
   log('get node or api async')
   if (argv.api || isDaemonOn()) {
     return Promise.resolve(getAPICtl(argv.api))

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -38,13 +38,14 @@ function getAPICtl (apiAddr) {
   return APIctl(apiAddr)
 }
 
-exports.getNodeOrAPI = (argv) => {
+exports.getNodeOrAPI = (argv, stateOptions = {forceInitialized: true}) => {
   log('get node or api async')
   if (argv.api || isDaemonOn()) {
     return Promise.resolve(getAPICtl(argv.api))
   }
-  const {createReadyNodePromise} = require('../core')
-  return IPFS.createReadyNodePromise({
+
+  const {createNodePromise} = require('../core')
+  return IPFS.createNodePromise({
     repo: exports.getRepoPath(),
     init: false,
     start: false,
@@ -52,7 +53,7 @@ exports.getNodeOrAPI = (argv) => {
     EXPERIMENTAL: {
       pubsub: true
     }
-  })
+  }, stateOptions)
 }
 
 exports.getRepoPath = () => {

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -44,7 +44,7 @@ exports.getNodeOrAPI = (argv, stateOptions = {forceInitialized: true}) => {
     return Promise.resolve(getAPICtl(argv.api))
   }
 
-  const {createNodePromise} = require('../core')
+  const IPFS = require('../core')
   return IPFS.createNodePromise({
     repo: exports.getRepoPath(),
     init: false,

--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -72,7 +72,7 @@ module.exports = (self) => {
     // No repo, but need should init one
     if (doInit && !hasRepo) {
       tasks.push((cb) => self.init(initOptions, cb))
-      // we know we will have a repo for all follwing tasks
+      // we know we will have a repo for all following tasks
       // if the above succeeds
       hasRepo = true
     }
@@ -98,8 +98,12 @@ module.exports = (self) => {
     // Need to start up the node
     if (doStart) {
       if (!hasRepo) {
-        console.log('WARNING, trying to start ipfs node on uninitialized repo, maybe forgot to set "init: true"')
-        return done(new Error('Uninitalized repo'))
+        return done(
+          Object.assign(new Error('repo is not initialized yet'), {
+            code: 'ERR_REPO_NOT_INITIALIZED',
+            path: self._repo.path
+          })
+        )
       } else {
         tasks.push((cb) => self.start(cb))
       }

--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -36,15 +36,7 @@ module.exports = (self) => {
       }
     ], (err, res) => {
       if (err) {
-        // If the error is that no repo exists,
-        // which happens when the version file is not found
-        // we just want to signal that no repo exist, not
-        // fail the whole process.
-        // TODO: improve datastore and ipfs-repo implemenations so this error is a bit more unified
-        if (err.message.match(/not found/) || // indexeddb
-          err.message.match(/ENOENT/) || // fs
-          err.message.match(/No value/) // memory
-        ) {
+        if (err.code === 'ERR_REPO_NOT_INITIALIZED') {
           return cb(null, false)
         }
         return cb(err)

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -27,11 +27,6 @@ module.exports = function init (self) {
       callback(null, res)
     }
 
-    if (self.state.state() !== 'uninitalized') {
-      return done(new Error('Not able to init from state: ' + self.state.state()))
-    }
-
-    self.state.init()
     self.log('init')
 
     opts.emptyRepo = opts.emptyRepo || false

--- a/src/core/components/repo.js
+++ b/src/core/components/repo.js
@@ -19,15 +19,7 @@ module.exports = function repo (self) {
     version: promisify((callback) => {
       self._repo._isInitialized(err => {
         if (err) {
-          // TODO: (dryajov) This is really hacky, there must be a better way
-          const match = [
-            /Key not found in database \[\/version\]/,
-            /ENOENT/,
-            /not yet initialized/
-          ].some((m) => {
-            return m.test(err.message)
-          })
-          if (match) {
+          if (err.code === 'ERR_REPO_NOT_INITIALIZED') {
             // this repo has not been initialized
             return callback(null, repoVersion)
           }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -164,7 +164,7 @@ IPFS.createNodePromise = (options = {}, stateOptions = {}) => {
     })
 
     node.once('ready', () => {
-      if (stateOptions.forceInitialized) {
+      if (stateOptions.forceRepoInitialized) {
         node._repo._isInitialized((err) => {
           if (err) {
             reject(err)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -136,6 +136,35 @@ class IPFS extends EventEmitter {
 
     boot(this)
   }
+
+
+  /**
+   * Clean a node after usage, checks the current state and calls the needed methods
+   * Until _repo.close return a promise we just throw the error to perserve the stack
+   *
+   * @memberof IPFS
+   */
+  clean() {
+    this.log('cleaning: state ', this.state.state())
+    switch (this.state.state()) {
+      case 'stopped':
+        this._repo.close(err => {
+          if(err) {
+            throw err
+          }
+        });
+        break;
+      case 'running':
+        this.stop(err => {
+          if(err) {
+            throw err
+          }
+        })
+        break;
+      default:
+        break;
+    }
+  }
 }
 
 module.exports = IPFS
@@ -160,6 +189,7 @@ IPFS.createNodePromise = (options = {}, stateOptions = {}) => {
     const node = new IPFS(options)
 
     node.on('error', err => {
+      node.clean()
       reject(err)
     })
 

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -81,7 +81,6 @@ function HttpApi (repo, config, cliArgs) {
 
         this.node.once('error', (err) => {
           this.log('error starting core', err)
-          err.code = 'ENOENT'
           cb(err)
         })
         this.node.once('start', cb)

--- a/test/cli/config.js
+++ b/test/cli/config.js
@@ -58,7 +58,7 @@ describe('config', () => runOnAndOff((thing) => {
     })
 
     it('set a config key with invalid json', () => {
-      return ipfs.fail('config foo {"bar:0} --json')
+      return ipfs.fail('config foo {\\"bar:0} --json')
     })
 
     it('get a config key value', () => {

--- a/test/cli/daemon.js
+++ b/test/cli/daemon.js
@@ -118,10 +118,10 @@ describe('daemon', () => {
   it('gives error if user hasn\'t run init before', function (done) {
     this.timeout(100 * 1000)
 
-    const expectedError = 'no initialized ipfs repo found in ' + repoPath
+    const expectedError = 'No IPFS repo found in ' + repoPath
 
     ipfs('daemon').catch((err) => {
-      expect(err.stdout).to.have.string(expectedError)
+      expect(err.stderr).to.have.string(expectedError)
       done()
     })
   })

--- a/test/http-api/interface/index.js
+++ b/test/http-api/interface/index.js
@@ -4,7 +4,7 @@
 const fs = require('fs')
 const path = require('path')
 
-describe('## interface-ipfs-core over ipfs-api', () => {
+describe.only('## interface-ipfs-core over ipfs-api', () => {
   fs.readdirSync(path.join(__dirname))
     .forEach((file) => file !== 'index.js' && require(`./${file}`))
 })

--- a/test/http-api/interface/index.js
+++ b/test/http-api/interface/index.js
@@ -4,7 +4,7 @@
 const fs = require('fs')
 const path = require('path')
 
-describe.only('## interface-ipfs-core over ipfs-api', () => {
+describe('## interface-ipfs-core over ipfs-api', () => {
   fs.readdirSync(path.join(__dirname))
     .forEach((file) => file !== 'index.js' && require(`./${file}`))
 })


### PR DESCRIPTION
This PR should improve error handling and help messages in the cli. All messages printed to the console follow the go implementation.

In order to do this i used the yargs `fail()` method to catch and handle errors from the commands (https://github.com/ipfs/js-ipfs/blob/feat/better-errors-cli/src/cli/bin.js#L81-L104).
Previously we were using the `parse()` method which isn't made to handle errors, its for running yargs in headless mode to build cli tests.

The `fail()` method handles promises returned from the commands handler, so its the perfect top-level spot to catch errors and output help specific to the cli. Like this:
https://github.com/ipfs/js-ipfs/blob/feat/better-errors-cli/src/cli/bin.js#L87-L90
Another nice thing is that we can hide the stack trace behind a flag `--debug or -D`.

In the PR i keep an hybrid solution only `daemon`, `init` and `id` commands are ported to return promises and use `fail()`. Everything else works almost the same, only two things changed:
 - moved away from yargs singleton mode, now we actually have two different instances [here](https://github.com/ipfs/js-ipfs/blob/feat/better-errors-cli/src/cli/bin.js#L43) and [here](https://github.com/ipfs/js-ipfs/blob/feat/better-errors-cli/src/cli/bin.js#L106)
 - all errors are actually outputted correctly

The ultimate goal if everyone agrees would be to port all commands to something like the 'id' command included in the PR and start creating errors with codes like this 
```js
Object.assign(new Error('repo is not initialized yet'),
{
    code: 'ERR_REPO_NOT_INITIALIZED',
    path: node._repo.path
})
```  
  
Basically just adding error codes just like node does, so we can do this
```js
if (err.code === 'ERR_REPO_NOT_INITIALIZED') {
     return `No IPFS repo found in ${err.path}. 
please run: 'ipfs init'`
}
```

instead of this
```js
if (err.message.match(/not found/) || // indexeddb
    err.message.match(/ENOENT/) || // fs
    err.message.match(/No value/) // memory
) {
    return cb(null, false)
}
```

In the end we could delete all [this](https://github.com/ipfs/js-ipfs/blob/feat/better-errors-cli/src/cli/bin.js#L105-L145) and do all the cli specific error handling inside `fail()`.



Needs:
- https://github.com/ipfs/js-ipfsd-ctl/pull/241



Fixes #1180