### PR TITLE
chore: add debug logging to http server

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -100,7 +100,11 @@ function HttpApi (repo, config, cliArgs) {
               routes: {
                 cors: true
               }
-            }
+            },
+            debug: process.env.DEBUG ? {
+              request: ['*'],
+              log: ['*']
+            } : undefined
           })
 
           this.server.app.ipfs = this.node


### PR DESCRIPTION
Sets up Hapi's debug logging when DEBUG env var is present.

This will enable developers to see what is happening inside
the daemon when ipfs/js-ipfsd-ctl#270 is merged instead of just
getting error messages like 'Please retrace your steps'.

It lets you do this sort of thing:

```
$ DEBUG=ipfsd-ctl:daemon:* npm test
```

...and see Hapi's request/server logs in the output.