### PR TITLE
fix: do not stringify output of object data

### DIFF
--- a/src/cli/commands/object/data.js
+++ b/src/cli/commands/object/data.js
@@ -17,7 +17,7 @@ module.exports = {
         throw err
       }
 
-      print(data.toString(), false)
+      print(data, false)
     })
   }
 }

--- a/test/cli/object.js
+++ b/test/cli/object.js
@@ -4,6 +4,11 @@
 
 const expect = require('chai').expect
 const runOnAndOff = require('../utils/on-and-off')
+const UnixFs = require('ipfs-unixfs')
+const path = require('path')
+const fs = require('fs')
+const crypto = require('crypto')
+const os = require('os')
 
 describe('object', () => runOnAndOff((thing) => {
   let ipfs
@@ -62,6 +67,25 @@ describe('object', () => runOnAndOff((thing) => {
     return ipfs('object data QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm').then((out) => {
       expect(out).to.eql('another')
     })
+  })
+
+  it('unaulterated data', () => {
+    // has to be big enough to span several DAGNodes
+    const data = crypto.randomBytes(1024 * 300)
+    const file = path.join(os.tmpdir(), `file-${Math.random()}.txt`)
+
+    fs.writeFileSync(file, data)
+
+    return ipfs(`add ${file}`)
+      .then((out) => {
+        return ipfs.raw(`object data ${out.split(' ')[1]}`)
+      })
+      .then((out) => {
+        const meta = UnixFs.unmarshal(out)
+
+        expect(meta.type).to.equal('file')
+        expect(meta.fileSize()).to.equal(data.length)
+      })
   })
 
   it('links', () => {

--- a/test/utils/ipfs-exec.js
+++ b/test/utils/ipfs-exec.js
@@ -29,9 +29,11 @@ module.exports = (repoPath, opts) => {
   }, opts)
 
   const exec = (args) => execa(`${process.cwd()}/src/cli/bin.js`, args, config)
+  const execRaw = (args) => execa(`${process.cwd()}/src/cli/bin.js`, args, Object.assign({}, config, {
+    encoding: null
+  }))
 
-  function ipfs () {
-    let args = Array.from(arguments)
+  const execute = (exec, args) => {
     if (args.length === 1) {
       args = args[0].split(' ')
     }
@@ -49,6 +51,15 @@ module.exports = (repoPath, opts) => {
     res.stderr = cp.stderr
 
     return res
+  }
+
+  function ipfs () {
+    return execute(exec, Array.from(arguments))
+  }
+
+  // Will return buffers instead of strings
+  ipfs.raw = function () {
+    return execute(execRaw, Array.from(arguments))
   }
 
   /**


### PR DESCRIPTION
Without this change:

```sh
$ jsipfs object data `dd if=/dev/urandom bs=307200 count=1 | jsipfs files write --create /some-file && jsipfs files stat -h /some-file` | unixfs
{"type":"file","blockSizes":[72481833443311,10909182287855]}
```

e.g.

```
00000000: 0802 18ef bfbd efbf bd12 20ef bfbd efbf  .......... .....
00000010: bd10 20ef bfbd efbf bd02                 .. .......
```

With this change:

```sh
$ jsipfs object data `dd if=/dev/urandom bs=307200 count=1 | jsipfs files write --create /some-file && jsipfs files stat -h /some-file` | unixfs
{"type":"file","blockSizes":[262144,45056]}
```

e.g.

```
00000000: 0802 1880 e012 2080 8010 2080 e002       ...... ... ...
```

Stringifying the data changes it's encoding. Been banging my head against this all morning.