### PR TITLE
chore: allow dht to be enabled via cli arg

### DIFF
--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -22,6 +22,10 @@ module.exports = {
         type: 'boolean',
         default: false
       })
+      .option('enable-dht-experiment', {
+        type: 'boolean',
+        default: false
+      })
   },
 
   handler (argv) {

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -70,6 +70,7 @@ function HttpApi (repo, config, cliArgs) {
             pass: cliArgs && cliArgs.pass,
             EXPERIMENTAL: {
               pubsub: cliArgs && cliArgs.enablePubsubExperiment,
+              dht: cliArgs && cliArgs.enableDhtExperiment,
               sharding: cliArgs && cliArgs.enableShardingExperiment
             },
             libp2p: libp2p


### PR DESCRIPTION
This will allow to spin ipfs nodes using `js-ipfsd-ctl` and the DHT experimental feature enabled.