### PR TITLE
chore(tests): share ipfs instances between tests

### DIFF
--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -2,8 +2,41 @@
 'use strict'
 
 const fs = require('fs')
+const spawn = require('../utils/on-and-off')
+const parallel = require('async/parallel')
 
 describe('cli', () => {
+  let daemonOff
+  let ipfsd
+  before(function (done) {
+    // CI takes longer to instantiate the daemon,
+    // so we need to increase the timeout for the
+    // before step
+    this.timeout(60 * 1000)
+    parallel([
+      (cb) => spawn.daemonOff((err, isNew, ipfs) => {
+        if (err) {
+          throw err
+        }
+        daemonOff = ipfs
+        cb()
+      }),
+      (cb) => spawn.daemonOn((err, isNew, ipfs, node) => {
+        if (err) {
+          throw err
+        }
+        ipfsd = node
+        cb()
+      })
+    ], done)
+  })
+
+  after(function (done) {
+    this.timeout(20 * 1000)
+    spawn.cleanDaemon(daemonOff)
+    spawn.stopDaemon(ipfsd, done)
+  })
+
   fs.readdirSync(__dirname)
     .filter((file) => file !== 'index.js')
     .forEach((file) => require('./' + file))


### PR DESCRIPTION
It accounts for the tests being run from either the cli/index.js
file, or the individual files themselves, programatically determining
whether or not it is responsible for shutting down the instance or
cleaning up its repoPath

This speeds up cli tests by about 25% on my local machine, which I know
is not a benchmark in and of itself but it's at least a measurement