### PR TITLE
fix: stub out call to fetch for ipfs.dns test in browser

### DIFF
--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -1,11 +1,27 @@
-/* eslint-env mocha */
+/* eslint-env mocha, browser */
 'use strict'
 
 const tests = require('interface-ipfs-core')
 const CommonFactory = require('../utils/interface-common-factory')
 const isNode = require('detect-node')
+const dnsFetchStub = require('../utils/dns-fetch-stub')
 
 describe('interface-ipfs-core tests', () => {
+  // ipfs.dns in the browser calls out to https://ipfs.io/api/v0/dns.
+  // The following code stubs self.fetch to return a static CID for calls
+  // to https://ipfs.io/api/v0/dns?arg=ipfs.io.
+  if (!isNode) {
+    const fetch = self.fetch
+
+    before(() => {
+      self.fetch = dnsFetchStub()
+    })
+
+    after(() => {
+      self.fetch = fetch
+    })
+  }
+
   const defaultCommonFactory = CommonFactory.create()
 
   tests.bitswap(defaultCommonFactory, { skip: !isNode })

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -14,7 +14,7 @@ describe('interface-ipfs-core tests', () => {
     const fetch = self.fetch
 
     before(() => {
-      self.fetch = dnsFetchStub()
+      self.fetch = dnsFetchStub(fetch)
     })
 
     after(() => {

--- a/test/utils/dns-fetch-stub.js
+++ b/test/utils/dns-fetch-stub.js
@@ -1,9 +1,8 @@
-/* eslint-env browser */
 'use strict'
 
-const _fetch = typeof self === 'undefined' ? null : self.fetch
-
-module.exports = () => {
+// Create a fetch stub with a fall through to the provided fetch implementation
+// if the URL doesn't match https://ipfs.io/api/v0/dns?arg=ipfs.io.
+module.exports = (fetch) => {
   return function () {
     if (arguments[0].startsWith('https://ipfs.io/api/v0/dns?arg=ipfs.io')) {
       return Promise.resolve({
@@ -12,6 +11,6 @@ module.exports = () => {
         })
       })
     }
-    return _fetch.apply(this, arguments)
+    return fetch.apply(this, arguments)
   }
 }

--- a/test/utils/dns-fetch-stub.js
+++ b/test/utils/dns-fetch-stub.js
@@ -1,0 +1,17 @@
+/* eslint-env browser */
+'use strict'
+
+const _fetch = typeof self === 'undefined' ? null : self.fetch
+
+module.exports = () => {
+  return function () {
+    if (arguments[0].startsWith('https://ipfs.io/api/v0/dns?arg=ipfs.io')) {
+      return Promise.resolve({
+        json: () => Promise.resolve({
+          Path: '/ipfs/QmYNQJoKGNHTpPxCBPh9KkDpaExgd2duMa3aF6ytMpHdao'
+        })
+      })
+    }
+    return _fetch.apply(this, arguments)
+  }
+}


### PR DESCRIPTION
Stubs `self.fetch` to return a static CID for calls to `https://ipfs.io/api/v0/dns?arg=ipfs.io`.

Removes dependency on external service.