### PR TITLE
fix: double pre start

### DIFF
--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -35,7 +35,7 @@ module.exports = {
     httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
 
     httpAPI.start((err) => {
-      if (err && err.code === 'ENOENT' && err.message.match(/not initialized/i)) {
+      if (err && err.code === 'ENOENT' && err.message.match(/uninitialized/i)) {
         print('Error: no initialized ipfs repo found in ' + repoPath)
         print('please run: jsipfs init')
         process.exit(1)

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -35,7 +35,7 @@ module.exports = {
     httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
 
     httpAPI.start((err) => {
-      if (err && err.code === 'ENOENT' && err.message.match(/Uninitalized repo/i)) {
+      if (err && err.code === 'ENOENT' && err.message.match(/uninitalized/i)) {
         print('Error: no initialized ipfs repo found in ' + repoPath)
         print('please run: jsipfs init')
         process.exit(1)

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -35,7 +35,7 @@ module.exports = {
     httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
 
     httpAPI.start((err) => {
-      if (err && err.code === 'ENOENT' && err.message.match(/uninitalized/i)) {
+      if (err && err.code === 'ENOENT' && err.message.match(/not initialized/i)) {
         print('Error: no initialized ipfs repo found in ' + repoPath)
         print('please run: jsipfs init')
         process.exit(1)

--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -9,78 +9,88 @@ module.exports = (self) => {
   const options = self._options
   const doInit = options.init
   const doStart = options.start
-  const repoOpen = !self._repo.closed
 
   const customInitOptions = typeof options.init === 'object' ? options.init : {}
   const initOptions = Object.assign({ bits: 2048, pass: self._options.pass }, customInitOptions)
 
-  // Checks if a repo exists, and if so opens it
-  // Will return callback with a bool indicating the existence
-  // of the repo
-  const maybeOpenRepo = (cb) => {
-    // nothing to do
-    if (repoOpen) {
-      return cb(null, true)
-    }
-
-    self._repo.open((err, res) => {
-      if (err) {
-        // If the error is that no repo exists,
-        // which happens when the version file is not found
-        // we just want to signal that no repo exist, not
-        // fail the whole process.
-
-        // Use standardized errors as much as possible
-        if (err.code === RepoErrors.ERR_REPO_NOT_INITIALIZED) {
-          return cb(null, false)
-        }
-
-        // TODO: As error codes continue to be standardized, this logic can be phase out;
-        // it is here to maintain compatability
-        if (err.message.match(/not found/) || // indexeddb
-          err.message.match(/ENOENT/) || // fs
-          err.message.match(/No value/) // memory
-        ) {
-          return cb(null, false)
-        }
-        return cb(err)
+  // Do the actual boot sequence
+  waterfall([
+    // Checks if a repo exists, and if so opens it
+    // Will return callback with a bool indicating the existence
+    // of the repo
+    (cb) => {
+      // nothing to do
+      if (!self._repo.closed) {
+        return cb(null, true)
       }
-      cb(null, true)
-    })
-  }
 
-  const tasks = [
-    (cb) => maybeOpenRepo(cb),
-    (repoOpened, cb) => {
-      if (!doInit || repoOpened) return cb(null, repoOpened)
-      // No repo, but should init one
-      self.init(initOptions, (err) => cb(err, true))
+      self._repo.open((err, res) => {
+        if (isRepoUninitializedError(err)) return cb(null, false)
+        if (err) return cb(err)
+        cb(null, true)
+      })
     },
-    (initialized, cb) => {
-      if (initialized) {
+    // Initialize the repo if it was not opened
+    (repoOpened, cb) => {
+      if (repoOpened) {
         self.log('initialized')
         self.state.initialized()
+        return cb()
       }
-      cb(null, initialized)
+
+      if (!doInit) {
+        return cb()
+      }
+
+      // No repo, but should init one
+      self.init(initOptions, (err) => cb(err))
     },
-    (initialized, cb) => {
+    (cb) => {
       // No problem, we can't preStart until we're initialized
-      if (!initialized) return cb()
+      if (!self.state.state() !== 'initialized') {
+        return cb()
+      }
       self.preStart(cb)
     },
     (cb) => {
       // No problem, we don't have to start the node
-      if (!doStart) return cb()
+      if (!doStart) {
+        return cb()
+      }
       self.start(cb)
     }
-  ]
-
-  // Do the actual boot sequence
-  waterfall(tasks, (err) => {
+  ], (err) => {
     if (err) {
       return self.emit('error', err)
     }
     self.log('booted')
     self.emit('ready')
   })
+}
+
+function isRepoUninitializedError (err) {
+  if (!err) {
+    return false
+  }
+
+  // If the error is that no repo exists,
+  // which happens when the version file is not found
+  // we just want to signal that no repo exist, not
+  // fail the whole process.
+
+  // Use standardized errors as much as possible
+  if (err.code === RepoErrors.ERR_REPO_NOT_INITIALIZED) {
+    return true
+  }
+
+  // TODO: As error codes continue to be standardized, this logic can be phase out;
+  // it is here to maintain compatability
+  if (err.message.match(/not found/) || // indexeddb
+    err.message.match(/ENOENT/) || // fs
+    err.message.match(/No value/) // memory
+  ) {
+    return true
+  }
+
+  return false
 }

--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -53,11 +53,8 @@ module.exports = (self) => {
     (cb) => maybeOpenRepo(cb),
     (repoOpened, cb) => {
       if (!doInit || repoOpened) return cb(null, repoOpened)
-      // No repo, but need should init one
-      self.init(initOptions, (err) => {
-        if (err) return cb(err)
-        cb(null, true)
-      })
+      // No repo, but should init one
+      self.init(initOptions, (err) => cb(err, true))
     },
     (initialized, cb) => {
       if (initialized) {

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -27,7 +27,7 @@ module.exports = function init (self) {
       callback(null, res)
     }
 
-    if (self.state.state() !== 'uninitalized') {
+    if (self.state.state() !== 'uninitialized') {
       return done(new Error('Not able to init from state: ' + self.state.state()))
     }
 

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -22,9 +22,16 @@ module.exports = function init (self) {
         return callback(err)
       }
 
-      self.state.initialized()
-      self.emit('init')
-      callback(null, res)
+      self.preStart((err) => {
+        if (err) {
+          self.emit('error', err)
+          return callback(err)
+        }
+
+        self.state.initialized()
+        self.emit('init')
+        callback(null, res)
+      })
     }
 
     if (self.state.state() !== 'uninitialized') {
@@ -33,6 +40,12 @@ module.exports = function init (self) {
 
     self.state.init()
     self.log('init')
+
+    // An initialized, open repo was passed, use this one!
+    if (opts.repo) {
+      self._repo = opts.repo
+      return done(null, true)
+    }
 
     opts.emptyRepo = opts.emptyRepo || false
     opts.bits = Number(opts.bits) || 2048

--- a/src/core/components/pre-start.js
+++ b/src/core/components/pre-start.js
@@ -12,22 +12,10 @@ const NoKeychain = require('./no-keychain')
  */
 module.exports = function preStart (self) {
   return (callback) => {
-    if (self.state.state() !== 'initialized') {
-      return callback(new Error('Not able to pre-start from state: ' + self.state.state()))
-    }
-
     self.log('pre-start')
-    self.state.preStart()
 
     const pass = self._options.pass
     waterfall([
-      (cb) => {
-        // The repo may be closed if previously stopped
-        if (self._repo.closed) {
-          return self._repo.open(cb)
-        }
-        cb()
-      },
       (cb) => self._repo.config.get(cb),
       (config, cb) => {
         if (!self._options.config) {
@@ -108,13 +96,6 @@ module.exports = function preStart (self) {
         cb()
       },
       (cb) => self.pin._load(cb)
-    ], (err) => {
-      if (err) {
-        return callback(err)
-      }
-      self.log('pre-started')
-      self.state.preStarted()
-      callback()
-    })
+    ], callback)
   }
 }

--- a/src/core/components/pre-start.js
+++ b/src/core/components/pre-start.js
@@ -21,6 +21,13 @@ module.exports = function preStart (self) {
 
     const pass = self._options.pass
     waterfall([
+      (cb) => {
+        // The repo may be closed if previously stopped
+        if (self._repo.closed) {
+          return self._repo.open(cb)
+        }
+        cb()
+      },
       (cb) => self._repo.config.get(cb),
       (config, cb) => {
         if (!self._options.config) {

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -10,9 +10,12 @@ module.exports = (self) => {
     series([
       (cb) => {
         switch (self.state.state()) {
-          case 'initialized': return self.preStart(cb)
-          case 'stopped': return cb()
-          default: cb(new Error(`Not able to start from state: ${self.state.state()}`))
+          case 'initialized':
+            return self.preStart(cb)
+          case 'stopped':
+            return cb()
+          default:
+            cb(new Error(`Not able to start from state: ${self.state.state()}`))
         }
       },
       (cb) => {
@@ -30,6 +33,7 @@ module.exports = (self) => {
 
         self._bitswap.start()
         self._blockService.setExchange(self._bitswap)
+        cb()
       }
     ], (err) => {
       if (err) {

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -7,47 +7,40 @@ const promisify = require('promisify-es6')
 
 module.exports = (self) => {
   return promisify((callback) => {
-    self.log('starting')
+    series([
+      (cb) => {
+        switch (self.state.state()) {
+          case 'initialized': return self.preStart(cb)
+          case 'stopped': return cb()
+          default: cb(new Error(`Not able to start from state: ${self.state.state()}`))
+        }
+      },
+      (cb) => {
+        self.log('starting')
+        self.state.start()
+        cb()
+      },
+      (cb) => self.libp2p.start(cb),
+      (cb) => {
+        self._bitswap = new Bitswap(
+          self._libp2pNode,
+          self._repo.blocks,
+          { statsEnabled: true }
+        )
 
-    const done = (err) => {
+        self._bitswap.start()
+        self._blockService.setExchange(self._bitswap)
+      }
+    ], (err) => {
       if (err) {
         setImmediate(() => self.emit('error', err))
         return callback(err)
       }
 
-      self.state.started()
       self.log('started')
+      self.state.started()
       setImmediate(() => self.emit('start'))
       callback()
-    }
-
-    if (self.state.state() !== 'stopped') {
-      return done(new Error('Not able to start from state: ' + self.state.state()))
-    }
-
-    self.log('starting')
-    self.state.start()
-
-    series([
-      (cb) => {
-        self._repo.closed
-          ? self._repo.open(cb)
-          : cb()
-      },
-      (cb) => self.preStart(cb),
-      (cb) => self.libp2p.start(cb)
-    ], (err) => {
-      if (err) { return done(err) }
-
-      self._bitswap = new Bitswap(
-        self._libp2pNode,
-        self._repo.blocks,
-        { statsEnabled: true }
-      )
-
-      self._bitswap.start()
-      self._blockService.setExchange(self._bitswap)
-      done()
     })
   })
 }

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -19,6 +19,13 @@ module.exports = (self) => {
         }
       },
       (cb) => {
+        // The repo may be closed if previously stopped
+        if (self._repo.closed) {
+          return self._repo.open(cb)
+        }
+        cb()
+      },
+      (cb) => {
         self.log('starting')
         self.state.start()
         cb()

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -7,7 +7,7 @@ const promisify = require('promisify-es6')
 
 module.exports = (self) => {
   return promisify((callback) => {
-    callback = callback || function noop () {}
+    self.log('starting')
 
     const done = (err) => {
       if (err) {
@@ -16,6 +16,7 @@ module.exports = (self) => {
       }
 
       self.state.started()
+      self.log('started')
       setImmediate(() => self.emit('start'))
       callback()
     }

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -7,8 +7,8 @@ log.error = debug('jsipfs:state:error')
 const fsm = require('fsm-event')
 
 module.exports = (self) => {
-  const s = fsm('uninitalized', {
-    uninitalized: {
+  const s = fsm('uninitialized', {
+    uninitialized: {
       init: 'initializing',
       initialized: 'initialized'
     },

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -10,16 +10,10 @@ module.exports = (self) => {
   const s = fsm('uninitialized', {
     uninitialized: {
       init: 'initializing',
-      initialized: 'initialized'
+      initialized: 'stopped'
     },
     initializing: {
-      initialized: 'initialized'
-    },
-    initialized: {
-      preStart: 'preStarting'
-    },
-    preStarting: {
-      preStarted: 'stopped'
+      initialized: 'stopped'
     },
     stopped: {
       start: 'starting'

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -10,10 +10,16 @@ module.exports = (self) => {
   const s = fsm('uninitalized', {
     uninitalized: {
       init: 'initializing',
-      initialized: 'stopped'
+      initialized: 'initialized'
     },
     initializing: {
-      initialized: 'stopped'
+      initialized: 'initialized'
+    },
+    initialized: {
+      preStart: 'preStarting'
+    },
+    preStarting: {
+      preStarted: 'stopped'
     },
     stopped: {
       start: 'starting'
@@ -41,6 +47,14 @@ module.exports = (self) => {
 
   s.initialized = () => {
     s('initialized')
+  }
+
+  s.preStart = () => {
+    s('preStart')
+  }
+
+  s.preStarted = () => {
+    s('preStarted')
   }
 
   s.stop = () => {

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -43,14 +43,6 @@ module.exports = (self) => {
     s('initialized')
   }
 
-  s.preStart = () => {
-    s('preStart')
-  }
-
-  s.preStarted = () => {
-    s('preStarted')
-  }
-
   s.stop = () => {
     s('stop')
   }


### PR DESCRIPTION
This is a fix for `preStart` being called twice but also a partial refactor of the boot sequence.

The problem is that `preStart` always needs to be called between `init` and `start` and was actually being called in `boot.js` (via the `IPFS` constructor if repo exists or is newly initialized) as well as in `start.js`.

The following permutations of constructing, initializing and starting show how `preStart` was being called twice:

```js
const ipfs = new IPFS({ init: false, start: false })
ipfs.on('ready', () => {
  await ipfs.init()
  await ipfs.start()
})
```

`preStart` is called ✅ 
`preStart` is called once from `ipfs.start()` ✅ 

```js
const ipfs = new IPFS({ init: true, start: false })
ipfs.on('ready', () => {
  await ipfs.start()
})
```

`preStart` is called ✅ 
`preStart` is called once from `boot.js` (via the constructor) and again in `ipfs.start()` ❌ 

```js
const ipfs = new IPFS({ init: true, start: true })
ipfs.on('ready', () => {})
```

`preStart` is called ✅ 
`preStart` is called once from `boot.js` (via the constructor) and again via `boot.js` since it calls `ipfs.start()` ❌ 

---

So having `preStart` called in `boot.js` and `ipfs.start` ensures it is always called, but in most cases it ends up being called twice.

This PR moves the call to `preStart` into `init` and ensures `init` is always called even if the repo already exists.

towards #1061
fixes #1162