### PR TITLE
RFC: allow passing constructor for the libp2p modules

### DIFF
--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -19,7 +19,7 @@ module.exports = function libp2p (self) {
           mdns: get(config, 'Discovery.MDNS.Enabled'),
           webRTCStar: get(config, 'Discovery.webRTCStar.Enabled'),
           bootstrap: get(config, 'Bootstrap'),
-          modules: self._libp2pModules,
+          modules: prepareModules(self, self._libp2pModules),
           // EXPERIMENTAL
           pubsub: get(self._options, 'EXPERIMENTAL.pubsub', false),
           dht: get(self._options, 'EXPERIMENTAL.dht', false),
@@ -68,4 +68,11 @@ module.exports = function libp2p (self) {
       self._libp2pNode.stop(callback)
     })
   }
+}
+
+function prepareModules (self, modules) {
+  if (typeof modules === 'function') {
+    return modules(self._peerInfo)
+  }
+  return modules
 }

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -36,7 +36,7 @@ const schema = Joi.object().keys({
     Bootstrap: Joi.array().items(Joi.multiaddr().IPFS().options({ convert: false }))
   }).allow(null),
   libp2p: Joi.object().keys({
-    modules: Joi.object().allow(null) // TODO: schemas for libp2p modules?
+    modules: Joi.any().allow(null) // TODO: schemas for libp2p modules?
   }).allow(null)
 }).options({ allowUnknown: true })
 


### PR DESCRIPTION
WIP

Context: allow overriding the libp2p modules, permitting this type of options:

```js
const ipfs = new IPFS({
  libp2p: { modules }
})

return ipfs

function modules (peerInfo) {
  const appTransport = AppTransport(appName, new WebSocketStar({ id: peerInfo.id }))
  return {
    transport: [ appTransport ],
    discovery: [ appTransport.discovery ]
  }
}
```

Some libp2p modules require the peer id in the constructor. Instead of a fancy DI framework, I propose a simple solution that allows to pass a function that will act as a module constructor.

This could be made to be even more flexible, like, for instance, by allowing some transports to be passed as instances and others as a constructor, like this:

```js
const ipfs = new IPFS({
  libp2p: {
    modules: {
      transport: [
        ws,
        (peerInfo) => myWonderfulTransport(peerInfo.id)
      ]
    }
  }
})
```

(What this doesn't solve is the transport -> discovery coupling, which sometimes may be required. I suggest this by adding `transport.discovery` to the list of discovery modules if it exists).

I prefer this type of simplistic approach over [some others that have been discussed](https://github.com/libp2p/js-libp2p/issues/130), as this does not require libp2p module constructors to implement specific interfaces or require generic DI libs.