### PR TITLE
fix: coerce key gen size to number in CLI

### DIFF
--- a/src/cli/commands/key/gen.js
+++ b/src/cli/commands/key/gen.js
@@ -16,7 +16,8 @@ module.exports = {
     size: {
       alias: 's',
       describe: 'size of the key to generate.',
-      default: '2048'
+      default: '2048',
+      type: 'number'
     }
   },
 

--- a/src/cli/commands/key/gen.js
+++ b/src/cli/commands/key/gen.js
@@ -16,7 +16,7 @@ module.exports = {
     size: {
       alias: 's',
       describe: 'size of the key to generate.',
-      default: '2048',
+      default: 2048,
       type: 'number'
     }
   },

--- a/src/http/api/resources/key.js
+++ b/src/http/api/resources/key.js
@@ -64,7 +64,7 @@ exports.gen = (request, reply) => {
   const ipfs = request.server.app.ipfs
   const name = request.query.arg
   const type = request.query.type
-  const size = request.query.size
+  const size = parseInt(request.query.size)
   ipfs._keychain.createKey(name, type, size, (err, key) => {
     if (err) {
       return applyError(reply, err)


### PR DESCRIPTION
Keychain params are now validated properly and has caused these test to fail https://github.com/libp2p/js-libp2p-keychain/pull/26