### PR TITLE
fix: use class is function on ipns

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "once": "^1.4.0",
     "path-exists": "^3.0.0",
     "peer-book": "~0.8.0",
-    "peer-id": "~0.11.0",
+    "peer-id": "~0.12.0",
     "peer-info": "~0.14.1",
     "progress": "^2.0.0",
     "promisify-es6": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ipld": "~0.17.3",
     "ipld-dag-cbor": "~0.12.1",
     "ipld-dag-pb": "~0.14.6",
-    "ipns": "~0.2.0",
+    "ipns": "~0.3.0",
     "is-ipfs": "~0.4.2",
     "is-pull-stream": "~0.0.0",
     "is-stream": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "hapi-set-header": "^1.0.2",
     "hoek": "^5.0.3",
     "human-to-milliseconds": "^1.0.0",
-    "interface-datastore": "~0.5.0",
+    "interface-datastore": "~0.6.0",
     "ipfs-api": "^24.0.0",
     "ipfs-bitswap": "~0.20.3",
     "ipfs-block": "~0.7.1",

--- a/src/core/ipns/publisher.js
+++ b/src/core/ipns/publisher.js
@@ -51,7 +51,7 @@ class IpnsPublisher {
   }
 
   _putRecordToRouting (record, peerId, callback) {
-    if (!(peerId instanceof PeerId)) {
+    if (!(PeerId.isPeerId(peerId))) {
       const errMsg = `peerId received is not valid`
 
       log.error(errMsg)
@@ -90,7 +90,7 @@ class IpnsPublisher {
   }
 
   _publishEntry (key, entry, peerId, callback) {
-    if (!(key instanceof Key)) {
+    if (!(Key.isKey(key))) {
       const errMsg = `datastore key does not have a valid format`
 
       log.error(errMsg)
@@ -123,7 +123,7 @@ class IpnsPublisher {
   }
 
   _publishPublicKey (key, publicKey, peerId, callback) {
-    if (!(key instanceof Key)) {
+    if ((!Key.isKey(key))) {
       const errMsg = `datastore key does not have a valid format`
 
       log.error(errMsg)
@@ -163,7 +163,7 @@ class IpnsPublisher {
   // Returns the record this node has published corresponding to the given peer ID.
   // If `checkRouting` is true and we have no existing record, this method will check the routing system for any existing records.
   _getPublished (peerId, options, callback) {
-    if (!(peerId instanceof PeerId)) {
+    if (!(PeerId.isPeerId(peerId))) {
       const errMsg = `peerId received is not valid`
 
       log.error(errMsg)
@@ -216,7 +216,7 @@ class IpnsPublisher {
   }
 
   _updateOrCreateRecord (privKey, value, validity, peerId, callback) {
-    if (!(peerId instanceof PeerId)) {
+    if (!(PeerId.isPeerId(peerId))) {
       const errMsg = `peerId received is not valid`
 
       log.error(errMsg)

--- a/src/core/ipns/republisher.js
+++ b/src/core/ipns/republisher.js
@@ -151,7 +151,7 @@ class IpnsRepublisher {
   }
 
   _getPreviousValue (peerId, callback) {
-    if (!(peerId instanceof PeerId)) {
+    if (!(PeerId.isPeerId(peerId))) {
       const errMsg = `peerId received is not valid`
 
       log.error(errMsg)


### PR DESCRIPTION
As `instance of` fails using different versions of a module, it was changed to use `class-is`.

Needs:

- [x] [js-peer-id#84](https://github.com/libp2p/js-peer-id/pull/84)
- [x] [interface-datastore#24](https://github.com/ipfs/interface-datastore/pull/24)

Fixes #1615 