### PR TITLE
fix: emit boot error only once

### DIFF
--- a/src/core/boot.js
+++ b/src/core/boot.js
@@ -30,7 +30,10 @@ module.exports = (self) => {
     (repoOpened, cb) => {
       // Init with existing initialized, opened, repo
       if (repoOpened) {
-        return self.init({ repo: self._repo }, (err) => cb(err))
+        return self.init({ repo: self._repo }, (err) => {
+          if (err) return cb(Object.assign(err, { emitted: true }))
+          cb()
+        })
       }
 
       if (doInit) {
@@ -38,7 +41,10 @@ module.exports = (self) => {
           { bits: 2048, pass: self._options.pass },
           typeof options.init === 'object' ? options.init : {}
         )
-        return self.init(initOptions, (err) => cb(err))
+        return self.init(initOptions, (err) => {
+          if (err) return cb(Object.assign(err, { emitted: true }))
+          cb()
+        })
       }
 
       cb()
@@ -48,11 +54,18 @@ module.exports = (self) => {
       if (!doStart) {
         return cb()
       }
-      self.start(cb)
+
+      self.start((err) => {
+        if (err) return cb(Object.assign(err, { emitted: true }))
+        cb()
+      })
     }
   ], (err) => {
     if (err) {
-      return self.emit('error', err)
+      if (!err.emitted) {
+        self.emit('error', err)
+      }
+      return
     }
     self.log('booted')
     self.emit('ready')

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -19,7 +19,7 @@ const IPFS = require('../../src/core')
 // This gets replaced by `create-repo-browser.js` in the browser
 const createTempRepo = require('../utils/create-repo-nodejs.js')
 
-describe('create node', function () {
+describe.only('create node', function () {
   it('custom repoPath', function (done) {
     this.timeout(80 * 1000)
 
@@ -123,7 +123,7 @@ describe('create node', function () {
     })
   })
 
-  it('init: false errors (start default: true)', function (done) {
+  it('init: false errors (start default: true) and errors only once', function (done) {
     this.timeout(80 * 1000)
 
     const node = new IPFS({
@@ -135,10 +135,24 @@ describe('create node', function () {
         }
       }
     })
-    node.once('error', (err) => {
-      expect(err).to.exist()
-      done()
-    })
+
+    const shouldHappenOnce = () => {
+      let timeoutId = null
+
+      return (err) => {
+        expect(err).to.exist()
+
+        // Bad news, this handler has been executed before
+        if (timeoutId) {
+          clearTimeout(timeoutId)
+          return done(new Error('error handler called multiple times'))
+        }
+
+        timeoutId = setTimeout(done, 100)
+      }
+    }
+
+    node.on('error', shouldHappenOnce())
   })
 
   it('init: false, start: false', function (done) {

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -19,7 +19,7 @@ const IPFS = require('../../src/core')
 // This gets replaced by `create-repo-browser.js` in the browser
 const createTempRepo = require('../utils/create-repo-nodejs.js')
 
-describe.only('create node', function () {
+describe('create node', function () {
   it('custom repoPath', function (done) {
     this.timeout(80 * 1000)
 


### PR DESCRIPTION
`init` and `start` both emit any error they encounter. `boot` will then receive that error and also emit it! This PR adds an `emitted` property in `boot` to errors that came from `init` or `start` so that later in the code it knows whether to emit it or not!