### PR TITLE
Add way to run a subset of the interface tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,9 @@ Listing of the main packages used in the IPFS ecosystem. There are also three sp
 
 # run just IPFS core tests in the Browser (Chrome)
 > npm run test:browser
+
+# run some interface tests (block API) on Node.js
+> npm run test:node:interface -- --grep '.block'
 ```
 
 ### Run interop tests

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ Listing of the main packages used in the IPFS ecosystem. There are also three sp
 ### Run tests
 
 ```sh
-# run all the unit tsts
+# run all the unit tests
 > npm test
 
 # run just IPFS tests in Node.js

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:node:http": "aegir test -t node -f test/http-api/index.js --timeout=10000",
     "test:node:gateway": "aegir test -t node -f test/gateway/index.js --timeout=10000",
     "test:node:cli": "aegir test -t node -f test/cli/index.js --timeout=10000",
+    "test:node:interface": "aegir test -t node -f test/core/interface.spec.js --timeout=10000",
     "test:bootstrapers": "IPFS_TEST=bootstrapers aegir test -t browser -f test/bootstrapers.js --timeout=10000",
     "benchmark": "echo \"Error: no benchmarks yet\" && exit 1",
     "benchmark:node": "echo \"Error: no benchmarks yet\" && exit 1",


### PR DESCRIPTION
It was already possible, but now it's documented an a bit simplified.

Thanks @jacobheun for explaining me how the `grep` functionality works.