### PR TITLE
chore: remove unused instance property

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -87,7 +87,6 @@ class IPFS extends EventEmitter {
     this._bitswap = undefined
     this._blockService = new BlockService(this._repo)
     this._ipld = new Ipld(this._blockService)
-    this._pubsub = undefined
     this._preload = preload(this)
     this._mfsPreload = mfsPreload(this)
     this._ipns = new IPNS(null, this)


### PR DESCRIPTION
The `_pubsub` property was added in [https://github.com/ipfs/js-ipfs/pull/749](https://github.com/ipfs/js-ipfs/pull/749). However, after several refactors it seems that it is not being used anymore.