### PR TITLE
fix: datastore not found error on ipns publish

### DIFF
--- a/src/core/ipns/publisher.js
+++ b/src/core/ipns/publisher.js
@@ -177,7 +177,7 @@ class IpnsPublisher {
       let result
 
       if (err) {
-        if (err.code !== 'ERR_NOT_FOUND') {
+        if (err.code !== 'ERR_NOT_FOUND' && !err.notFound) {
           const errMsg = `unexpected error getting the ipns record ${peerId.id} from datastore`
 
           log.error(errMsg)


### PR DESCRIPTION
Check for both error types when hitting a `datastore` not found error.

Closes #1620 