### PR TITLE
fix(repo): do not hang on calls to repo gc

### DIFF
--- a/src/cli/commands/repo/gc.js
+++ b/src/cli/commands/repo/gc.js
@@ -3,10 +3,15 @@
 module.exports = {
   command: 'gc',
 
-  describe: '',
+  describe: 'Perform a garbage collection sweep on the repo.',
 
   builder: {},
 
   handler (argv) {
+    argv.ipfs.repo.gc((err) => {
+      if (err) {
+        throw err
+      }
+    })
   }
 }

--- a/src/core/components/repo.js
+++ b/src/core/components/repo.js
@@ -38,7 +38,14 @@ module.exports = function repo (self) {
       })
     }),
 
-    gc: () => {},
+    gc: promisify((options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+
+      callback(new Error('Not implemented'))
+    }),
 
     stat: promisify((options, callback) => {
       if (typeof options === 'function') {

--- a/src/http/api/resources/repo.js
+++ b/src/http/api/resources/repo.js
@@ -2,6 +2,21 @@
 
 exports = module.exports
 
+exports.gc = (request, reply) => {
+  const ipfs = request.server.app.ipfs
+
+  ipfs.repo.gc((err) => {
+    if (err) {
+      return reply({
+        Message: err.toString(),
+        Code: 0
+      }).code(500)
+    }
+
+    reply()
+  })
+}
+
 exports.version = (request, reply) => {
   const ipfs = request.server.app.ipfs
 


### PR DESCRIPTION
Previously calls to repo.gc would hang or fail silently or in the case of the HTTP API cause a 404. This PR responds to calls to repo.gc with an error to inform that this feature will eventually exist (it is spec'd) but is not implemented yet.