### PR TITLE
fix: libp2p records for ipns should be signed

### DIFF
--- a/src/core/ipns/resolver.js
+++ b/src/core/ipns/resolver.js
@@ -133,13 +133,20 @@ class IpnsResolver {
           return callback(err)
         }
 
-        // Record validation
-        ipns.validate(pubKey, ipnsEntry, (err) => {
+        // libp2p record signature validation
+        record.verifySignature(pubKey, (err) => {
           if (err) {
             return callback(err)
           }
 
-          callback(null, ipnsEntry.value.toString())
+          // IPNS entry validation
+          ipns.validate(pubKey, ipnsEntry, (err) => {
+            if (err) {
+              return callback(err)
+            }
+
+            callback(null, ipnsEntry.value.toString())
+          })
         })
       })
     })


### PR DESCRIPTION
There are two types of IPNS records. IPNS records for being stored locally and IPNS records for being used in the network.

IPNS records for being stored locally are used for understanding which is the most recent record since it is stored by the peer who published it.

IPNS records for being used in the network, are used as a common [libp2p-record](https://github.com/libp2p/js-libp2p-record) and are intended to be used with the DHT and Pubsub.

This way, the `libp2p-record` should have a signature and that signature should be validated on the resolve, in order to guarantee that the record was not changed in the network. 

NOTE: The current implementation guarantees that the `IPNS Record` is not changed, since it has its own signature, but the `libp2p-record` used must be used as a generic `libp2p-record`, with its own signature as well.