### PR TITLE
docs: adds mfs browser example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ Let us know if you find any issue or if you want to contribute and add a new tut
 - [Tutorial (Video): How to build an application with IPFS PubSub Room](https://www.youtube.com/watch?v=Nv_Teb--1zg)
 - [Tutorial (Video): How to build an Collaborative Editing Application with IPFS using CRDT](https://www.youtube.com/watch?v=-kdx8rJd8rQ)
 - [Tutorial - Understanding Circuit Relay](./circuit-relaying)
+
 ## Examples
 
 - [js-ipfs in the browser with Browserify](./browser-browserify)
@@ -22,7 +23,8 @@ Let us know if you find any issue or if you want to contribute and add a new tut
 - [js-ipfs in electron](./run-in-electron)
 - [Using streams to add a directory of files to ipfs](./browser-add-readable-stream)
 - [Customizing the ipfs repository](./custom-ipfs-repo)
-- - [Streaming video from ipfs to the browser using `ReadableStream`s](./browser-readablestream)
+- [Streaming video from ipfs to the browser using `ReadableStream`s](./browser-readablestream)
+- [The Mutable File System in the browser](./browser-mfs)
 
 ## Understanding the IPFS Stack
 

--- a/examples/browser-mfs/README.md
+++ b/examples/browser-mfs/README.md
@@ -1,0 +1,14 @@
+# Mutable File System examples
+
+The MFS is a file system abstraction built on top of IPFS.  It supports all the operations you would expect such as creating directories, adding files to them, renaming, coping, deleting, etc.
+
+## Running the demo
+
+In this directory:
+
+```
+$ npm install
+$ npm start
+```
+
+Then open [http://localhost:8888](http://localhost:8888) in your browser.

--- a/examples/browser-mfs/filetree.js
+++ b/examples/browser-mfs/filetree.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const {
+  log,
+  createNode
+} = require('./utils')
+
+const FILE_TYPES = {
+  FILE: 0,
+  DIRECTORY: 1
+}
+
+let selected = {}
+
+const getSelected = () => {
+  return Object.values(selected)
+}
+
+const loadFiles = async (ipfs, path) => {
+  const output = {}
+  path = path.replace(/\/\/+/g, '/')
+
+  const contents = await ipfs.files.ls(path, {
+    long: true
+  })
+    .catch(error => log(error))
+
+  for (let i = 0; i < contents.length; i++) {
+    let entry = contents[i]
+    output[entry.name] = entry
+
+    if (entry.type === FILE_TYPES.DIRECTORY) {
+      entry.contents = await loadFiles(ipfs, `${path}/${entry.name}`)
+    }
+  }
+
+  return output
+}
+
+const listFiles = (parent, files, prefix) => {
+  const fileNames = Object.keys(files)
+
+  fileNames.forEach((name, index) => {
+    const file = files[name]
+    const lastFile = index === fileNames.length - 1
+    const listIcon = lastFile ? '└── ' : '├── '
+    const listing = `${prefix}${listIcon}${name}`
+
+    if (file.type === FILE_TYPES.DIRECTORY) {
+      parent.appendChild(createNode('pre', `${listing}/`))
+      let descender = '|'
+      let directoryPrefix = `${prefix}${descender}   `
+
+      if (lastFile) {
+        directoryPrefix = `${prefix}    `
+      }
+
+      listFiles(parent, file.contents, directoryPrefix)
+    } else {
+      parent.appendChild(createNode('pre', listing))
+    }
+  })
+}
+
+const updateTree = async (ipfs) => {
+  const files = await loadFiles(ipfs, '/')
+  const container = document.querySelector('#files')
+
+  while (container.firstChild) {
+    container.removeChild(container.firstChild)
+  }
+
+  container.appendChild(createNode('pre', '/'))
+
+  listFiles(container, files, '')
+}
+
+module.exports = {
+  getSelected,
+  updateTree
+}

--- a/examples/browser-mfs/forms.js
+++ b/examples/browser-mfs/forms.js
@@ -1,0 +1,178 @@
+'use strict'
+
+const modalScreen = document.getElementById('modal-screen')
+
+modalScreen.onclick = (event) => {
+  if (event.target === modalScreen) {
+    hideForms()
+  }
+}
+
+const forms = {
+  mkdir: document.getElementById('form-mkdir'),
+  mv: document.getElementById('form-mv'),
+  cp: document.getElementById('form-cp'),
+  rm: document.getElementById('form-rm'),
+  stat: document.getElementById('form-stat'),
+  read: document.getElementById('form-read')
+}
+
+const getValue = (id) => {
+  const element = document.getElementById(id)
+
+  if (element.type === 'checkbox') {
+    return Boolean(element.checked)
+  }
+
+  if (element.type === 'number') {
+    const result = parseInt(element.value.trim())
+
+    return isNaN(result) ? undefined : result
+  }
+
+  return element.value.trim()
+}
+
+const hideForms = () => {
+  modalScreen.style.display = 'none'
+
+  Object.values(forms)
+    .forEach(form => {
+      form.style.display = 'none'
+    })
+}
+
+const showForm = (form) => {
+  return (event) => {
+    event.preventDefault()
+
+    modalScreen.style.display = 'block'
+    form.style.display = 'block'
+  }
+}
+
+const mkdirForm = (onMkdir) => {
+  const button = document.getElementById('button-mkdir')
+  const submit = document.getElementById('button-form-mkdir-submit')
+
+  button.onclick = showForm(forms.mkdir)
+  submit.onclick = () => {
+    hideForms()
+
+    onMkdir(
+      getValue('form-mkdir-path'),
+      getValue('form-mkdir-parents'),
+      getValue('form-mkdir-format'),
+      getValue('form-mkdir-hashalg'),
+      getValue('form-mkdir-flush')
+    )
+  }
+
+  button.disabled = false
+}
+
+const mvForm = (onMv) => {
+  const button = document.getElementById('button-mv')
+  const submit = document.getElementById('button-form-mv-submit')
+
+  button.onclick = showForm(forms.mv)
+  submit.onclick = () => {
+    hideForms()
+
+    onMv(
+      [getValue('form-mv-path')],
+      getValue('form-mv-dest'),
+      getValue('form-mv-parents'),
+      getValue('form-mv-format'),
+      getValue('form-mv-hashalg'),
+      getValue('form-mv-flush')
+    )
+  }
+
+  button.disabled = false
+}
+
+const cpForm = (onCp) => {
+  const button = document.getElementById('button-cp')
+  const submit = document.getElementById('button-form-cp-submit')
+
+  button.onclick = showForm(forms.cp)
+  submit.onclick = () => {
+    hideForms()
+
+    onCp(
+      [getValue('form-cp-path')],
+      getValue('form-cp-dest'),
+      getValue('form-cp-parents'),
+      getValue('form-cp-format'),
+      getValue('form-cp-hashalg'),
+      getValue('form-cp-flush')
+    )
+  }
+
+  button.disabled = false
+}
+
+const rmForm = (onRm) => {
+  const button = document.getElementById('button-rm')
+  const submit = document.getElementById('button-form-rm-submit')
+
+  button.onclick = showForm(forms.rm)
+  submit.onclick = () => {
+    hideForms()
+
+    onRm(
+      [getValue('form-rm-path')],
+      getValue('form-rm-recursive')
+    )
+  }
+
+  button.disabled = false
+}
+
+const statForm = (onStat) => {
+  const button = document.getElementById('button-stat')
+  const submit = document.getElementById('button-form-stat-submit')
+
+  button.onclick = showForm(forms.stat)
+  submit.onclick = () => {
+    hideForms()
+
+    onStat(
+      getValue('form-stat-path'),
+      getValue('form-stat-hash'),
+      getValue('form-stat-size'),
+      getValue('form-stat-withlocal')
+    )
+  }
+
+  button.disabled = false
+}
+
+const readForm = (onRead) => {
+  const button = document.getElementById('button-read')
+  const submit = document.getElementById('button-form-read-submit')
+
+  button.onclick = showForm(forms.read)
+  submit.onclick = () => {
+    hideForms()
+
+    onRead(
+      getValue('form-read-path'),
+      getValue('form-read-offset'),
+      getValue('form-read-length')
+    )
+  }
+
+  button.disabled = false
+}
+
+module.exports = {
+  mkdirForm,
+  mvForm,
+  rmForm,
+  cpForm,
+  statForm,
+  readForm,
+  hideForms
+}

--- a/examples/browser-mfs/index.html
+++ b/examples/browser-mfs/index.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <style type="text/css">
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+button {
+  font-size: 1.5em;
+  padding: 5px 10px;
+}
+
+#container {
+  height: calc(100vh - 60px);
+  padding: 20px;
+  border: 10px transparent;
+}
+
+#container.drag-over {
+  border: 10px dashed green;
+}
+
+#buttons {
+  height: 50px;
+}
+
+#display {
+  display: flex;
+  height: calc(100vh - 90px);
+}
+
+#log {
+  flex-grow: 2;
+  padding: 10px;
+  height: calc(100vh - 120px);
+  overflow: auto;
+}
+
+#log p {
+  font-family: "Lucida Console", Monaco, monospace;
+  margin: 0;
+  white-space: pre;
+  line-height: 1.4;
+}
+
+#log p.error {
+  color: red;
+}
+
+#log p.output {
+  color: green;
+}
+
+#files {
+  width: 50vw;
+}
+
+#files pre {
+  margin: 0;
+  line-height: 1.4;
+}
+
+#modal-screen {
+  position: absolute;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(0, 0, 0, 0.4);
+  top: 0;
+  left: 0;
+}
+
+.modal {
+  -webkit-box-shadow: 0px 0px 92px -3px rgba(0, 0, 0, 0.4);
+  -moz-box-shadow: 0px 0px 92px -3px rgba(0, 0, 0, 0.4);
+  box-shadow: 0px 0px 92px -3px rgba(0, 0, 0, 0.4);
+  background-color: white;
+
+  position: absolute;
+  top: 50px;
+  width: 500px;
+  margin-left: 50%;
+  left: -250px;
+  padding: 20px;
+  display: none;
+}
+
+.modal h2 {
+  margin-top: 10px;
+}
+
+.modal input {
+  font-size: 1.5em;
+  padding: 5px 10px;
+}
+
+.modal label, .modal input, .modal checkbox, .modal button {
+  display: block;
+  margin: 10px 0;
+}
+    </style>
+  </head>
+  <body>
+    <div id="container" ondrop="dropHandler(event)" ondragover="dragOverHandler(event)">
+      <div id="buttons">
+        <button id="button-cp" disabled>cp</button>
+        <button id="button-mkdir" disabled>mkdir</button>
+        <button id="button-mv" disabled>mv</button>
+        <button id="button-read" disabled>read</button>
+        <button id="button-rm" disabled>rm</button>
+        <button id="button-stat" disabled>stat</button>
+      </div>
+      <div id="display">
+        <div id="files"></div>
+        <div id="log"></div>
+      </div>
+    </div>
+
+    <div id="modal-screen"></div>
+
+    <div id="form-mkdir" class="modal">
+      <h2>mkdir</h2>
+
+      <label for="form-mkdir-path">path:</label>
+      <input type="text" id="form-mkdir-path" value="/" />
+
+      <label for="form-mkdir-parents">format:</label>
+      <input type="text" id="form-mkdir-format" value="dag-pb" />
+
+      <label for="form-mkdir-parents">hashAlg:</label>
+      <input type="text" id="form-mkdir-hashalg" value="sha2-256" />
+
+      <label for="form-mkdir-parents">parents:</label>
+      <input type="checkbox" id="form-mkdir-parents" checked />
+
+      <label for="form-mkdir-parents">flush:</label>
+      <input type="checkbox" id="form-mkdir-flush" checked />
+
+      <button id="button-form-mkdir-submit">Go!</button>
+    </div>
+
+    <div id="form-cp" class="modal">
+      <h2>cp</h2>
+
+      <label for="form-cp-path">path:</label>
+      <input type="text" id="form-cp-path" value="/" />
+
+      <label for="form-cp-dest">destination:</label>
+      <input type="text" id="form-cp-dest" value="/" />
+
+      <label for="form-cp-parents">format:</label>
+      <input type="text" id="form-cp-format" value="dag-pb" />
+
+      <label for="form-cp-parents">hashAlg:</label>
+      <input type="text" id="form-cp-hashalg" value="sha2-256" />
+
+      <label for="form-cp-parents">parents:</label>
+      <input type="checkbox" id="form-cp-parents" checked />
+
+      <label for="form-cp-parents">flush:</label>
+      <input type="checkbox" id="form-cp-flush" checked />
+
+      <button id="button-form-cp-submit">Go!</button>
+    </div>
+
+    <div id="form-mv" class="modal">
+      <h2>mv</h2>
+
+      <label for="form-mv-path">path:</label>
+      <input type="text" id="form-mv-path" value="/" />
+
+      <label for="form-mv-dest">destination:</label>
+      <input type="text" id="form-mv-dest" value="/" />
+
+      <label for="form-mv-parents">format:</label>
+      <input type="text" id="form-mv-format" value="dag-pb" />
+
+      <label for="form-mv-parents">hashAlg:</label>
+      <input type="text" id="form-mv-hashalg" value="sha2-256" />
+
+      <label for="form-mv-parents">parents:</label>
+      <input type="checkbox" id="form-mv-parents" checked />
+
+      <label for="form-mv-parents">flush:</label>
+      <input type="checkbox" id="form-mv-flush" checked />
+
+      <button id="button-form-mv-submit">Go!</button>
+    </div>
+
+    <div id="form-rm" class="modal">
+      <h2>rm</h2>
+
+      <label for="form-rm-path">path:</label>
+      <input type="text" id="form-rm-path" value="/" />
+
+      <label for="form-mkdir-recursive">recursive:</label>
+      <input type="checkbox" id="form-rm-recursive" checked />
+
+      <button id="button-form-rm-submit">Go!</button>
+    </div>
+
+    <div id="form-stat" class="modal">
+      <h2>stat</h2>
+
+      <label for="form-stat-path">path:</label>
+      <input type="text" id="form-stat-path" value="/" />
+
+      <label for="form-stat-hash">hash:</label>
+      <input type="checkbox" id="form-stat-hash" />
+
+      <label for="form-stat-size">size:</label>
+      <input type="checkbox" id="form-stat-size" />
+
+      <label for="form-stat-withlocal">withLocal:</label>
+      <input type="checkbox" id="form-stat-withlocal" checked />
+
+      <button id="button-form-stat-submit">Go!</button>
+    </div>
+
+    <div id="form-read" class="modal">
+      <h2>read</h2>
+
+      <label for="form-read-path">path:</label>
+      <input type="text" id="form-read-path" value="/" />
+
+      <label for="form-read-offset">offset:</label>
+      <input type="number" id="form-read-offset" value="" />
+
+      <label for="form-read-length">length:</label>
+      <input type="number" id="form-read-length" value="" />
+
+      <button id="button-form-read-submit">Go!</button>
+    </div>
+  </body>
+</html>

