### PR TITLE
Allow chunking algorithm to be specified when adding a file

### DIFF
--- a/src/cli/commands/files/add.js
+++ b/src/cli/commands/files/add.js
@@ -137,14 +137,7 @@ module.exports = {
     },
     'chunker': {
       default: 'default',
-      describe: 'Chunking algorithm to use',
-      choices: [
-        "default",
-        "size-{size}",
-        "rabin",
-        "rabin-{avg}",
-        "rabin-{min}-{avg}-{max}"
-      ]
+      describe: 'Chunking algorithm to use, formatted like [default, size-{size}, rabin, rabin-{avg}, rabin-{min}-{avg}-{max}]',
     },
     'enable-sharding-experiment': {
       type: 'boolean',

--- a/src/cli/commands/files/add.js
+++ b/src/cli/commands/files/add.js
@@ -135,6 +135,17 @@ module.exports = {
       default: false,
       describe: 'Only chunk and hash, do not write'
     },
+    'chunker': {
+      default: 'default',
+      describe: 'Chunking algorithm to use',
+      choices: [
+        "default",
+        "size-{size}",
+        "rabin",
+        "rabin-{avg}",
+        "rabin-{min}-{avg}-{max}"
+      ]
+    },
     'enable-sharding-experiment': {
       type: 'boolean',
       default: false
@@ -194,7 +205,8 @@ module.exports = {
       onlyHash: argv.onlyHash,
       hashAlg: argv.hash,
       wrapWithDirectory: argv.wrapWithDirectory,
-      pin: argv.pin
+      pin: argv.pin,
+      chunker: argv.chunker
     }
 
     // Temporary restriction on raw-leaves:

--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -17,6 +17,7 @@ const Duplex = require('readable-stream').Duplex
 const OtherBuffer = require('buffer').Buffer
 const CID = require('cids')
 const toB58String = require('multihashes').toB58String
+const parseChunkerString = require('../utils').parseChunkerString
 
 const WRAPPER = 'wrapper/'
 
@@ -134,11 +135,12 @@ class AddHelper extends Duplex {
 
 module.exports = function files (self) {
   function _addPullStream (options) {
+    const chunkerOptions = parseChunkerString(options.chunker)
     const opts = Object.assign({}, {
       shardSplitThreshold: self._options.EXPERIMENTAL.sharding
         ? 1000
         : Infinity
-    }, options)
+    }, options, chunkerOptions)
 
     if (opts.hashAlg && opts.cidVersion !== 1) {
       opts.cidVersion = 1

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -166,7 +166,7 @@ function parseRabinString(chunker) {
       break
     case 2:
       options.avgChunkSize = parseInt(parts[1])
-      if (isNaN(options.avgBlockSize)) {
+      if (isNaN(options.avgChunkSize)) {
         throw new Error("Parameter avg must be an integer")
       }
       break

--- a/src/http/api/resources/files.js
+++ b/src/http/api/resources/files.js
@@ -233,7 +233,8 @@ exports.add = {
       onlyHash: request.query['only-hash'],
       hashAlg: request.query['hash'],
       wrapWithDirectory: request.query['wrap-with-directory'],
-      pin: request.query.pin
+      pin: request.query.pin,
+      chunker: request.query['chunker']
     }
 
     const aborter = abortable()

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -157,4 +157,53 @@ describe('utils', () => {
       })
     })
   })
+
+  describe('parseChunkerString', () => {
+
+    it('handles an empty string', () => {
+      const options = utils.parseChunkerString("")
+      expect(options).to.have.property('chunker').to.equal("fixed")
+    })
+
+    it('handles a null chunker string', () => {
+      const options = utils.parseChunkerString(null)
+      expect(options).to.have.property('chunker').to.equal("fixed")
+    })
+
+    it('parses a fixed size string', () => {
+      const options = utils.parseChunkerString("size-512")
+      expect(options).to.have.property('chunker').to.equal("fixed")
+      expect(options)
+        .to.have.property('chunkerOptions')
+        .to.have.property('maxChunkSize')
+        .to.equal(512)
+    })
+
+    it('parses a rabin string without size', () => {
+      const options = utils.parseChunkerString("rabin")
+      expect(options).to.have.property('chunker').to.equal("rabin")
+      expect(options)
+        .to.have.property('chunkerOptions')
+        .to.have.property('avgChunkSize')
+    })
+
+    it('parses a rabin string with only avg size', () => {
+      const options = utils.parseChunkerString("rabin-512")
+      expect(options).to.have.property('chunker').to.equal("rabin")
+      expect(options)
+        .to.have.property('chunkerOptions')
+        .to.have.property('avgChunkSize')
+        .to.equal(512)
+    })
+
+    it('parses a rabin string with min, avg, and max', () => {
+      const options = utils.parseChunkerString("rabin-42-92-184")
+      expect(options).to.have.property('chunker').to.equal("rabin")
+      expect(options).to.have.property('chunkerOptions')
+      expect(options.chunkerOptions).to.have.property('minChunkSize').to.equal(42)
+      expect(options.chunkerOptions).to.have.property('avgChunkSize').to.equal(92)
+      expect(options.chunkerOptions).to.have.property('maxChunkSize').to.equal(184)
+    })
+
+  })
 })


### PR DESCRIPTION
Adds functionality to enable rabin chunking as described by ipfs/js-ipfs/issues/1283.

This mirrors the api defined by the go library, usage via command line as follows.
```bash
$ ./src/cli/bin.js add --chunker rabin-48-96-192 LICENSE
added QmZH1VRMjDD48A7uqzaEU6qdfk4ddNVKZLnBMN1Lc1iEic LICENSE
$ ./src/cli/bin.js object links QmZH1VRMjDD48A7uqzaEU6qdfk4ddNVKZLnBMN1Lc1iEic
QmamX3HDpMkE6NNun2pvz1UmBubA1nsuEzMEnBqUSVXy5E 180
QmdH3L1zu7hWu7nrpoCe33zfn3hDm6baYpTSENbRitpcFu 140
Qmaw7roFAKSj3V3QxmFUfpqU3dqAEMPMqHynqXxJmhhGhB 64
Qmewm77gB4V7cgnZLsuikXgrG8Q38M1TX8qPRBcKrw4yJ4 90
QmRd6EoLAyp6TXZmSRTByaAgEn5632J8u9NwFSiHfXurLx 95
QmeLhozoTP1z3RiLRBRUuLJ7xpmDh5oi1ShN91B4UPjRwA 172
QmdxhoXpK74gGbm2G8bAoCiuqDfbq44rN6RZKefCAFEhoZ 99
QmZNEhqU6uVjMc7p7xfqfwQK5YGxe1bdUNdG6Hq81149iw 139
Qmd1yFj2ZuNd28r5MaQaWkr3vcUwPF61i8oBdfRjaUC4V5 64
QmeJhcwipWbjXA5DdXVGe6Sh8kwBzADNnw3Zd3HKcPtPkm 82
Qme1G8Mk1PLThzCr11NzChQVy1FJoHCQkjK7rB2iTWKkaJ 58
```