### PR TITLE
fix: allow put empty block & add X-Stream-Output header on get

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "hoek": "^5.0.3",
     "human-to-milliseconds": "^1.0.0",
     "interface-datastore": "^0.4.1",
-    "ipfs-api": "^22.0.0",
+    "ipfs-api": "^22.1.1",
     "ipfs-bitswap": "~0.20.0",
     "ipfs-block": "~0.7.1",
     "ipfs-block-service": "~0.14.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "expose-loader": "~0.7.5",
     "form-data": "^2.3.2",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.68.2",
+    "interface-ipfs-core": "~0.69.0",
     "ipfsd-ctl": "~0.37.3",
     "lodash": "^4.17.10",
     "mocha": "^5.1.1",

--- a/src/core/components/pin.js
+++ b/src/core/components/pin.js
@@ -92,7 +92,7 @@ module.exports = function pin (self) {
       }),
 
       // hack for CLI tests
-      cb => repo.closed ? repo.datastore.open(cb) : cb(null, null),
+      cb => repo.closed ? repo.open(cb) : cb(null, null),
 
       // save root to datastore under a consistent key
       cb => repo.datastore.put(pinDataStoreKey, root.multihash, cb)


### PR DESCRIPTION
This PR allows the test in https://github.com/ipfs/interface-ipfs-core/pull/308 to pass.

`X-Stream-Output` header is added to the `block.get` reply for parity with go-ipfs.

`block.put` is altered to allow an empty block to be put (again for feature parity with go-ipfs) but only if there is a multipart file part for it. Error responses have also been improved.

depends on https://github.com/ipfs/js-ipfs-api/pull/789
tested by https://github.com/ipfs/interface-ipfs-core/pull/308