--- a/examples/browser-mfs/index.js
+++ b/examples/browser-mfs/index.js
@@ -1,0 +1,178 @@
+'use strict'
+
+/* eslint-env browser */
+
+const IPFS = require('ipfs')
+const ipfs = new IPFS({
+  repo: `ipfs-${Math.random()}`
+})
+const {
+  dragDrop,
+  log,
+  bufferToArrayBuffer
+} = require('./utils')
+const {
+  updateTree
+} = require('./filetree')
+const {
+  mvForm,
+  mkdirForm,
+  rmForm,
+  cpForm,
+  statForm,
+  readForm,
+  hideForms
+} = require('./forms')
+const mime = require('mime-sniffer')
+
+hideForms()
+
+log('IPFS: Initialising')
+
+ipfs.on('ready', () => {
+  // Allow adding files to IPFS via drag and drop
+  dragDrop(async (files) => {
+    /* eslint-disable-next-line no-alert */
+    const destinationDirectory = prompt(`Dropped ${files.length} file${files.length > 1 ? 's' : ''}, please enter a directory to store them in`, '/')
+
+    if (!destinationDirectory || !`${destinationDirectory}`.trim()) {
+      return
+    }
+
+    await Promise.all(
+      files.map(file => {
+        const path = `${destinationDirectory}/${file.name}`.replace(/\/\/+/g, '/')
+        log(`ipfs.files.write('${path}', <File>, { create: true, parents: true })`)
+        return ipfs.files.write(path, file, {
+          create: true,
+          parents: true
+        })
+          .catch(error => log(error))
+      })
+    )
+
+    updateTree(ipfs)
+  })
+
+  mkdirForm(async (path, parents, format, hashAlg, flush) => {
+    log(`ipfs.files.mkdir('${path}', ${JSON.stringify({
+      parents,
+      format,
+      hashAlg,
+      flush
+    }, null, 2)})`)
+
+    await ipfs.files.mkdir(path, {
+      parents,
+      format,
+      hashAlg,
+      flush
+    })
+      .catch(error => log(error))
+
+    updateTree(ipfs)
+  })
+
+  mvForm(async (paths, destination, parents, format, hashAlg, flush) => {
+    log(`ipfs.files.mv(${paths.map(path => `'${path}'`).join(', ')}, ${JSON.stringify({
+      parents,
+      format,
+      hashAlg,
+      flush
+    }, null, 2)})`)
+
+    await ipfs.files.mv.apply(null, paths.concat(destination, {
+      parents,
+      format,
+      hashAlg,
+      flush
+    }))
+      .catch(error => log(error))
+
+    updateTree(ipfs)
+  })
+
+  rmForm(async (paths, recursive) => {
+    log(`ipfs.files.rm(${paths.map(path => `'${path}'`).join(', ')}, ${JSON.stringify({
+      recursive
+    }, null, 2)})`)
+
+    await ipfs.files.rm.apply(null, paths.concat({
+      recursive
+    }))
+      .catch(error => log(error))
+
+    updateTree(ipfs)
+  })
+
+  cpForm(async (paths, destination, parents, format, hashAlg, flush) => {
+    log(`ipfs.files.cp(${paths.map(path => `'${path}'`).join(', ')}, '${destination}', ${JSON.stringify({
+      parents,
+      format,
+      hashAlg,
+      flush
+    }, null, 2)})`)
+
+    await ipfs.files.cp.apply(null, paths.concat(destination, {
+      parents,
+      format,
+      hashAlg,
+      flush
+    }))
+      .catch(error => log(error))
+
+    updateTree(ipfs)
+  })
+
+  statForm(async (path, hash, size, withLocal) => {
+    log(`ipfs.files.stat('${path}', ${JSON.stringify({
+      hash,
+      size,
+      withLocal
+    }, null, 2)})`)
+
+    await ipfs.files.stat(path, {
+      hash,
+      size,
+      withLocal
+    })
+      .then((stats) => log(stats))
+      .catch(error => log(error))
+  })
+
+  readForm(async (path, offset, length) => {
+    log(`ipfs.files.read('${path}', ${JSON.stringify({
+      offset,
+      length
+    }, null, 2)})`)
+
+    await ipfs.files.read(path, {
+      offset,
+      length
+    })
+      .then((buffer) => {
+        mime.lookup(buffer, (error, result) => {
+          // will cause file to be downloaded if we don't know what it is
+          let mimeType = 'application/octet-stream'
+
+          if (!error) {
+            mimeType = result.mime
+          }
+
+          const data = bufferToArrayBuffer(buffer)
+          const file = new Blob([data], {
+            type: mimeType
+          })
+          const fileURL = URL.createObjectURL(file)
+          window.open(fileURL)
+        })
+      })
+      .catch(error => log(error))
+  })
+
+  log('IPFS: Ready')
+  log('IPFS: Drop some files into this window to get started')
+  log('')
+
+  updateTree(ipfs)
+})

