### PR TITLE
test(dag): skip spec for put API

### DIFF
--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -16,7 +16,14 @@ describe('interface-ipfs-core tests', () => {
 
   tests.config(defaultCommonFactory)
 
-  tests.dag(defaultCommonFactory)
+  tests.dag(defaultCommonFactory, {
+    skip: [
+      {
+        name: 'should override hash algoritm default and resolve with it',
+        reason: 'https://github.com/ipld/js-ipld/pull/133 needs to land first'
+      }
+    ]
+  })
 
   tests.dht(defaultCommonFactory, {
     skip: { reason: 'TODO: DHT is not implemented in js-ipfs yet!' }


### PR DESCRIPTION
Over at https://github.com/ipfs/interface-ipfs-core/pull/323 we introduce a
test spec that ensures `dag.put()` honors the `hashAlg` option, which at
the time of this commit is ignored by the underlying `ipld.put()` API
(more info: https://github.com/ipfs/js-ipfs/commit/1a36375fa7c19ba5da11b1a7f84ee79d910742bc).

This commit skips that spec in `js-ipfs` as https://github.com/ipld/js-ipld/pull/133 has to
land first to fulfill the scenario.

License: MIT
Signed-off-by: Pascal Precht <pascal.precht@gmail.com>