### PR TITLE
fix(tests): loosen assertion for bitswap.stat test

### DIFF
--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -41,15 +41,15 @@ describe('bitswap', () => runOn((thing) => {
     this.timeout(20 * 1000)
 
     return ipfs('bitswap stat').then((out) => {
-      expect(out).to.be.eql([
+      expect(out).to.include([
         'bitswap status',
         '  blocks received: 0',
         '  dup blocks received: 0',
         '  dup data received: 0B',
         '  wantlist [1 keys]',
         `    ${key}`,
-        '  partners [0]',
-        '    '
+        // We sometimes pick up partners while the tests run so our assertion ends here
+        '  partners'
       ].join('\n') + '\n')
     })
   })

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -50,7 +50,7 @@ describe('bitswap', () => runOn((thing) => {
         `    ${key}`,
         // We sometimes pick up partners while the tests run so our assertion ends here
         '  partners'
-      ].join('\n') + '\n')
+      ].join('\n'))
     })
   })
 


### PR DESCRIPTION
Sometimes we pick up partners during the test so we can't
reliably assert that part of the output