### PR TITLE
chore: remove ipld-dag-cbor dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "ipfs-unixfs": "~0.1.15",
     "ipfs-unixfs-engine": "~0.32.3",
     "ipld": "~0.17.3",
-    "ipld-dag-cbor": "~0.12.1",
     "ipld-dag-pb": "~0.14.6",
     "ipns": "~0.2.0",
     "is-ipfs": "~0.4.2",

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -4,7 +4,6 @@ const BlockService = require('ipfs-block-service')
 const Ipld = require('ipld')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const dagCBOR = require('ipld-dag-cbor')
 const dagPB = require('ipld-dag-pb')
 const crypto = require('libp2p-crypto')
 const isIPFS = require('is-ipfs')
@@ -75,8 +74,7 @@ class IPFS extends EventEmitter {
       multibase: multibase,
       multihash: multihash,
       CID: CID,
-      dagPB: dagPB,
-      dagCBOR: dagCBOR
+      dagPB: dagPB
     }
 
     // IPFS Core Internals

--- a/test/core/init.spec.js
+++ b/test/core/init.spec.js
@@ -10,7 +10,6 @@ const isNode = require('detect-node')
 const hat = require('hat')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const dagCBOR = require('ipld-dag-cbor')
 const dagPB = require('ipld-dag-pb')
 const crypto = require('libp2p-crypto')
 const isIPFS = require('is-ipfs')
@@ -123,8 +122,7 @@ describe('init', () => {
       multibase: multibase,
       multihash: multihash,
       CID: CID,
-      dagPB: dagPB,
-      dagCBOR: dagCBOR
+      dagPB: dagPB
     })
   })
 


### PR DESCRIPTION
The `ipld-dag-cbor` module isn't used anywhere, hence remove it
as a direct dependency.