### PR TITLE
Faster tests

### DIFF
--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const CID = require('cids')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'stat',
 
@@ -11,6 +8,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const CID = require('cids')
+    const print = require('../../utils').print
+
     argv.ipfs.bitswap.stat((err, stats) => {
       if (err) {
         throw err

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'wantlist',
 
@@ -16,6 +14,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../../utils').print
+
     // TODO: handle argv.peer
     argv.ipfs.bitswap.wantlist((err, res) => {
       if (err) {

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const CID = require('cids')
-
 module.exports = {
   command: 'get <key>',
 
@@ -10,6 +8,7 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const CID = require('cids')
     const cid = new CID(argv.key)
 
     argv.ipfs.block.get(cid, (err, block) => {

--- a/src/cli/commands/block/put.js
+++ b/src/cli/commands/block/put.js
@@ -1,36 +1,5 @@
 'use strict'
 
-const CID = require('cids')
-const multihashing = require('multihashing-async')
-const bl = require('bl')
-const fs = require('fs')
-const Block = require('ipfs-block')
-const waterfall = require('async/waterfall')
-const print = require('../../utils').print
-
-function addBlock (data, opts) {
-  const ipfs = opts.ipfs
-  let cid
-
-  waterfall([
-    (cb) => multihashing(data, opts.mhtype || 'sha2-256', cb),
-    (multihash, cb) => {
-      if (opts.format !== 'dag-pb' || opts.version !== 0) {
-        cid = new CID(1, opts.format || 'dag-pb', multihash)
-      } else {
-        cid = new CID(0, 'dag-pb', multihash)
-      }
-
-      ipfs.block.put(new Block(data, cid), cb)
-    }
-  ], (err) => {
-    if (err) {
-      throw err
-    }
-    print(cid.toBaseEncodedString())
-  })
-}
-
 module.exports = {
   command: 'put [block]',
 
@@ -58,6 +27,37 @@ module.exports = {
   },
 
   handler (argv) {
+    const CID = require('cids')
+    const multihashing = require('multihashing-async')
+    const bl = require('bl')
+    const fs = require('fs')
+    const Block = require('ipfs-block')
+    const waterfall = require('async/waterfall')
+    const print = require('../../utils').print
+
+    function addBlock (data, opts) {
+      const ipfs = opts.ipfs
+      let cid
+
+      waterfall([
+        (cb) => multihashing(data, opts.mhtype || 'sha2-256', cb),
+        (multihash, cb) => {
+          if (opts.format !== 'dag-pb' || opts.version !== 0) {
+            cid = new CID(1, opts.format || 'dag-pb', multihash)
+          } else {
+            cid = new CID(0, 'dag-pb', multihash)
+          }
+
+          ipfs.block.put(new Block(data, cid), cb)
+        }
+      ], (err) => {
+        if (err) {
+          throw err
+        }
+        print(cid.toBaseEncodedString())
+      })
+    }
+
     if (argv.block) {
       const buf = fs.readFileSync(argv.block)
       return addBlock(buf, argv)

--- a/src/cli/commands/block/rm.js
+++ b/src/cli/commands/block/rm.js
@@ -1,9 +1,5 @@
 'use strict'
 
-const utils = require('../../utils')
-const mh = require('multihashes')
-const print = utils.print
-
 module.exports = {
   command: 'rm <key>',
 
@@ -12,6 +8,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const utils = require('../../utils')
+    const print = utils.print
+    const mh = require('multihashes')
     if (utils.isDaemonOn()) {
       // TODO implement this once `js-ipfs-api` supports it
       throw new Error('rm block with daemon running is not yet implemented')

--- a/src/cli/commands/block/stat.js
+++ b/src/cli/commands/block/stat.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const CID = require('cids')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'stat <key>',
 
@@ -11,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const CID = require('cids')
+    const print = require('../../utils').print
     argv.ipfs.block.stat(new CID(argv.key), (err, stats) => {
       if (err) {
         throw err

--- a/src/cli/commands/bootstrap/add.js
+++ b/src/cli/commands/bootstrap/add.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'add [<peer>]',
 
@@ -16,6 +14,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.bootstrap.add(argv.peer, {
       default: argv.default
     }, (err, list) => {

--- a/src/cli/commands/bootstrap/list.js
+++ b/src/cli/commands/bootstrap/list.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'list',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.bootstrap.list((err, list) => {
       if (err) {
         throw err

--- a/src/cli/commands/bootstrap/rm.js
+++ b/src/cli/commands/bootstrap/rm.js
@@ -1,10 +1,5 @@
 'use strict'
 
-const debug = require('debug')
-const log = debug('cli:bootstrap')
-log.error = debug('cli:bootstrap:error')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'rm [<peer>]',
 
@@ -19,6 +14,11 @@ module.exports = {
   },
 
   handler (argv) {
+    const debug = require('debug')
+    const log = debug('cli:bootstrap')
+    log.error = debug('cli:bootstrap:error')
+    const print = require('../../utils').print
+
     argv.ipfs.bootstrap.rm(argv.peer, {
       all: argv.all
     }, (err, list) => {

--- a/src/cli/commands/commands.js
+++ b/src/cli/commands/commands.js
@@ -1,7 +1,4 @@
 'use strict'
-const print = require('../utils').print
-const path = require('path')
-const glob = require('glob').sync
 
 module.exports = {
   command: 'commands',
@@ -9,6 +6,9 @@ module.exports = {
   describe: 'List all available commands',
 
   handler () {
+    const print = require('../utils').print
+    const path = require('path')
+    const glob = require('glob').sync
     const basePath = path.resolve(__dirname, '..')
 
     // modeled after https://github.com/vdemedes/ronin/blob/master/lib/program.js#L78

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -1,6 +1,4 @@
 'use strict'
-const print = require('../utils').print
-
 module.exports = {
   command: 'config <key> [value]',
 
@@ -24,6 +22,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../utils').print
+
     if (argv._handled) {
       return
     }

--- a/src/cli/commands/config/edit.js
+++ b/src/cli/commands/config/edit.js
@@ -1,12 +1,5 @@
 'use strict'
 
-const spawn = require('child_process').spawn
-const fs = require('fs')
-const temp = require('temp')
-const waterfall = require('async/waterfall')
-
-const utils = require('../../utils')
-
 module.exports = {
   command: 'edit',
 
@@ -15,6 +8,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const spawn = require('child_process').spawn
+    const fs = require('fs')
+    const temp = require('temp')
+    const waterfall = require('async/waterfall')
+
+    const utils = require('../../utils')
     if (argv._handled) return
     argv._handled = true
 

--- a/src/cli/commands/config/replace.js
+++ b/src/cli/commands/config/replace.js
@@ -1,9 +1,5 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs')
-const utils = require('../../utils')
-
 module.exports = {
   command: 'replace <file>',
 
@@ -12,6 +8,10 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const path = require('path')
+    const fs = require('fs')
+    const utils = require('../../utils')
+
     if (argv._handled) return
     argv._handled = true
 

--- a/src/cli/commands/config/show.js
+++ b/src/cli/commands/config/show.js
@@ -1,10 +1,5 @@
 'use strict'
 
-const debug = require('debug')
-const log = debug('cli:config')
-log.error = debug('cli:config:error')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'show',
 
@@ -13,6 +8,11 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const debug = require('debug')
+    const log = debug('cli:config')
+    log.error = debug('cli:config:error')
+    const print = require('../../utils').print
+
     if (argv._handled) return
     argv._handled = true
 

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -1,10 +1,7 @@
 'use strict'
 
-const HttpAPI = require('../../http')
 const utils = require('../utils')
 const print = utils.print
-
-let httpAPI
 
 module.exports = {
   command: 'daemon',
@@ -29,10 +26,11 @@ module.exports = {
   },
 
   handler (argv) {
+    const HttpAPI = require('../../http')
     print('Initializing daemon...')
 
     const repoPath = utils.getRepoPath()
-    httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
+    const httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
 
     httpAPI.start((err) => {
       if (err && err.code === 'ENOENT' && err.message.match(/Uninitalized repo/i)) {

--- a/src/cli/commands/dag/get.js
+++ b/src/cli/commands/dag/get.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const CID = require('cids')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'get <cid path>',
 
@@ -16,6 +13,9 @@ module.exports = {
   },
 
   handler (argv) {
+    const CID = require('cids')
+    const print = require('../../utils').print
+
     const refParts = argv.cidpath.split('/')
     const cidString = refParts[0]
     const path = refParts.slice(1).join('/')

--- a/src/cli/commands/dns.js
+++ b/src/cli/commands/dns.js
@@ -1,6 +1,4 @@
 'use strict'
-const print = require('../utils').print
-
 module.exports = {
   command: 'dns <domain>',
 
@@ -13,6 +11,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../utils').print
+
     argv.ipfs.dns(argv['domain'], (err, path) => {
       if (err) {
         throw err

--- a/src/cli/commands/file/ls.js
+++ b/src/cli/commands/file/ls.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'ls <key>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     let path = argv.key
     // `ipfs file ls` is deprecated. See https://ipfs.io/docs/commands/#ipfs-file-ls
     print(`This functionality is deprecated, and will be removed in future versions. If possible, please use 'ipfs ls' instead.`)

--- a/src/cli/commands/files.js
+++ b/src/cli/commands/files.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const print = require('../utils').print
-const lsCmd = require('./ls')
-
 module.exports = {
   command: 'files <command>',
 
   description: 'Operations over files (add, cat, get, ls, etc)',
 
   builder (yargs) {
+    const lsCmd = require('./ls')
     return yargs
       .commandDir('files')
       .command(lsCmd)
   },
 
   handler (argv) {
+    const print = require('../utils').print
+
     print('Type `jsipfs files --help` for more instructions')
   }
 }

--- a/src/cli/commands/files/get.js
+++ b/src/cli/commands/files/get.js
@@ -1,49 +1,5 @@
 'use strict'
 
-var fs = require('fs')
-const path = require('path')
-const mkdirp = require('mkdirp')
-const pull = require('pull-stream')
-const toPull = require('stream-to-pull-stream')
-const print = require('../../utils').print
-
-function checkArgs (hash, outPath) {
-  // format the output directory
-  if (!outPath.endsWith(path.sep)) {
-    outPath += path.sep
-  }
-
-  return outPath
-}
-
-function ensureDirFor (dir, file, callback) {
-  const lastSlash = file.path.lastIndexOf('/')
-  const filePath = file.path.substring(0, lastSlash + 1)
-  const dirPath = path.join(dir, filePath)
-  mkdirp(dirPath, callback)
-}
-
-function fileHandler (dir) {
-  return function onFile (file, callback) {
-    ensureDirFor(dir, file, (err) => {
-      if (err) {
-        callback(err)
-      } else {
-        const fullFilePath = path.join(dir, file.path)
-        if (file.content) {
-          file.content
-            .pipe(fs.createWriteStream(fullFilePath))
-            .once('error', callback)
-            .once('finish', callback)
-        } else {
-          // this is a dir
-          mkdirp(fullFilePath, callback)
-        }
-      }
-    })
-  }
-}
-
 module.exports = {
   command: 'get <ipfsPath>',
 
@@ -58,6 +14,50 @@ module.exports = {
   },
 
   handler (argv) {
+    var fs = require('fs')
+    const path = require('path')
+    const mkdirp = require('mkdirp')
+    const pull = require('pull-stream')
+    const toPull = require('stream-to-pull-stream')
+    const print = require('../../utils').print
+
+    function checkArgs (hash, outPath) {
+      // format the output directory
+      if (!outPath.endsWith(path.sep)) {
+        outPath += path.sep
+      }
+
+      return outPath
+    }
+
+    function ensureDirFor (dir, file, callback) {
+      const lastSlash = file.path.lastIndexOf('/')
+      const filePath = file.path.substring(0, lastSlash + 1)
+      const dirPath = path.join(dir, filePath)
+      mkdirp(dirPath, callback)
+    }
+
+    function fileHandler (dir) {
+      return function onFile (file, callback) {
+        ensureDirFor(dir, file, (err) => {
+          if (err) {
+            callback(err)
+          } else {
+            const fullFilePath = path.join(dir, file.path)
+            if (file.content) {
+              file.content
+                .pipe(fs.createWriteStream(fullFilePath))
+                .once('error', callback)
+                .once('finish', callback)
+            } else {
+              // this is a dir
+              mkdirp(fullFilePath, callback)
+            }
+          }
+        })
+      }
+    }
+
     const ipfsPath = argv['ipfsPath']
 
     const dir = checkArgs(ipfsPath, argv.output)

--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -1,6 +1,4 @@
 'use strict'
-const print = require('../utils').print
-
 module.exports = {
   command: 'id',
 
@@ -14,6 +12,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../utils').print
+
     // TODO: handle argv.format
     argv.ipfs.id((err, id) => {
       if (err) {

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const Repo = require('ipfs-repo')
-const IPFS = require('../../core')
 const utils = require('../utils')
 const print = utils.print
 
@@ -27,6 +25,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const Repo = require('ipfs-repo')
+    const IPFS = require('../../core')
     const path = utils.getRepoPath()
 
     print(`initializing ipfs node at ${path}`)

--- a/src/cli/commands/key/export.js
+++ b/src/cli/commands/key/export.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-
 module.exports = {
   command: 'export <name>',
 
@@ -23,6 +21,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const fs = require('fs')
+
     argv.ipfs.key.export(argv.name, argv.passout, (err, pem) => {
       if (err) {
         throw err

--- a/src/cli/commands/key/gen.js
+++ b/src/cli/commands/key/gen.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'gen <name>',
 
@@ -21,6 +19,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../../utils').print
+
     const opts = {
       type: argv.type,
       size: argv.size

--- a/src/cli/commands/key/import.js
+++ b/src/cli/commands/key/import.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fs = require('fs')
-const print = require('../../utils').print
 
 module.exports = {
   command: 'import <name>',
@@ -24,6 +23,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.key.import(argv.name, argv.input, argv.passin, (err, key) => {
       if (err) {
         throw err

--- a/src/cli/commands/key/list.js
+++ b/src/cli/commands/key/list.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'list',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.key.list((err, keys) => {
       if (err) {
         throw err

--- a/src/cli/commands/key/rename.js
+++ b/src/cli/commands/key/rename.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'rename <name> <newName>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.key.rename(argv.name, argv.newName, (err, res) => {
       if (err) {
         throw err

--- a/src/cli/commands/key/rm.js
+++ b/src/cli/commands/key/rm.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'rm <name>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.key.rm(argv.name, (err, key) => {
       if (err) {
         throw err

--- a/src/cli/commands/ls.js
+++ b/src/cli/commands/ls.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const utils = require('../utils')
-
 module.exports = {
   command: 'ls <key>',
 
@@ -28,6 +26,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const utils = require('../utils')
+
     let path = argv.key
     if (path.startsWith('/ipfs/')) {
       path = path.replace('/ipfs/', '')

--- a/src/cli/commands/object/data.js
+++ b/src/cli/commands/object/data.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'data <key>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.object.data(argv.key, {
       enc: 'base58'
     }, (err, data) => {

--- a/src/cli/commands/object/get.js
+++ b/src/cli/commands/object/get.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'get <key>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.object.get(argv.key, {enc: 'base58'}, (err, node) => {
       if (err) {
         throw err

--- a/src/cli/commands/object/links.js
+++ b/src/cli/commands/object/links.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'links <key>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.object.links(argv.key, {
       enc: 'base58'
     }, (err, links) => {

--- a/src/cli/commands/object/new.js
+++ b/src/cli/commands/object/new.js
@@ -1,10 +1,5 @@
 'use strict'
 
-const debug = require('debug')
-const log = debug('cli:object')
-log.error = debug('cli:object:error')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'new [<template>]',
 
@@ -13,6 +8,11 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const debug = require('debug')
+    const log = debug('cli:object')
+    log.error = debug('cli:object:error')
+    const print = require('../../utils').print
+
     argv.ipfs.object.new(argv.template, (err, node) => {
       if (err) {
         throw err

--- a/src/cli/commands/object/patch/add-link.js
+++ b/src/cli/commands/object/patch/add-link.js
@@ -1,9 +1,5 @@
 'use strict'
 
-const dagPB = require('ipld-dag-pb')
-const DAGLink = dagPB.DAGLink
-const print = require('../../../utils').print
-
 module.exports = {
   command: 'add-link <root> <name> <ref>',
 
@@ -12,6 +8,10 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const dagPB = require('ipld-dag-pb')
+    const DAGLink = dagPB.DAGLink
+    const print = require('../../../utils').print
+
     const ipfs = argv.ipfs
     ipfs.object.get(argv.ref, {
       enc: 'base58'

--- a/src/cli/commands/object/patch/append-data.js
+++ b/src/cli/commands/object/patch/append-data.js
@@ -1,25 +1,5 @@
 'use strict'
 
-const bl = require('bl')
-const fs = require('fs')
-const debug = require('debug')
-const log = debug('cli:object')
-log.error = debug('cli:object:error')
-const print = require('../../../utils').print
-
-function appendData (key, data, ipfs) {
-  ipfs.object.patch.appendData(key, data, {
-    enc: 'base58'
-  }, (err, node) => {
-    if (err) {
-      throw err
-    }
-    const nodeJSON = node.toJSON()
-
-    print(nodeJSON.multihash)
-  })
-}
-
 module.exports = {
   command: 'append-data <root> [data]',
 
@@ -28,6 +8,25 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const bl = require('bl')
+    const fs = require('fs')
+    const debug = require('debug')
+    const log = debug('cli:object')
+    log.error = debug('cli:object:error')
+    const print = require('../../../utils').print
+
+    function appendData (key, data, ipfs) {
+      ipfs.object.patch.appendData(key, data, {
+        enc: 'base58'
+      }, (err, node) => {
+        if (err) {
+          throw err
+        }
+        const nodeJSON = node.toJSON()
+
+        print(nodeJSON.multihash)
+      })
+    }
     const ipfs = argv.ipfs
     if (argv.data) {
       return appendData(argv.root, fs.readFileSync(argv.data), ipfs)

--- a/src/cli/commands/object/patch/rm-link.js
+++ b/src/cli/commands/object/patch/rm-link.js
@@ -1,11 +1,5 @@
 'use strict'
 
-const DAGLink = require('ipld-dag-pb').DAGLink
-const debug = require('debug')
-const log = debug('cli:object')
-log.error = debug('cli:object:error')
-const print = require('../../../utils').print
-
 module.exports = {
   command: 'rm-link <root> <link>',
 
@@ -14,6 +8,11 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const DAGLink = require('ipld-dag-pb').DAGLink
+    const debug = require('debug')
+    const log = debug('cli:object')
+    log.error = debug('cli:object:error')
+    const print = require('../../../utils').print
     // TODO rmLink should support removing by name and/or multihash
     // without having to know everything, which in fact it does, however,
     // since it expectes a DAGLink type, we have to pass some fake size and

--- a/src/cli/commands/object/patch/set-data.js
+++ b/src/cli/commands/object/patch/set-data.js
@@ -1,25 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const bl = require('bl')
-const debug = require('debug')
-const log = debug('cli:object')
-log.error = debug('cli:object:error')
-const print = require('../../../utils').print
-
-function parseAndAddNode (key, data, ipfs) {
-  ipfs.object.patch.setData(key, data, {
-    enc: 'base58'
-  }, (err, node) => {
-    if (err) {
-      throw err
-    }
-    const nodeJSON = node.toJSON()
-
-    print(nodeJSON.multihash)
-  })
-}
-
 module.exports = {
   command: 'set-data <root> [data]',
 
@@ -28,6 +8,25 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const fs = require('fs')
+    const bl = require('bl')
+    const debug = require('debug')
+    const log = debug('cli:object')
+    log.error = debug('cli:object:error')
+    const print = require('../../../utils').print
+
+    function parseAndAddNode (key, data, ipfs) {
+      ipfs.object.patch.setData(key, data, {
+        enc: 'base58'
+      }, (err, node) => {
+        if (err) {
+          throw err
+        }
+        const nodeJSON = node.toJSON()
+
+        print(nodeJSON.multihash)
+      })
+    }
     const ipfs = argv.ipfs
     if (argv.data) {
       return parseAndAddNode(argv.root, fs.readFileSync(argv.data), ipfs)

--- a/src/cli/commands/object/put.js
+++ b/src/cli/commands/object/put.js
@@ -1,21 +1,5 @@
 'use strict'
 
-const bl = require('bl')
-const fs = require('fs')
-const print = require('../../utils').print
-
-function putNode (buf, enc, ipfs) {
-  ipfs.object.put(buf, {enc: enc}, (err, node) => {
-    if (err) {
-      throw err
-    }
-
-    const nodeJSON = node.toJSON()
-
-    print(`added ${nodeJSON.multihash}`)
-  })
-}
-
 module.exports = {
   command: 'put [data]',
 
@@ -29,6 +13,21 @@ module.exports = {
   },
 
   handler (argv) {
+    const bl = require('bl')
+    const fs = require('fs')
+    const print = require('../../utils').print
+
+    function putNode (buf, enc, ipfs) {
+      ipfs.object.put(buf, {enc: enc}, (err, node) => {
+        if (err) {
+          throw err
+        }
+
+        const nodeJSON = node.toJSON()
+
+        print(`added ${nodeJSON.multihash}`)
+      })
+    }
     const ipfs = argv.ipfs
     if (argv.data) {
       const buf = fs.readFileSync(argv.data)

--- a/src/cli/commands/object/stat.js
+++ b/src/cli/commands/object/stat.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'stat <key>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.object.stat(argv.key, {
       enc: 'base58'
     }, (err, stats) => {

--- a/src/cli/commands/pubsub/ls.js
+++ b/src/cli/commands/pubsub/ls.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'ls',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.pubsub.ls((err, subscriptions) => {
       if (err) {
         throw err

--- a/src/cli/commands/pubsub/peers.js
+++ b/src/cli/commands/pubsub/peers.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'peers <topic>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.pubsub.peers(argv.topic, (err, peers) => {
       if (err) {
         throw err

--- a/src/cli/commands/pubsub/sub.js
+++ b/src/cli/commands/pubsub/sub.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'sub <topic>',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     const handler = (msg) => {
       print(msg.data.toString())
     }

--- a/src/cli/commands/repo/stat.js
+++ b/src/cli/commands/repo/stat.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'stat',
 
@@ -15,6 +13,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.repo.stat({human: argv.human}, (err, stats) => {
       if (err) {
         throw err

--- a/src/cli/commands/repo/version.js
+++ b/src/cli/commands/repo/version.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'version',
 
@@ -10,6 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.repo.version((err, version) => {
       if (err) {
         throw err

--- a/src/cli/commands/stats/bw.js
+++ b/src/cli/commands/stats/bw.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const pull = require('pull-stream')
-
 module.exports = {
   command: 'bw',
 
@@ -27,6 +25,7 @@ module.exports = {
   },
 
   handler (argv) {
+    const pull = require('pull-stream')
     const stream = argv.ipfs.stats.bwPullStream({
       peer: argv.peer,
       proto: argv.proto,

--- a/src/cli/commands/stats/repo.js
+++ b/src/cli/commands/stats/repo.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'repo',
 
@@ -15,6 +13,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.stats.repo({human: argv.human}, (err, stats) => {
       if (err) {
         throw err

--- a/src/cli/commands/swarm/addrs.js
+++ b/src/cli/commands/swarm/addrs.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'addrs',
 
@@ -13,6 +11,8 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../../utils').print
+
     argv.ipfs.swarm.addrs((err, res) => {
       if (err) {
         throw err

--- a/src/cli/commands/swarm/addrs/local.js
+++ b/src/cli/commands/swarm/addrs/local.js
@@ -1,11 +1,5 @@
 'use strict'
 
-const utils = require('../../../utils')
-const debug = require('debug')
-const log = debug('cli:object')
-log.error = debug('cli:object:error')
-const print = require('../../../utils').print
-
 module.exports = {
   command: 'local',
 
@@ -14,6 +8,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const utils = require('../../../utils')
+    const debug = require('debug')
+    const log = debug('cli:object')
+    log.error = debug('cli:object:error')
+    const print = require('../../../utils').print
+
     if (!utils.isDaemonOn()) {
       throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
     }

--- a/src/cli/commands/swarm/connect.js
+++ b/src/cli/commands/swarm/connect.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const utils = require('../../utils')
-const print = utils.print
-
 module.exports = {
   command: 'connect <address>',
 
@@ -11,6 +8,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const utils = require('../../utils')
+    const print = utils.print
+
     if (!utils.isDaemonOn()) {
       throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
     }

--- a/src/cli/commands/swarm/disconnect.js
+++ b/src/cli/commands/swarm/disconnect.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const utils = require('../../utils')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'disconnect <address>',
 
@@ -11,6 +8,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const utils = require('../../utils')
+    const print = require('../../utils').print
+
     if (!utils.isDaemonOn()) {
       throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
     }

--- a/src/cli/commands/swarm/peers.js
+++ b/src/cli/commands/swarm/peers.js
@@ -1,10 +1,5 @@
 'use strict'
 
-const mafmt = require('mafmt')
-const multiaddr = require('multiaddr')
-const utils = require('../../utils')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'peers',
 
@@ -13,6 +8,11 @@ module.exports = {
   builder: {},
 
   handler (argv) {
+    const mafmt = require('mafmt')
+    const multiaddr = require('multiaddr')
+    const utils = require('../../utils')
+    const print = require('../../utils').print
+
     if (!utils.isDaemonOn()) {
       throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
     }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const os = require('os')
-const print = require('../utils').print
-
 module.exports = {
   command: 'version',
 
@@ -33,6 +30,9 @@ module.exports = {
   },
 
   handler (argv) {
+    const print = require('../utils').print
+
+    const os = require('os')
     argv.ipfs.version((err, data) => {
       if (err) {
         throw err

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -1,21 +1,15 @@
 'use strict'
 
-const fs = require('fs')
-const os = require('os')
-const APIctl = require('ipfs-api')
-const multiaddr = require('multiaddr')
-const IPFS = require('../core')
 const path = require('path')
 const debug = require('debug')
 const log = debug('cli')
 log.error = debug('cli:error')
-const Progress = require('progress')
-const byteman = require('byteman')
 
 exports = module.exports
 
 exports.isDaemonOn = isDaemonOn
 function isDaemonOn () {
+  const fs = require('fs')
   try {
     fs.readFileSync(path.join(exports.getRepoPath(), 'api'))
     log('daemon is on')
@@ -28,10 +22,15 @@ function isDaemonOn () {
 
 exports.getAPICtl = getAPICtl
 function getAPICtl (apiAddr) {
+  const APIctl = require('ipfs-api')
+
   if (!apiAddr && !isDaemonOn()) {
     throw new Error('daemon is not on')
   }
   if (!apiAddr) {
+    const fs = require('fs')
+    const multiaddr = require('multiaddr')
+
     const apiPath = path.join(exports.getRepoPath(), 'api')
     apiAddr = multiaddr(fs.readFileSync(apiPath).toString()).toString()
   }
@@ -42,6 +41,7 @@ exports.getIPFS = (argv, callback) => {
   if (argv.api || isDaemonOn()) {
     return callback(null, getAPICtl(argv.api), (cb) => cb())
   }
+  const IPFS = require('../core')
 
   const node = new IPFS({
     repo: exports.getRepoPath(),
@@ -71,6 +71,7 @@ exports.getIPFS = (argv, callback) => {
 }
 
 exports.getRepoPath = () => {
+  const os = require('os')
   return process.env.IPFS_PATH || os.homedir() + '/.jsipfs'
 }
 
@@ -92,6 +93,9 @@ exports.print = (msg, newline) => {
 }
 
 exports.createProgressBar = (totalBytes) => {
+  const Progress = require('progress')
+  const byteman = require('byteman')
+
   const total = byteman(totalBytes, 2, 'MB')
   const barFormat = `:progress / ${total} [:bar] :percent :etas`
 

--- a/test/cli/daemon.js
+++ b/test/cli/daemon.js
@@ -79,7 +79,7 @@ describe('daemon', () => {
       const res = ipfs('daemon')
       const timeout = setTimeout(() => {
         done(new Error('Daemon did not get ready in time'))
-      }, 1000 * 60)
+      }, 1000 * 120)
       res.stdout.on('data', (data) => {
         const line = data.toString()
         if (line.includes('Daemon is ready')) {

--- a/test/cli/daemon.js
+++ b/test/cli/daemon.js
@@ -83,7 +83,7 @@ describe('daemon', () => {
       res.stdout.on('data', (data) => {
         const line = data.toString()
         if (line.includes('Daemon is ready')) {
-          clearInterval(timeout)
+          clearTimeout(timeout)
           res.kill()
           done()
         }


### PR DESCRIPTION
Pretty basic changes, in short:

- Make the daemon cli tests faster by not relying on timeouts and streaming stdout (removed pull-streams here as well) Made the daemon tests go from 6 minutes to 30 seconds
- Inline all the `require`s in the cli part of js-ipfs. Makes the cli (without arguments) go from 0.9 seconds to 0.3 seconds, speeding up the CLI tests from 12 minutes to 7 minutes
- Modify the load tests for pubsub in interface-core-ipfs to be more like mini-load tests

More to come

Depends on https://github.com/ipfs/interface-ipfs-core/pull/263