### PR TITLE
fix: get started command

### DIFF
--- a/src/core/components/init-assets.js
+++ b/src/core/components/init-assets.js
@@ -26,7 +26,7 @@ module.exports = function addDefaultAssets (self, log, callback) {
       if (file.path === 'init-docs') {
         const cid = new CID(file.hash)
         log('to get started, enter:\n')
-        log(`\tjsipfs files cat /ipfs/${cid.toBaseEncodedString()}/readme\n`)
+        log(`\tjsipfs cat /ipfs/${cid.toBaseEncodedString()}/readme\n`)
       }
     }),
     pull.collect((err) => {


### PR DESCRIPTION
`ipfs files cat` does not exist (nor in go-ipfs), change to `ipfs cat`