### PR TITLE
feat: bitswap.wantlist peerid

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "expose-loader": "~0.7.5",
     "form-data": "^2.3.2",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.68.1",
+    "interface-ipfs-core": "~0.68.2",
     "ipfsd-ctl": "~0.37.3",
     "lodash": "^4.17.10",
     "mocha": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "expose-loader": "~0.7.5",
     "form-data": "^2.3.2",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.66.2",
+    "interface-ipfs-core": "~0.68.1",
     "ipfsd-ctl": "~0.37.3",
     "lodash": "^4.17.10",
     "mocha": "^5.1.1",

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const CID = require('cids')
 const print = require('../../utils').print
 
 module.exports = {
@@ -17,11 +16,7 @@ module.exports = {
       }
 
       stats.wantlist = stats.wantlist || []
-      stats.wantlist = stats.wantlist.map((entry) => {
-        const buf = Buffer.from(entry.cid.hash.data)
-        const cid = new CID(entry.cid.version, entry.cid.codec, buf)
-        return cid.toBaseEncodedString()
-      })
+      stats.wantlist = stats.wantlist.map(entry => entry['/'])
       stats.peers = stats.peers || []
 
       print(`bitswap status

--- a/src/cli/commands/bitswap/unwant.js
+++ b/src/cli/commands/bitswap/unwant.js
@@ -15,7 +15,11 @@ module.exports = {
     }
   },
   handler (argv) {
-    argv.ipfs.bitswap.unwant(argv.key)
-    print(`Key ${argv.key} removed from wantlist`)
+    argv.ipfs.bitswap.unwant(argv.key, (err) => {
+      if (err) {
+        throw err
+      }
+      print(`Key ${argv.key} removed from wantlist`)
+    })
   }
 }

--- a/src/cli/commands/bitswap/unwant.js
+++ b/src/cli/commands/bitswap/unwant.js
@@ -1,11 +1,21 @@
 'use strict'
 
+const print = require('../../utils').print
+
 module.exports = {
   command: 'unwant <key>',
 
-  describe: 'Remove a given block from your wantlist.',
+  describe: 'Removes a given block from your wantlist.',
 
+  builder: {
+    key: {
+      alias: 'k',
+      describe: 'Key to remove from your wantlist',
+      type: 'string'
+    }
+  },
   handler (argv) {
-    throw new Error('Not implemented yet')
+    argv.ipfs.bitswap.unwant(argv.key)
+    print(`Key ${argv.key} removed from wantlist`)
   }
 }

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -3,7 +3,7 @@
 const print = require('../../utils').print
 
 module.exports = {
-  command: 'wantlist',
+  command: 'wantlist [peer]',
 
   describe: 'Print out all blocks currently on the bitswap wantlist for the local peer.',
 

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -16,8 +16,7 @@ module.exports = {
   },
 
   handler (argv) {
-    // TODO: handle argv.peer
-    argv.ipfs.bitswap.wantlist((err, res) => {
+    argv.ipfs.bitswap.wantlist(argv.peer, (err, res) => {
       if (err) {
         throw err
       }

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -21,8 +21,8 @@ module.exports = {
       if (err) {
         throw err
       }
-      res.Keys.forEach((cidStr) => {
-        print(cidStr)
+      res.Keys.forEach((cid) => {
+        print(cid['/'])
       })
     })
   }

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -19,9 +19,9 @@ module.exports = {
       }
 
       if (block) {
-        process.stdout.write(block.data)
+        print(block.data)
       } else {
-        process.stderr.write('Block was unwanted before it could be remotely retrieved')
+        print('Block was unwanted before it could be remotely retrieved')
       }
     })
   }

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -19,9 +19,9 @@ module.exports = {
       }
 
       if (block) {
-        print(block.data)
+        process.stdout.write(block.data)
       } else {
-        print('Block was unwanted before it could be remotely retrieved')
+        process.stderr.write('Block was unwanted before it could be remotely retrieved')
       }
     })
   }

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -19,7 +19,7 @@ module.exports = {
       }
 
       if (block) {
-        print(block.data)
+        print(block.data, false)
       } else {
         print('Block was unwanted before it could be remotely retrieved')
       }

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CID = require('cids')
+const print = require('../../utils').print
 
 module.exports = {
   command: 'get <key>',
@@ -17,7 +18,11 @@ module.exports = {
         throw err
       }
 
-      process.stdout.write(block.data)
+      if (block) {
+        print(block.data)
+      } else {
+        print('Block was unwanted before it could be remotely retrieved')
+      }
     })
   }
 }

--- a/src/core/components/bitswap.js
+++ b/src/core/components/bitswap.js
@@ -45,7 +45,7 @@ module.exports = function bitswap (self) {
         throw new Error(OFFLINE_ERROR)
       }
 
-      // TODO: implement when https://github.com/ipfs/js-ipfs-bitswap/pull/10 is merged
+      self._bitswap.unwant(key)
     }
   }
 }

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -46,10 +46,19 @@ exports.stat = (request, reply) => {
 }
 
 exports.unwant = {
-  // uses common parseKey method that returns a `key`
+  // uses common parseKey method that assigns a `key` to request.pre.args
   parseArgs: parseKey,
 
+  // main route handler which is called after the above `parseArgs`, but only if the args were valid
   handler: (request, reply) => {
-    reply(boom.badRequest(new Error('Not implemented yet')))
+    const key = request.pre.args.key
+    const ipfs = request.server.app.ipfs
+    try {
+      ipfs.bitswap.unwant(key)
+    } catch (err) {
+      return reply(boom.badRequest(err))
+    }
+
+    reply({ Key: key })
   }
 }

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -9,7 +9,6 @@ exports = module.exports
 exports.wantlist = {
   handler: (request, reply) => {
     const peerId = request.query.arg
-    let list
     request.server.app.ipfs.bitswap.wantlist(peerId, (err, list) => {
       if (err) {
         return reply(boom.badRequest(err))

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -6,41 +6,44 @@ const parseKey = require('./block').parseKey
 
 exports = module.exports
 
-exports.wantlist = (request, reply) => {
-  request.server.app.ipfs.bitswap.wantlist((err, list) => {
-    if (err) {
-      return reply(boom.badRequest(err))
-    }
-    list = list.map((entry) => entry.cid.toBaseEncodedString())
-    reply({
-      Keys: list
+exports.wantlist = {
+  handler: (request, reply) => {
+    const peerId = request.query.arg
+    let list
+    request.server.app.ipfs.bitswap.wantlist(peerId, (err, list) => {
+      if (err) {
+        return reply(boom.badRequest(err))
+      }
+      reply(list)
     })
-  })
+  }
 }
 
-exports.stat = (request, reply) => {
-  const ipfs = request.server.app.ipfs
+exports.stat = {
+  handler: (request, reply) => {
+    const ipfs = request.server.app.ipfs
 
-  ipfs.bitswap.stat((err, stats) => {
-    if (err) {
-      return reply({
-        Message: err.toString(),
-        Code: 0
-      }).code(500)
-    }
+    ipfs.bitswap.stat((err, stats) => {
+      if (err) {
+        return reply({
+          Message: err.toString(),
+          Code: 0
+        }).code(500)
+      }
 
-    reply({
-      ProvideBufLen: stats.provideBufLen,
-      BlocksReceived: stats.blocksReceived,
-      Wantlist: stats.wantlist,
-      Peers: stats.peers,
-      DupBlksReceived: stats.dupBlksReceived,
-      DupDataReceived: stats.dupDataReceived,
-      DataReceived: stats.dataReceived,
-      BlocksSent: stats.blocksSent,
-      DataSent: stats.dataSent
+      reply({
+        ProvideBufLen: stats.provideBufLen,
+        BlocksReceived: stats.blocksReceived,
+        Wantlist: stats.wantlist,
+        Peers: stats.peers,
+        DupBlksReceived: stats.dupBlksReceived,
+        DupDataReceived: stats.dupDataReceived,
+        DataReceived: stats.dataReceived,
+        BlocksSent: stats.blocksSent,
+        DataSent: stats.dataSent
+      })
     })
-  })
+  }
 }
 
 exports.unwant = {

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -11,7 +11,10 @@ exports.wantlist = (request, reply) => {
     if (err) {
       return reply(boom.badRequest(err))
     }
-    reply(list)
+    list = list.map((entry) => entry.cid.toBaseEncodedString())
+    reply({
+      Keys: list
+    })
   })
 }
 

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -7,16 +7,11 @@ const parseKey = require('./block').parseKey
 exports = module.exports
 
 exports.wantlist = (request, reply) => {
-  let list
-  try {
-    list = request.server.app.ipfs.bitswap.wantlist()
-    list = list.map((entry) => entry.cid.toBaseEncodedString())
-  } catch (err) {
-    return reply(boom.badRequest(err))
-  }
-
-  reply({
-    Keys: list
+  request.server.app.ipfs.bitswap.wantlist((err, list) => {
+    if (err) {
+      return reply(boom.badRequest(err))
+    }
+    reply(list)
   })
 }
 
@@ -53,12 +48,11 @@ exports.unwant = {
   handler: (request, reply) => {
     const key = request.pre.args.key
     const ipfs = request.server.app.ipfs
-    try {
-      ipfs.bitswap.unwant(key)
-    } catch (err) {
-      return reply(boom.badRequest(err))
-    }
-
-    reply({ Key: key })
+    ipfs.bitswap.unwant(key, (err) => {
+      if (err) {
+        return reply(boom.badRequest(err))
+      }
+      reply({ key: key.toBaseEncodedString() })
+    })
   }
 }

--- a/src/http/api/resources/bitswap.js
+++ b/src/http/api/resources/bitswap.js
@@ -8,7 +8,7 @@ exports = module.exports
 
 exports.wantlist = {
   handler: (request, reply) => {
-    const peerId = request.query.arg
+    const peerId = request.query.peer
     request.server.app.ipfs.bitswap.wantlist(peerId, (err, list) => {
       if (err) {
         return reply(boom.badRequest(err))

--- a/src/http/api/resources/block.js
+++ b/src/http/api/resources/block.js
@@ -48,7 +48,13 @@ exports.get = {
         }).code(500)
       }
 
-      return reply(block.data)
+      if (block) {
+        return reply(block.data)
+      }
+      return reply({
+        Message: 'Block was unwanted before it could be remotely retrieved',
+        Code: 0
+      }).code(404)
     })
   }
 }

--- a/src/http/api/routes/bitswap.js
+++ b/src/http/api/routes/bitswap.js
@@ -9,7 +9,7 @@ module.exports = (server) => {
     method: '*',
     path: '/api/v0/bitswap/wantlist',
     config: {
-      handler: resources.bitswap.wantlist
+      handler: resources.bitswap.wantlist.handler
     }
   })
 
@@ -17,7 +17,7 @@ module.exports = (server) => {
     method: '*',
     path: '/api/v0/bitswap/stat',
     config: {
-      handler: resources.bitswap.stat
+      handler: resources.bitswap.stat.handler
     }
   })
 

--- a/src/http/api/routes/stats.js
+++ b/src/http/api/routes/stats.js
@@ -9,7 +9,7 @@ module.exports = (server) => {
     method: '*',
     path: '/api/v0/stats/bitswap',
     config: {
-      handler: resources.stats.bitswap
+      handler: resources.stats.bitswap.handler
     }
   })
 

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -23,8 +23,7 @@ describe('bitswap', () => runOn((thing) => {
     })
   })
 
-  // TODO @hacdias fix this with https://github.com/ipfs/js-ipfs/pull/1198
-  it.skip('stat', function () {
+  it('stat', function () {
     this.timeout(20 * 1000)
 
     return ipfs('bitswap stat').then((out) => {
@@ -38,6 +37,12 @@ describe('bitswap', () => runOn((thing) => {
         '  partners [0]',
         '    '
       ].join('\n') + '\n')
+    })
+  })
+
+  it('unwant', function () {
+    return ipfs('bitswap unwant ' + key).then((out) => {
+      expect(out).to.eql(`Key ${key} removed from wantlist\n`)
     })
   })
 }))

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -13,7 +13,7 @@ describe('bitswap', () => runOn((thing) => {
     ipfs('block get ' + key)
       .then(() => {})
       .catch(() => {})
-    setTimeout(done, 800)
+    setTimeout(done, 250)
   })
 
   it('wantlist', function () {

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -3,9 +3,11 @@
 
 const expect = require('chai').expect
 const runOn = require('../utils/on-and-off').on
+const PeerId = require('peer-id')
 
 describe('bitswap', () => runOn((thing) => {
   let ipfs
+  let peerId
   const key = 'QmUBdnXXPyoDFXj3Hj39dNJ5VkN3QFRskXxcGaYFBB8CNR'
 
   before((done) => {
@@ -13,13 +15,24 @@ describe('bitswap', () => runOn((thing) => {
     ipfs('block get ' + key)
       .then(() => {})
       .catch(() => {})
-    setTimeout(done, 250)
+    PeerId.create((err, peer) => {
+      expect(err).to.not.exist()
+      peerId = peer.toB58String()
+      setTimeout(done, 250)
+    })
   })
 
   it('wantlist', function () {
     this.timeout(20 * 1000)
     return ipfs('bitswap wantlist').then((out) => {
       expect(out).to.eql(key + '\n')
+    })
+  })
+
+  it('wantlist peerid', function () {
+    this.timeout(20 * 1000)
+    return ipfs('bitswap wantlist ' + peerId).then((out) => {
+      expect(out).to.eql('')
     })
   })
 

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -10,7 +10,8 @@ describe('bitswap', () => runOn((thing) => {
   let peerId
   const key = 'QmUBdnXXPyoDFXj3Hj39dNJ5VkN3QFRskXxcGaYFBB8CNR'
 
-  before((done) => {
+  before(function (done) {
+    this.timeout(60 * 1000)
     ipfs = thing.ipfs
     ipfs('block get ' + key)
       .then(() => {})
@@ -18,7 +19,7 @@ describe('bitswap', () => runOn((thing) => {
     PeerId.create((err, peer) => {
       expect(err).to.not.exist()
       peerId = peer.toB58String()
-      setTimeout(done, 250)
+      done()
     })
   })
 

--- a/test/core/bitswap.spec.js
+++ b/test/core/bitswap.spec.js
@@ -283,7 +283,7 @@ skipOnWindows('bitswap', function () {
         })
       })
 
-      it('throws if offline', () => {
+      it('.unwant throws if offline', () => {
         expect(() => node.bitswap.unwant('my key')).to.throw(/online/)
       })
     })

--- a/test/core/bitswap.spec.js
+++ b/test/core/bitswap.spec.js
@@ -18,9 +18,6 @@ const CID = require('cids')
 
 const IPFSFactory = require('ipfsd-ctl')
 
-// This gets replaced by '../utils/create-repo-browser.js' in the browser
-const createTempRepo = require('../utils/create-repo-nodejs.js')
-
 const IPFS = require('../../src/core')
 
 // TODO bitswap tests on windows is failing, missing proper shutdown of daemon
@@ -244,77 +241,6 @@ skipOnWindows('bitswap', function () {
         expect(err).to.not.exist()
         expect(data).to.eql(file)
         done()
-      })
-    })
-  })
-
-  describe('api', () => {
-    let node
-
-    before(function (done) {
-      this.timeout(40 * 1000)
-
-      node = new IPFS({
-        repo: createTempRepo(),
-        start: false,
-        config: {
-          Addresses: {
-            Swarm: []
-          },
-          Discovery: {
-            MDNS: {
-              Enabled: false
-            }
-          }
-        }
-      })
-      node.on('ready', () => done())
-    })
-
-    describe('while offline', () => {
-      it('.wantlist throws if offline', () => {
-        expect(() => node.bitswap.wantlist()).to.throw(/online/)
-      })
-
-      it('.stat gives error while offline', () => {
-        node.bitswap.stat((err, stats) => {
-          expect(err).to.exist()
-          expect(stats).to.not.exist()
-        })
-      })
-
-      it('.unwant throws if offline', () => {
-        expect(() => node.bitswap.unwant('my key')).to.throw(/online/)
-      })
-    })
-
-    describe('while online', () => {
-      before(function (done) {
-        this.timeout(80 * 1000)
-
-        node.start(() => done())
-      })
-
-      it('.wantlist returns an array of wanted blocks', () => {
-        expect(node.bitswap.wantlist()).to.eql([])
-      })
-
-      it('returns the stats', (done) => {
-        node.bitswap.stat((err, stats) => {
-          expect(err).to.not.exist()
-          expect(stats).to.have.keys([
-            'blocksReceived',
-            'blocksSent',
-            'dataReceived',
-            'dataSent',
-            'wantlist',
-            'peers',
-            'provideBufLen',
-            'dupDataReceived',
-            'dupBlksReceived'
-          ])
-          done()
-        })
       })
     })
   })

--- a/test/core/interface/bitswap.js
+++ b/test/core/interface/bitswap.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+'use strict'
+
+const test = require('interface-ipfs-core')
+const parallel = require('async/parallel')
+
+const IPFS = require('../../../src')
+
+const DaemonFactory = require('ipfsd-ctl')
+const df = DaemonFactory.create({ type: 'proc', exec: IPFS })
+
+const nodes = []
+const common = {
+  setup: function (callback) {
+    callback(null, {
+      spawnNode: (cb) => {
+        df.spawn({
+          initOptions: { bits: 512 }
+        }, (err, _ipfsd) => {
+          if (err) {
+            return cb(err)
+          }
+
+          nodes.push(_ipfsd)
+          cb(null, _ipfsd.api)
+        })
+      }
+    })
+  },
+  teardown: function (callback) {
+    parallel(nodes.map((node) => (cb) => node.stop(cb)), callback)
+  }
+}
+
+test.bitswap(common)

--- a/test/core/interface/interface.spec.js
+++ b/test/core/interface/interface.spec.js
@@ -15,6 +15,7 @@ describe('interface-ipfs-core tests', () => {
   require('./stats')
   require('./key')
   if (isNode) {
+    require('./bitswap')
     require('./swarm')
     require('./ping')
     require('./pubsub')

--- a/test/http-api/index.js
+++ b/test/http-api/index.js
@@ -1,11 +1,12 @@
 'use strict'
 
-require('./interface')
-require('./inject')
+require('./bitswap')
 require('./block')
 require('./bootstrap')
 require('./config')
 require('./dns')
 require('./id')
+require('./inject')
+require('./interface')
 require('./object')
 require('./version')

--- a/test/http-api/index.js
+++ b/test/http-api/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-require('./bitswap')
 require('./block')
 require('./bootstrap')
 require('./config')

--- a/test/http-api/interface/bitswap.js
+++ b/test/http-api/interface/bitswap.js
@@ -1,0 +1,31 @@
+/* eslint-env mocha */
+'use strict'
+
+const test = require('interface-ipfs-core')
+const parallel = require('async/parallel')
+
+const DaemonFactory = require('ipfsd-ctl')
+const df = DaemonFactory.create({ exec: 'src/cli/bin.js' })
+
+const nodes = []
+const common = {
+  setup: function (callback) {
+    callback(null, {
+      spawnNode: (cb) => {
+        df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+          if (err) {
+            return cb(err)
+          }
+
+          nodes.push(_ipfsd)
+          cb(null, _ipfsd.api)
+        })
+      }
+    })
+  },
+  teardown: function (callback) {
+    parallel(nodes.map((node) => (cb) => node.stop(cb)), callback)
+  }
+}
+
+test.bitswap(common)


### PR DESCRIPTION
Because of the amount of work done in #1306 this PR is built off of that, that PR needs to be merged before this one can be isolated and discussed.

This adds a peerId parameter to bitswap.unwant.

Tests are in https://github.com/ipfs/interface-ipfs-core/pull/267
API changes are in https://github.com/ipfs/js-ipfs-api/pull/761