### PR TITLE
revert: docs: add migration note about upgrading from < 0.30.0 (#1450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,19 +53,6 @@ Signed-off-by: David Dias <mail@daviddias.me>
 License: MIT
 Signed-off-by: Alan Shaw <alan@tableflip.io>
 
-* Git pre-push hook has been removed
-
-  **This only applies to developers that build IPFS from source, not for consumers**
-
-  This can cause problems during installation of npm dependencies, in case the repository
-  is not freshly cloned. Prior to 0.30.0 a pre-push hook has been set up to verify
-  changes before sending them to a remote repository. Due to the removal, existing
-  installations will have dead symlinks that cause `npm install` to fail.
-
-  The migration path is to remove the `pre-hook` file/symlink inside `.git/hooks` of
-  your clone.
-
-  [Read this issue](https://github.com/ipfs/js-ipfs/issues/1444) for more information.
 
 
 <a name="0.29.3"></a>

--- a/README.md
+++ b/README.md
@@ -42,11 +42,6 @@ You can check the development status at the [Waffle Board](https://waffle.io/ipf
 
 [**`Weekly Core Dev Calls`**](https://github.com/ipfs/pm/issues/650)
 
-
-### Upgrading from < 0.30.0
-
-If you're upgrading from < 0.30.0 you might run into errors when installing dependencies due to non-existing git hooks. For fixes, please refer to the [changelog](https://github.com/ipfs/js-ipfs/blob/master/CHANGELOG.md#breaking-changes).
-
 ## Tech Lead
 
 [David Dias](https://github.com/diasdavid)
@@ -365,10 +360,10 @@ The core API is grouped into several areas:
   - [`ipfs.files.addPullStream([options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filesaddpullstream)
   - [`ipfs.files.addReadableStream([options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filesaddreadablestream)
   - [`ipfs.files.cat(ipfsPath, [options], [callback])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filescat). Alias to `ipfs.cat`.
-  - [`ipfs.files.catPullStream(ipfsPath, [options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filescatpullstream)
+  - [`ipfs.files.catPullStream(ipfsPath, [options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filescatpullstream)  
   - [`ipfs.files.catReadableStream(ipfsPath, [options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filescatreadablestream)
   - [`ipfs.files.get(ipfsPath, [options], [callback])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filesget). Alias to `ipfs.get`.
-  - [`ipfs.files.getPullStream(ipfsPath, [options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filesgetpullstream)
+  - [`ipfs.files.getPullStream(ipfsPath, [options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filesgetpullstream)  
   - [`ipfs.files.getReadableStream(ipfsPath, [options])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filesgetreadablestream)
   - [`ipfs.ls(ipfsPath, [callback])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#ls)
   - [`ipfs.lsPullStream(ipfsPath)`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#lspullstream)


### PR DESCRIPTION
This reverts commit 48aceb1392ccdf230a764dfb74e2ab4e4f7d06a9.

This issue was fixed upstream. As we use version ranges for dependencies,
it is automatically fixed now. Hence reverting the original commit.

cc @PascalPrecht 