### PR TITLE
feat: show Web UI url in daemon output

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "form-data": "^2.3.2",
     "hat": "0.0.3",
     "interface-ipfs-core": "~0.78.0",
-    "ipfsd-ctl": "~0.39.1",
+    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#fix/cli-scraping",
     "mocha": "^5.2.0",
     "ncp": "^2.0.0",
     "nexpect": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "form-data": "^2.3.2",
     "hat": "0.0.3",
     "interface-ipfs-core": "~0.78.0",
-    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#fix/cli-scraping",
+    "ipfsd-ctl": "~0.39.3",
     "mocha": "^5.2.0",
     "ncp": "^2.0.0",
     "nexpect": "~0.5.0",

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -28,7 +28,7 @@ module.exports = {
   },
 
   handler (argv) {
-    print('Initializing daemon...')
+    print('Initializing IPFS daemon...')
 
     const repoPath = utils.getRepoPath()
 

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -155,8 +155,9 @@ function HttpApi (repo, config, cliArgs) {
         api.info.ma = uriToMultiaddr(api.info.uri)
         gateway.info.ma = uriToMultiaddr(gateway.info.uri)
 
-        console.log('API is listening on: %s', api.info.ma)
-        console.log('Gateway (readonly) is listening on: %s', gateway.info.ma)
+        console.log('API listening on %s', api.info.ma)
+        console.log('Gateway (read only) listening on %s', gateway.info.ma)
+        console.log('Web UI available at %s', api.info.uri + '/webui')
 
         // for the CLI to know the where abouts of the API
         this.node._repo.apiAddr.set(api.info.ma, cb)


### PR DESCRIPTION
- make it easier for people to discover the Web UI
- tidy up inconsistencies across the log lines
- add IPFS to the first line. confirm to new users they started what they expected to.

fixes https://github.com/ipfs-shipyard/ipfs-webui/issues/815

**Before**
```console
$ jsipfs daemon
Initializing daemon...
Swarm listening on /ip4/127.0.0.1/tcp/4003/ws/ipfs/QmPmrqh4ybdUJwGchEecuj2GBXCxKL5iapW9qmk8pwgCGs
Swarm listening on /ip4/127.0.0.1/tcp/4002/ipfs/QmPmrqh4ybdUJwGchEecuj2GBXCxKL5iapW9qmk8pwgCGs
Swarm listening on /ip4/192.168.1.244/tcp/4002/ipfs/QmPmrqh4ybdUJwGchEecuj2GBXCxKL5iapW9qmk8pwgCGs
API is listening on: /ip4/127.0.0.1/tcp/5002
Gateway (readonly) is listening on: /ip4/127.0.0.1/tcp/9090
Daemon is ready
```

**After**
```console
$ node src/cli/bin.js daemon
Initializing IPFS daemon...
Swarm listening on /ip4/127.0.0.1/tcp/4003/ws/ipfs/QmPmrqh4ybdUJwGchEecuj2GBXCxKL5iapW9qmk8pwgCGs
Swarm listening on /ip4/127.0.0.1/tcp/4002/ipfs/QmPmrqh4ybdUJwGchEecuj2GBXCxKL5iapW9qmk8pwgCGs
Swarm listening on /ip4/192.168.1.244/tcp/4002/ipfs/QmPmrqh4ybdUJwGchEecuj2GBXCxKL5iapW9qmk8pwgCGs
API listening on /ip4/127.0.0.1/tcp/5002
Gateway (read only) listening on /ip4/127.0.0.1/tcp/9090
Web UI available at http://127.0.0.1:5002/webui
Daemon is ready
```
- Announces the Web UI 🎉
- No colons, simply siding with what most of the log lines do currently
- Use "listening on" consistently rather than "**is** listening on"
- Use "read only" not "readonly"
- Initializing **IPFS** daemon... to confirm to the user they started the thing they expected.

I'd keep the "Daemon is ready" copy the same though as it's the kind of output that people might be scraping from scripts to check that it started without error, and changing it would frustrate.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>