### PR TITLE
fix: ipns publish resolve option overwritten

### DIFF
--- a/src/cli/commands/name/publish.js
+++ b/src/cli/commands/name/publish.js
@@ -9,6 +9,7 @@ module.exports = {
 
   builder: {
     resolve: {
+      alias: 'r',
       describe: 'Resolve given path before publishing. Default: true.',
       default: true
     },
@@ -29,8 +30,16 @@ module.exports = {
   },
 
   handler (argv) {
+    // yargs-promise adds resolve/reject properties to argv
+    // resolve should use the alias as resolve will always be overwritten to a function
+    let resolve = true
+
+    if (argv.r === false || argv.r === 'false') {
+      resolve = false
+    }
+
     const opts = {
-      resolve: argv.resolve,
+      resolve,
       lifetime: argv.lifetime,
       key: argv.key,
       ttl: argv.ttl


### PR DESCRIPTION
`yargs-promise` [adds](https://github.com/eddywashere/yargs-promise/blob/master/index.js#L14) resolve/reject properties to `argv`. 

This way, `resolve` option was being overwritten to a function and, as it was not `false`, it was defined always as true for the `publish` operation.

Publish should use the `r` alias instead, as resolve will always be overwritten to a function.