### PR TITLE
fix(core/components/dag): make options in `put` API optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "expose-loader": "~0.7.5",
     "form-data": "^2.3.2",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.70.2",
+    "interface-ipfs-core": "~0.70.3",
     "ipfsd-ctl": "~0.37.3",
     "mocha": "^5.1.1",
     "ncp": "^2.0.0",

--- a/src/core/components/dag.js
+++ b/src/core/components/dag.js
@@ -9,6 +9,21 @@ const flattenDeep = require('lodash/flattenDeep')
 module.exports = function dag (self) {
   return {
     put: promisify((dagNode, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+      } else if (options.cid && (options.format || options.hashAlg)) {
+        return callback(new Error('Can\'t put dag node. Please provide either `cid` OR `format` and `hashAlg` options.'))
+      } else if ((options.format && !options.hashAlg) || (!options.format && options.hashAlg)) {
+        return callback(new Error('Can\'t put dag node. Please provide `format` AND `hashAlg` options.'))
+      }
+
+      const optionDefaults = {
+        format: 'dag-cbor',
+        hashAlg: 'sha2-255'
+      }
+
+      options = options.cid ? options : Object.assign({}, optionDefaults, options)
+
       self._ipld.put(dagNode, options, callback)
     }),
 


### PR DESCRIPTION
The [dag.put](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/DAG.md#dagput) interface
takes an options object which is required, but should be optional with
decent defaults.

See dedicated test here: https://github.com/ipfs/interface-ipfs-core/pull/316

This commit implements this behaviour.

**Before**:

```js
ipfs.dag.put(obj, options, (err, cid) => {...});
```

^ Prior to this commit, without passing `options`, this call resulted in an error.

**After**:

```js
ipfs.dag.put(obj, (err, cid) => {...});
```

^ This is now perfectly fine.


Fixes #1395

License: MIT
Signed-off-by: Pascal Precht <pascal.precht@gmail.com>