### PR TITLE
fix: update hlsjs-ipfs-loader version (#1422)

### DIFF
--- a/examples/browser-video-streaming/README.md
+++ b/examples/browser-video-streaming/README.md
@@ -19,7 +19,7 @@ The hls.js library ships with an HTTP based content loader only, but it's fortun
 ```html
 <script src="https://unpkg.com/ipfs/dist/index.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
-<script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.1/dist/index.js"></script>
+<script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.2/dist/index.js"></script>
 ```
 
 ## Generating HLS content

--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -2,7 +2,7 @@
   <body>
     <video id="video" controls></video>
     <script src="https://unpkg.com/ipfs/dist/index.js"></script>
-    <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.1/dist/index.js"></script>
+    <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.2/dist/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>
   </body>


### PR DESCRIPTION
The recent version of hsljs-ipfs-loader works well with no error (#1422)