### PR TITLE
feat: adds data-encoding argument to control data encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "hoek": "^5.0.3",
     "human-to-milliseconds": "^1.0.0",
     "interface-datastore": "~0.4.2",
-    "ipfs-api": "^22.2.4",
+    "ipfs-api": "^24.0.0",
     "ipfs-bitswap": "~0.20.3",
     "ipfs-block": "~0.7.1",
     "ipfs-block-service": "~0.14.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "expose-loader": "~0.7.5",
     "form-data": "^2.3.2",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.75.2",
+    "interface-ipfs-core": "~0.76.1",
     "ipfsd-ctl": "~0.39.1",
     "mocha": "^5.2.0",
     "ncp": "^2.0.0",

--- a/src/cli/commands/object/get.js
+++ b/src/cli/commands/object/get.js
@@ -7,7 +7,12 @@ module.exports = {
 
   describe: 'Get and serialize the DAG node named by <key>',
 
-  builder: {},
+  builder: {
+    'data-encoding': {
+      type: 'string',
+      default: 'base64'
+    }
+  },
 
   handler (argv) {
     argv.ipfs.object.get(argv.key, {enc: 'base58'}, (err, node) => {
@@ -16,7 +21,9 @@ module.exports = {
       }
       const nodeJSON = node.toJSON()
 
-      nodeJSON.data = nodeJSON.data ? nodeJSON.data.toString() : ''
+      if (Buffer.isBuffer(node.data)) {
+        nodeJSON.data = node.data.toString(argv['data-encoding'] || undefined)
+      }
 
       const answer = {
         Data: nodeJSON.data,

--- a/src/http/api/resources/object.js
+++ b/src/http/api/resources/object.js
@@ -85,7 +85,9 @@ exports.get = {
 
       const nodeJSON = node.toJSON()
 
-      nodeJSON.data = nodeJSON.data ? nodeJSON.data.toString() : ''
+      if (Buffer.isBuffer(node.data)) {
+        nodeJSON.data = node.data.toString(request.query['data-encoding'] || undefined)
+      }
 
       const answer = {
         Data: nodeJSON.data,

--- a/test/cli/object.js
+++ b/test/cli/object.js
@@ -41,6 +41,30 @@ describe('object', () => runOnAndOff((thing) => {
     })
   })
 
+  it('get with data', () => {
+    return ipfs('object new')
+      .then((out) => out.trim())
+      .then((hash) => ipfs(`object patch set-data ${hash} test/fixtures/test-data/hello`))
+      .then((out) => out.trim())
+      .then((hash) => ipfs(`object get ${hash}`))
+      .then((out) => {
+        const result = JSON.parse(out)
+        expect(result.Data).to.eql('aGVsbG8gd29ybGQK')
+      })
+  })
+
+  it('get while overriding data-encoding', () => {
+    return ipfs('object new')
+      .then((out) => out.trim())
+      .then((hash) => ipfs(`object patch set-data ${hash} test/fixtures/test-data/hello`))
+      .then((out) => out.trim())
+      .then((hash) => ipfs(`object get --data-encoding=utf8 ${hash}`))
+      .then((out) => {
+        const result = JSON.parse(out)
+        expect(result.Data).to.eql('hello world\n')
+      })
+  })
+
   it('put', () => {
     return ipfs('object put test/fixtures/test-data/node.json').then((out) => {
       expect(out).to.eql(

--- a/test/cli/object.js
+++ b/test/cli/object.js
@@ -41,7 +41,9 @@ describe('object', () => runOnAndOff((thing) => {
     })
   })
 
-  it('get with data', () => {
+  it('get with data', function () {
+    this.timeout(15 * 1000)
+
     return ipfs('object new')
       .then((out) => out.trim())
       .then((hash) => ipfs(`object patch set-data ${hash} test/fixtures/test-data/hello`))
@@ -53,7 +55,9 @@ describe('object', () => runOnAndOff((thing) => {
       })
   })
 
-  it('get while overriding data-encoding', () => {
+  it('get while overriding data-encoding', function () {
+    this.timeout(15 * 1000)
+
     return ipfs('object new')
       .then((out) => out.trim())
       .then((hash) => ipfs(`object patch set-data ${hash} test/fixtures/test-data/hello`))


### PR DESCRIPTION
This is the js counterpart to ipfs/go-ipfs#5139 and will allow the test in ipfs/interface-ipfs-core#302 to pass.

ipfs/js-ipfs-api#806 needs this to be merged before the interface test linked to above will pass.