--- a/examples/browser-mfs/package.json
+++ b/examples/browser-mfs/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "browser-mfs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack",
+    "start": "npm run build && http-server dist -a 127.0.0.1 -p 8888"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "html-webpack-plugin": "^3.2.0",
+    "http-server": "~0.11.1",
+    "uglifyjs-webpack-plugin": "^1.2.0",
+    "webpack": "^4.15.1",
+    "webpack-cli": "^3.0.8"
+  },
+  "dependencies": {
+    "ipfs": "../../",
+    "mime-sniffer": "~0.0.3"
+  }
+}

--- a/examples/browser-mfs/utils.js
+++ b/examples/browser-mfs/utils.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const createNode = (type, content, attrbutes) => {
+  attrbutes = attrbutes || {}
+
+  const node = document.createElement(type)
+  node.innerText = content
+
+  Object.keys(attrbutes).forEach(attrbute => {
+    if (attrbute === 'className') {
+      node.className = attrbutes[attrbute]
+
+      return
+    }
+
+    node.setAttribute(attrbute, attrbutes[attrbute])
+  })
+
+  return node
+}
+
+const log = (line) => {
+  const output = document.querySelector('#log')
+  let message
+  let className = ''
+
+  if (line instanceof Error) {
+    className = 'error'
+    message = `Error: ${line.message}`
+  } else if (typeof line === 'string') {
+    message = line
+  } else {
+    className = 'output'
+    message = JSON.stringify(line, null, 2)
+  }
+
+  if (!message) {
+    return
+  }
+
+  const node = createNode('p', message, {
+    className
+  })
+  output.appendChild(node)
+  output.scrollTop = output.offsetHeight
+
+  return node
+}
+
+const dragDrop = (onFiles) => {
+  const container = document.querySelector('#container')
+
+  container.ondragover = (event) => {
+    container.className = 'drag-over'
+    event.preventDefault()
+  }
+
+  container.ondragleave = () => {
+    container.className = ''
+  }
+
+  container.ondrop = (event) => {
+    container.className = ''
+    event.preventDefault()
+
+    const files = Array.from(event.dataTransfer.items)
+      .map(item => item.getAsFile())
+      .filter(item => Boolean(item))
+
+    if (files.length) {
+      onFiles(files)
+    }
+  }
+}
+
+const bufferToArrayBuffer = (buffer) => {
+  const ab = new ArrayBuffer(buffer.length)
+  const view = new Uint8Array(ab)
+
+  for (let i = 0; i < buffer.length; ++i) {
+    view[i] = buffer[i]
+  }
+
+  return ab
+}
+
+module.exports = {
+  log,
+  dragDrop,
+  createNode,
+  bufferToArrayBuffer
+}

--- a/examples/browser-mfs/webpack.config.js
+++ b/examples/browser-mfs/webpack.config.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const path = require('path')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+
+module.exports = {
+  mode: 'development',
+  devtool: 'source-map',
+  entry: [
+    './index.js'
+  ],
+  plugins: [
+    new UglifyJsPlugin({
+      sourceMap: true,
+      uglifyOptions: {
+        mangle: false,
+        compress: false
+      }
+    }),
+    new HtmlWebpackPlugin({
+      title: 'IPFS MFS example',
+      template: 'index.html'
+    })
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  node: {
+    fs: 'empty'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "ipfs-block": "~0.7.1",
     "ipfs-block-service": "~0.14.0",
     "ipfs-http-response": "~0.1.2",
-    "ipfs-mfs": "~0.0.14",
+    "ipfs-mfs": "~0.0.16",
     "ipfs-multipart": "~0.1.0",
     "ipfs-repo": "~0.22.1",
     "ipfs-unixfs": "~0.1.15",


### PR DESCRIPTION
Adds an interactive MFS example that runs in the browser!

Also upgrades to the latest js-ipfs-mfs to fix some bugs around handling errors when trying to copy files/directories onto themselves.