### PR TITLE
perf(cli): load only requested sub-system modules and inline require ipfs and ipfs-api

### DIFF
--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -2,9 +2,7 @@
 
 const fs = require('fs')
 const os = require('os')
-const APIctl = require('ipfs-api')
 const multiaddr = require('multiaddr')
-const IPFS = require('../core')
 const path = require('path')
 const debug = require('debug')
 const log = debug('cli')
@@ -35,6 +33,8 @@ function getAPICtl (apiAddr) {
     const apiPath = path.join(exports.getRepoPath(), 'api')
     apiAddr = multiaddr(fs.readFileSync(apiPath).toString()).toString()
   }
+  // Required inline to reduce startup time
+  const APIctl = require('ipfs-api')
   return APIctl(apiAddr)
 }
 
@@ -43,6 +43,8 @@ exports.getIPFS = (argv, callback) => {
     return callback(null, getAPICtl(argv.api), (cb) => cb())
   }
 
+  // Required inline to reduce startup time
+  const IPFS = require('../core')
   const node = new IPFS({
     repo: exports.getRepoPath(),
     init: false,

--- a/test/cli/daemon.js
+++ b/test/cli/daemon.js
@@ -5,8 +5,6 @@ const expect = require('chai').expect
 const clean = require('../utils/clean')
 const ipfsCmd = require('../utils/ipfs-exec')
 const isWindows = require('../utils/platforms').isWindows
-const pull = require('pull-stream')
-const toPull = require('stream-to-pull-stream')
 const os = require('os')
 const path = require('path')
 const hat = require('hat')
@@ -37,31 +35,20 @@ function testSignal (ipfs, sig) {
   }).then(() => {
     const proc = ipfs('daemon')
     return new Promise((resolve, reject) => {
-      pull(
-        toPull(proc.stdout),
-        pull.collect((err, res) => {
-          expect(err).to.not.exist()
-          const data = res.toString()
-          if (data.includes(`Daemon is ready`)) {
-            if (proc.kill(sig)) {
-              resolve()
-            } else {
-              reject(new Error(`Unable to ${sig} process`))
-            }
+      proc.stdout.on('data', (data) => {
+        if (data.toString().includes(`Daemon is ready`)) {
+          if (proc.kill(sig)) {
+            resolve()
+          } else {
+            reject(new Error(`Unable to ${sig} process`))
           }
-        })
-      )
-
-      pull(
-        toPull(proc.stderr),
-        pull.collect((err, res) => {
-          expect(err).to.not.exist()
-          const data = res.toString()
-          if (data.length > 0) {
-            reject(new Error(data))
-          }
-        })
-      )
+        }
+      })
+      proc.stderr.on('data', (data) => {
+        if (data.toString().length > 0) {
+          reject(new Error(data))
+        }
+      })
     })
   })
 }
@@ -79,6 +66,8 @@ describe('daemon', () => {
 
   skipOnWindows('do not crash if Addresses.Swarm is empty', function (done) {
     this.timeout(100 * 1000)
+    // These tests are flaky, but retrying 3 times seems to make it work 99% of the time
+    this.retries(3)
 
     ipfs('init').then(() => {
       return ipfs('config', 'Addresses', JSON.stringify({
@@ -87,10 +76,18 @@ describe('daemon', () => {
         Gateway: '/ip4/127.0.0.1/tcp/0'
       }), '--json')
     }).then(() => {
-      return ipfs('daemon')
-    }).then((res) => {
-      expect(res).to.have.string('Daemon is ready')
-      done()
+      const res = ipfs('daemon')
+      const timeout = setTimeout(() => {
+        done(new Error('Daemon did not get ready in time'))
+      }, 1000 * 120)
+      res.stdout.on('data', (data) => {
+        const line = data.toString()
+        if (line.includes('Daemon is ready')) {
+          clearTimeout(timeout)
+          res.kill()
+          done()
+        }
+      })
     }).catch(err => done(err))
   })
 


### PR DESCRIPTION
This is an alternative to https://github.com/ipfs/js-ipfs/pull/1336 inlining all the requires in every file for the CLI. This is a great idea but I wanted to see if it could be done with minimal disruption as well as [other reasons](https://github.com/ipfs/js-ipfs/pull/1336#issuecomment-387439256).

I had a look at the good work in #1336 and have taken the best bits that provide us with the biggest gains 🚀 

I've changed `src/cli/bin.js` so that `commandDir` now takes an `include` filter. The idea being to only include the command files for the sub-system the user asked for. i.e. if the user types `jsipfs files add` then we only require `src/cli/commands/files.js`.

I've applied the changes @VictorBjelkholm made to `test/cli/daemon.js` verbatim as this was also really beneficial.

Inlining the `require` for js-ipfs and js-ipfs-api is totally worth it as these two have many many dependencies. I've added a comment next to each to make it obvious why it has been done.

As a baseline, `npm run test:node:cli` took **12m57.607s**.

With the work in this PR, it took **6m26.499s**.

I also ran #1336 and it took **5m52.966s**.

So around ~30s slower than in #1336. It was never going to be faster, but it is a significantly smaller changeset, still reduces the test time for the CLI by over 50%, and addresses the concerns I [raised here](https://github.com/ipfs/js-ipfs/pull/1336#issuecomment-387439256).