### PR TITLE
fix: revert libp2p records being signed for ipns

### DIFF
--- a/src/core/ipns/resolver.js
+++ b/src/core/ipns/resolver.js
@@ -133,20 +133,13 @@ class IpnsResolver {
           return callback(err)
         }
 
-        // libp2p record signature validation
-        record.verifySignature(pubKey, (err) => {
+        // IPNS entry validation
+        ipns.validate(pubKey, ipnsEntry, (err) => {
           if (err) {
             return callback(err)
           }
 
-          // IPNS entry validation
-          ipns.validate(pubKey, ipnsEntry, (err) => {
-            if (err) {
-              return callback(err)
-            }
-
-            callback(null, ipnsEntry.value.toString())
-          })
+          callback(null, ipnsEntry.value.toString())
         })
       })
     })


### PR DESCRIPTION
The [js-ipfs#1543](https://github.com/ipfs/js-ipfs/pull/1543) broke the interop tests for `IPNS` on [interop#26](https://github.com/ipfs/interop/pull/26).

The [js-ipfs#1543](https://github.com/ipfs/js-ipfs/pull/1543) was added after my analysis for the implementation of `IPNS over Pubsub`, as I wanted to have exactly the same behavior and interface as the DHT, in order to have an easy to plug DHT afterward. Accordingly:

**DHT PUT**:
[js-libp2p-kad-dht/index.js#L166](https://github.com/libp2p/js-libp2p-kad-dht/blob/master/src/index.js#L166)
[js-libp2p-kad-dht/utils.js#L150](https://github.com/libp2p/js-libp2p-kad-dht/blob/master/src/utils.js#L150)

So, I wanted to make this logic available to Pubsub / local and it is all good in JS land. However,`go-ipfs` does not do that:

[go-ipfs/namesys/publisher.go#L278](https://github.com/ipfs/go-ipfs/blob/master/namesys/publisher.go#L278)
[go-libp2p-kad-dht/dht.go#L149](https://github.com/libp2p/go-libp2p-kad-dht/blob/master/dht.go#L149)

And this causes and **interop problem**!

At **first**, different protobuf definitions:
[go-libp2p-record/record.proto](https://github.com/libp2p/go-libp2p-record/blob/master/pb/record.proto)
[js-libp2p-record/record.proto.js](https://github.com/libp2p/js-libp2p-record/blob/master/src/record.proto.js)

So, when we publish using a GO node, followed by a JS node resolve, the `resolve` will try to validate the record, but it will break [js-libp2p-record/record.js#L42](https://github.com/libp2p/js-libp2p-record/blob/master/src/record.js#L42)

There is no author, and trying to get ID is :boom: Other than that, the interop is fine. I believe that, as the `IPNS` record is signed inside the `libp2p-record`, it is not bad to have it not signed. It would be better to have it signed, but we can handle this together with `DHT Interop`.

**Other note:** This can be one of many problems regarding DHT interop, and I will look deeper on that later.