### PR TITLE
example(run-in-electron): update to latest electron 2.0, electron-rebuild 1.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ If your [electron-rebuild step is failing](https://github.com/ipfs/js-ipfs/issue
 
 ```bash
 # Electron's version.
-export npm_config_target=1.7.6
+export npm_config_target=2.0.0
 # The architecture of Electron, can be ia32 or x64.
 export npm_config_arch=x64
 export npm_config_target_arch=x64

--- a/examples/run-in-electron/README.md
+++ b/examples/run-in-electron/README.md
@@ -2,8 +2,6 @@
 
 > This example is heavily inspired by [electron-quick-start](https://github.com/electron/electron-quick-start).
 
-**DISCLAIMER:** This example is still a work in progress, it currently doesn't work due to the usage of native dependencies that Electron is not supporting.
-
 To try it by yourself, do:
 
 ```

--- a/examples/run-in-electron/build.sh
+++ b/examples/run-in-electron/build.sh
@@ -1,5 +1,5 @@
 # Electron's version.
-export npm_config_target=1.6.11
+export npm_config_target=2.0.0
 # The architecture of Electron, can be ia32 or x64.
 export npm_config_arch=x64
 export npm_config_target_arch=x64

--- a/examples/run-in-electron/package.json
+++ b/examples/run-in-electron/package.json
@@ -15,8 +15,8 @@
   "author": "David Dias <daviddias@ipfs.io>",
   "license": "MIT",
   "devDependencies": {
-    "electron": "~1.6.11",
-    "electron-rebuild": "^1.5.11",
+    "electron": "^2.0.0",
+    "electron-rebuild": "^1.7.2",
     "ipfs": "ipfs/js-ipfs"
   }
 }


### PR DESCRIPTION
Use electron 2.0 latest version for semver versioning & few updates on Node JS compatibility. 

With Electron 2.0, `npm start` electron console print the messages.
```
Swarm listening on /ip4/127.0.0.1/tcp/4003/ws/ipfs/QmX8WSZZ3q1f8CCg4kenTvoT84j5rp6jcyhwE4ytkGkPVt
Swarm listening on /ip4/127.0.0.1/tcp/4002/ipfs/QmX8WSZZ3q1f8CCg4kenTvoT84j5rp6jcyhwE4ytkGkPVt
Swarm listening on /ip4/192.168.25.7/tcp/4002/ipfs/QmX8WSZZ3q1f8CCg4kenTvoT84j5rp6jcyhwE4ytkGkPVt
{ id: 'QmX8WSZZ3q1f8CCg4kenTvoT84j5rp6jcyhwE4ytkGkPVt',
  publicKey: 'CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCik4bdmt8Dj9luRgSSi5dejX2Uc3HpUkVmBzXmioEn69Int8fBN7E2OudyhmyE/OBbApWUbMBGBUbqDbmDwjcdXKaJQDBb6LLtNyakU+uwndqONalxaDAcxT7Kfi4+TnQrQe1/F4y7q+y6ntf78f+uqHPjPHM0astfeqUaB9ULIjNewaLezBWuBQ1D87KXoiv4V9xNGnPAU9egK5VRSU1HW+M9yTBJBG1OJ0UK1Y3s908XZufTENDWdnpZGvNKqiIKesQ3oAJ+1aAYLtPFVJj3k+vDbEu88FNJ3UO8z3o5kC5V7vnwAAKgqrtEwuVSsNLBizGI7xqYaNAZCJvStuE7AgMBAAE=',
  addresses:
   [ '/ip4/127.0.0.1/tcp/4002/ipfs/QmX8WSZZ3q1f8CCg4kenTvoT84j5rp6jcyhwE4ytkGkPVt',
     '/ip4/127.0.0.1/tcp/4003/ws/ipfs/QmX8WSZZ3q1f8CCg4kenTvoT84j5rp6jcyhwE4ytkGkPVt',
     '/ip4/192.168.25.7/tcp/4002/ipfs/QmX8WSZZ3q1f8CCg4kenTvoT84j5rp6jcyhwE4ytkGkPVt' ],
  agentVersion: 'js-ipfs/0.28.2',
  protocolVersion: '9000' }
```

issue #843 
https://github.com/ipfs/notes/issues/256