### PR TITLE
fix: object.patch.rmLink not working

### DIFF
--- a/src/cli/commands/object/patch/rm-link.js
+++ b/src/cli/commands/object/patch/rm-link.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const DAGLink = require('ipld-dag-pb').DAGLink
 const debug = require('debug')
 const log = debug('cli:object')
 log.error = debug('cli:object:error')
@@ -14,12 +13,7 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    // TODO rmLink should support removing by name and/or multihash
-    // without having to know everything, which in fact it does, however,
-    // since it expectes a DAGLink type, we have to pass some fake size and
-    // hash.
-    const link = new DAGLink(argv.link, 1, 'Qm')
-    argv.ipfs.object.patch.rmLink(argv.root, link, {
+    argv.ipfs.object.patch.rmLink(argv.root, { name: argv.link }, {
       enc: 'base58'
     }, (err, node) => {
       if (err) {

--- a/src/http/api/resources/object.js
+++ b/src/http/api/resources/object.js
@@ -520,7 +520,7 @@ exports.patchRmLink = {
 
     if (!request.query.arg[1]) {
       return reply({
-        Message: 'cannot create link with no name!',
+        Message: 'cannot remove link with no name!',
         Code: 0
       }).code(500).takeover()
     }
@@ -545,11 +545,11 @@ exports.patchRmLink = {
     const link = request.pre.args.link
     const ipfs = request.server.app.ipfs
 
-    ipfs.object.patch.rmLink(root, link, (err, node) => {
+    ipfs.object.patch.rmLink(root, { name: link }, (err, node) => {
       if (err) {
         log.error(err)
         return reply({
-          Message: 'Failed to add link to object: ' + err,
+          Message: 'Failed to remove link from object: ' + err,
           Code: 0
         }).code(500)
       }


### PR DESCRIPTION
This PR contains fixes for the test failures that are happening in master for `object.patch.rmLink`