### PR TITLE
Clarify preload behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Configure circuit relay (see the [circuit relay tutorial](https://github.com/ipf
 |------|---------|
 | object | `{ enabled: true, addresses: [...] }` |
 
-Configure external nodes that will preload content added to this node.
+Configure remote preload nodes. The remote will preload content added on this node, and also attempt to preload objects requested by this node.
 
 - `enabled` (boolean): Enable content preloading (Default: `true`)
 - `addresses` (array): Multiaddr API addresses of nodes that should preload content. **NOTE:** nodes specified here should also be added to your node's bootstrap address list at [`config.Boostrap`](#optionsconfig).


### PR DESCRIPTION
Preload is confusing because it happens on both add and get, and because it isn't documented anywhere in depth. This clarifies what happens a bit. We should also write out the behavior in more detail like with circuit relay above (possibly in the form of a tutorial for setting up your own preload node)

see also https://github.com/ipfs/js-ipfs/issues/1459#issuecomment-422079307