### PR TITLE
chore: use default Node.js versions on CI

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,2 @@
 // Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript(['nodejs_versions': ['8.11.1','9.2.0','10.0.0']])
+javascript()


### PR DESCRIPTION
I believe these were changed to add Node.js 10 when we were trying to get support for Node.js 10 working. This PR reverts to using the defaults, which are currently the LTS versions 8 and 10.