### PR TITLE
fix: fix `block rm` command

### DIFF
--- a/src/cli/commands/block/rm.js
+++ b/src/cli/commands/block/rm.js
@@ -17,7 +17,7 @@ module.exports = {
       throw new Error('rm block with daemon running is not yet implemented')
     }
 
-    argv.ipfs.block.del(mh.fromB58String(argv.key), (err) => {
+    argv.ipfs.block.rm(mh.fromB58String(argv.key), (err) => {
       if (err) {
         throw err
       }


### PR DESCRIPTION
On the command line `block rm` failed.

Sadly the test can't be enabled yet, as the HTTP API doesn't implement it yet.