### PR TITLE
perf: faster startup

### DIFF
--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const HttpAPI = require('../../http')
 const utils = require('../utils')
 const print = utils.print
 
@@ -32,6 +31,9 @@ module.exports = {
     print('Initializing daemon...')
 
     const repoPath = utils.getRepoPath()
+
+    // Required inline to reduce startup time
+    const HttpAPI = require('../../http')
     httpAPI = new HttpAPI(process.env.IPFS_PATH, null, argv)
 
     httpAPI.start((err) => {

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const Repo = require('ipfs-repo')
-const IPFS = require('../../core')
 const utils = require('../utils')
 const print = utils.print
 
@@ -30,6 +28,10 @@ module.exports = {
     const path = utils.getRepoPath()
 
     print(`initializing ipfs node at ${path}`)
+
+    // Required inline to reduce startup time
+    const IPFS = require('../../core')
+    const Repo = require('ipfs-repo')
 
     const node = new IPFS({
       repo: new Repo(path),


### PR DESCRIPTION
# CLI daemon on (over HTTP API)

Command: `ipfs cat QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG`

For talking to the daemon over the HTTP API there should be no need to `require` IPFS core.

I noticed that the CLI `daemon` command required the HTTP API, which requires `Hapi`, and IPFS core itself. Similarly, the `init` command also requires IPFS core itself.

Moving these requires inline avoids this.

Before (> 1200ms total):

<img width="1392" alt="screen shot 2018-08-28 at 21 48 01" src="https://user-images.githubusercontent.com/152863/44751201-6dcfe380-ab0f-11e8-91a0-d03fc1862e0b.png">

After (< 600ms total):

<img width="1392" alt="screen shot 2018-08-28 at 21 48 04" src="https://user-images.githubusercontent.com/152863/44751244-9061fc80-ab0f-11e8-9a59-b67088914d43.png">
