### PR TITLE
chore: upgrade ipfsd-ctl dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "form-data": "^2.3.2",
     "hat": "0.0.3",
     "interface-ipfs-core": "~0.66.2",
-    "ipfsd-ctl": "~0.37.0",
+    "ipfsd-ctl": "~0.37.3",
     "lodash": "^4.17.10",
     "mocha": "^5.1.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
Upgrade `ipfsd-ctl` version for unblocking #1331 