### PR TITLE
fix: report correct size for raw dag nodes

### DIFF
--- a/src/core/components/files.js
+++ b/src/core/components/files.js
@@ -40,10 +40,16 @@ function prepareFile (self, opts, file, callback) {
     (node, cb) => {
       const b58Hash = cid.toBaseEncodedString()
 
+      let size = node.size
+
+      if (Buffer.isBuffer(node)) {
+        size = node.length
+      }
+
       cb(null, {
         path: opts.wrapWithDirectory ? file.path.substring(WRAPPER.length) : (file.path || b58Hash),
         hash: b58Hash,
-        size: node.size
+        size
       })
     }
   ], callback)

--- a/test/core/files.spec.js
+++ b/test/core/files.spec.js
@@ -83,5 +83,30 @@ describe('files', () => {
         done()
       })
     })
+
+    it('should add a file with a v1 CID', (done) => {
+      ipfs.files.add(Buffer.from([0, 1, 2]), {
+        cidVersion: 1
+      }, (err, files) => {
+        expect(err).to.not.exist()
+        expect(files.length).to.equal(1)
+        expect(files[0].hash).to.equal('zb2rhiNedvrkpYhcrgtpmhKk5UPzcgizgSXaQLYXNY745BmYP')
+        expect(files[0].size).to.equal(3)
+        done()
+      })
+    })
+
+    it('should add a file with a v1 CID and not raw leaves', (done) => {
+      ipfs.files.add(Buffer.from([0, 1, 2]), {
+        cidVersion: 1,
+        rawLeaves: false
+      }, (err, files) => {
+        expect(err).to.not.exist()
+        expect(files.length).to.equal(1)
+        expect(files[0].hash).to.equal('zdj7WcDSFNSsZkdkbpSDGeLsBtHbYKyvPQsaw6PpeeYdGqoAx')
+        expect(files[0].size).to.equal(11)
+        done()
+      })
+    })
   })
 })

--- a/test/http-api/files.js
+++ b/test/http-api/files.js
@@ -26,7 +26,14 @@ describe('.files', () => {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after(function (done) {
+    this.timeout(20 * 1000)
+    if (ipfsd) {
+      ipfsd.stop(done)
+    } else {
+      done()
+    }
+  })
 
   describe('.add', function () {
     it('performs a speculative add, --only-hash', () => {


### PR DESCRIPTION
If you specify `cidVersion: 0`, for go compatibility you will have raw leaf nodes. If your data fits in one dag node, the root node will be a raw node for the same reason, and `ipfs.object.get` will return a buffer.

This PR inspects the returned node to see if it's a buffer, if it is, use the `length` property, otherwise use the DAGNode `size` property.

Fixes #1585