### PR TITLE
fix(core/components/dag): fix default hash algorithm for put() api

### DIFF
--- a/src/core/components/dag.js
+++ b/src/core/components/dag.js
@@ -19,7 +19,7 @@ module.exports = function dag (self) {
 
       const optionDefaults = {
         format: 'dag-cbor',
-        hashAlg: 'sha2-255'
+        hashAlg: 'sha2-256'
       }
 
       options = options.cid ? options : Object.assign({}, optionDefaults, options)


### PR DESCRIPTION
Turns out we've introduced a little bug in https://github.com/ipfs/js-ipfs/commit/d299ed77c288d82ce807af0ec7a5b2605336626f
in which the default hash algorithm has a typo.

This didn't fail on CI because the `options.hashAlg` passed down to `ipld.put()`
is actually not being used at time of this commit.

For more info see: https://github.com/ipld/js-ipld/blob/d3d78e053ebd3f8c85a8b5579715be8812773d4d/src/index.js#L236-L239

License: MIT
Signed-off-by: Pascal Precht <pascal.precht@gmail.com>