### PR TITLE
feat: expose libp2p connection manager configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Creates and returns an instance of an IPFS node. Use the `options` argument to s
                 - `enabled` (boolean): whether this module is enabled or disabled
                 - `[custom config]` (any): other keys are specific to the module
 
+- `connectionManager` (object): Configure the libp2p connection manager, see the [documentation for available options](https://github.com/libp2p/js-libp2p-connection-manager#create-a-connectionmanager).
+
 #### Events
 
 IPFS instances are Node.js [EventEmitters](https://nodejs.org/dist/latest-v8.x/docs/api/events.html#events_class_eventemitter). You can listen for events by calling `node.on('event', handler)`:

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "expose-loader": "~0.7.5",
     "form-data": "^2.3.2",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.70.3",
+    "interface-ipfs-core": "~0.71.0",
     "ipfsd-ctl": "~0.37.3",
     "mocha": "^5.1.1",
     "ncp": "^2.0.0",

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -50,7 +50,7 @@ module.exports = function libp2p (self) {
             }
           },
           connectionManager: get(self._options, 'connectionManager',
-            get(config, 'connectionManager', false))
+            get(config, 'connectionManager', {}))
         }
 
         const libp2pOptions = defaultsDeep(

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -49,11 +49,8 @@ module.exports = function libp2p (self) {
               pubsub: get(self._options, 'EXPERIMENTAL.pubsub', false)
             }
           },
-          connectionManager: get(
-            self._options,
-            'EXPERIMENTAL.connectionManager',
-            get(config, 'EXPERIMENTAL.connectionManager')
-          )
+          connectionManager: get(self._options, 'connectionManager',
+            get(config, 'connectionManager', false))
         }
 
         const libp2pOptions = defaultsDeep(

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -48,7 +48,12 @@ module.exports = function libp2p (self) {
               dht: get(self._options, 'EXPERIMENTAL.dht', false),
               pubsub: get(self._options, 'EXPERIMENTAL.pubsub', false)
             }
-          }
+          },
+          connectionManager: get(
+            self._options,
+            'EXPERIMENTAL.connectionManager',
+            get(config, 'EXPERIMENTAL.connectionManager')
+          )
         }
 
         const libp2pOptions = defaultsDeep(

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -23,7 +23,8 @@ const schema = Joi.object().keys({
   EXPERIMENTAL: Joi.object().keys({
     pubsub: Joi.boolean(),
     sharding: Joi.boolean(),
-    dht: Joi.boolean()
+    dht: Joi.boolean(),
+    connectionManager: Joi.object().allow(null)
   }).allow(null),
   config: Joi.object().keys({
     Addresses: Joi.object().keys({

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -23,9 +23,9 @@ const schema = Joi.object().keys({
   EXPERIMENTAL: Joi.object().keys({
     pubsub: Joi.boolean(),
     sharding: Joi.boolean(),
-    dht: Joi.boolean(),
-    connectionManager: Joi.object().allow(null)
+    dht: Joi.boolean()
   }).allow(null),
+  connectionManager: Joi.object().allow(null),
   config: Joi.object().keys({
     Addresses: Joi.object().keys({
       Swarm: Joi.array().items(Joi.multiaddr().options({ convert: false })),


### PR DESCRIPTION
Exposes options for the connection manager (see https://github.com/libp2p/js-libp2p-connection-manager#create-a-connectionmanager) as an optional top level option called `connectionManager`.