### PR TITLE
fix: increase timeout for unadulterated data test

### DIFF
--- a/test/cli/object.js
+++ b/test/cli/object.js
@@ -69,7 +69,9 @@ describe('object', () => runOnAndOff((thing) => {
     })
   })
 
-  it('unadulterated data', () => {
+  it('unadulterated data', function () {
+    this.timeout(10 * 1000)
+
     // has to be big enough to span several DAGNodes
     const data = crypto.randomBytes(1024 * 300)
     const file = path.join(os.tmpdir(), `file-${Math.random()}.txt`)


### PR DESCRIPTION
Currently taking just over 5s

<img width="332" alt="screen shot 2018-07-05 at 20 58 47" src="https://user-images.githubusercontent.com/152863/42345249-a00f3ba0-8096-11e8-808c-6db6809d323f.png">
