### PR TITLE
[documentation] Fixing incorrect npm run test line

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ Please use the same script if you need to update this table.
 > npm test
 
 # run just IPFS tests in Node.js
-> npm run test:node:core
+> npm run test:node
 
 # run just IPFS core tests
 > npm run test:node:core


### PR DESCRIPTION
I believe you meant to write `npm run test:node` in the instructions on how to run the unit tests. The `npm run test:node:core` line was written twice. Cheers