### PR TITLE
fix: enable tests in node that were not being included

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -109,7 +109,7 @@ const resolvePath = promisify(function (objectAPI, ipfsPaths, callback) {
       return cb(null, rootHash.buffer)
     }
 
-    objectAPI.get(rootHash, follow.bind(null, rootLinks))
+    objectAPI.get(rootHash.multihash, follow.bind(null, rootLinks))
 
     // recursively follow named links to the target node
     function follow (links, err, obj) {

--- a/test/core/node.js
+++ b/test/core/node.js
@@ -1,5 +1,8 @@
 'use strict'
 
+require('./circuit-relay')
+require('./key-exchange')
 require('./pin')
 require('./pin-set')
 // require('./key-exchange')
+require('./utils')


### PR DESCRIPTION
@vasco-santos uses `npm run test:node:core` which runs tests in `test/core/**/*.js` and there were some tests failing.

CI runs `npm test` => `npm test:node` => which runs only `mocha test/node.js`.

...which requires only:

```
require('./cli')
require('./http-api')
require('./gateway')
require('./core/node.js')
```

and core/node.js requires only

```
require('./pin')
require('./pin-set')
```

NOT `utils.js` and others!!!

Lets see if they pass.