### PR TITLE
fix: aegir docs fails if outer function is called pin

### DIFF
--- a/src/core/components/pin.js
+++ b/src/core/components/pin.js
@@ -19,7 +19,7 @@ function toB58String (hash) {
   return new CID(hash).toBaseEncodedString()
 }
 
-module.exports = function pin (self) {
+module.exports = (self) => {
   const repo = self._repo
   const dag = self.dag
   const pinset = createPinSet(dag)


### PR DESCRIPTION
It's legal javascript, but the docs command fails if this function is called pin 😕 

You can test this fix out by running `npx aegir docs` in the project directory.