### PR TITLE
chore: do not add newlines to object data

### DIFF
--- a/src/cli/commands/object/data.js
+++ b/src/cli/commands/object/data.js
@@ -17,7 +17,7 @@ module.exports = {
         throw err
       }
 
-      print(data.toString())
+      print(data.toString(), false)
     })
   }
 }

--- a/test/cli/object.js
+++ b/test/cli/object.js
@@ -60,7 +60,7 @@ describe('object', () => runOnAndOff((thing) => {
 
   it('data', () => {
     return ipfs('object data QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm').then((out) => {
-      expect(out).to.eql('another\n')
+      expect(out).to.eql('another')
     })
   })
 


### PR DESCRIPTION
For consistency with go-ipfs we should not add newlines to the output of `ipfs object data`.

go:

```
$ echo 'Hello' | ipfs files write --create /hello.txt
$ ipfs files ls / -l | grep hello.txt
hello.txt	QmcnK4wpoB6ozwZ7Siye8wyVTHYKNNoNvapPMLuCYUrHK2	6
$ ipfs object data QmcnK4wpoB6ozwZ7Siye8wyVTHYKNNoNvapPMLuCYUrHK2 | xxd
00000000: 0802 1806 2006                           .... .
```

js without this PR (with experimental mfs support) - note the extra `0a` at the end:

```
$ echo 'Hello' | JSipfs files write --create /hello.txt
$ jsipfs files ls / -l | grep hello.txt
hello.txt	QmZo8WtosAnHDHXWCvih3xJsiENgdaKBmdx4gKnYmRtSUu	6 
$ jsipfs object data QmZo8WtosAnHDHXWCvih3xJsiENgdaKBmdx4gKnYmRtSUu | xxd
00000000: 0802 1806 2006 0a                        .... ..
```

js with this PR:

```
$ echo 'Hello' | JSipfs files write --create /hello.txt
$ jsipfs files ls / -l | grep hello.txt
hello.txt	QmZo8WtosAnHDHXWCvih3xJsiENgdaKBmdx4gKnYmRtSUu	6 
$ jsipfs object data QmZo8WtosAnHDHXWCvih3xJsiENgdaKBmdx4gKnYmRtSUu | xxd
00000000: 0802 1806 2006                           .... .
```

You may notice that the CIDs are different between go and js although the content is identical - this is because they structure the DAG differently for small files - js uses a single node if the data will fit in one node, go always creates one child that holds the data but this can be addressed in a separate PR.