### PR TITLE
chore: remove ipld formats re-export

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "ipfs-unixfs": "~0.1.15",
     "ipfs-unixfs-engine": "~0.32.3",
     "ipld": "~0.17.3",
-    "ipld-dag-cbor": "~0.12.1",
     "ipld-dag-pb": "~0.14.6",
     "ipns": "~0.2.0",
     "is-ipfs": "~0.4.2",

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -4,8 +4,6 @@ const BlockService = require('ipfs-block-service')
 const Ipld = require('ipld')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const dagCBOR = require('ipld-dag-cbor')
-const dagPB = require('ipld-dag-pb')
 const crypto = require('libp2p-crypto')
 const isIPFS = require('is-ipfs')
 const multiaddr = require('multiaddr')
@@ -74,9 +72,7 @@ class IPFS extends EventEmitter {
       multiaddr: multiaddr,
       multibase: multibase,
       multihash: multihash,
-      CID: CID,
-      dagPB: dagPB,
-      dagCBOR: dagCBOR
+      CID: CID
     }
 
     // IPFS Core Internals

--- a/test/core/init.spec.js
+++ b/test/core/init.spec.js
@@ -10,8 +10,6 @@ const isNode = require('detect-node')
 const hat = require('hat')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const dagCBOR = require('ipld-dag-cbor')
-const dagPB = require('ipld-dag-pb')
 const crypto = require('libp2p-crypto')
 const isIPFS = require('is-ipfs')
 const multiaddr = require('multiaddr')
@@ -122,9 +120,7 @@ describe('init', () => {
       multiaddr: multiaddr,
       multibase: multibase,
       multihash: multihash,
-      CID: CID,
-      dagPB: dagPB,
-      dagCBOR: dagCBOR
+      CID: CID
     })
   })
 


### PR DESCRIPTION
Prior to this caange the `ipld-dag-cbor` and `ipld-dag-pb` modules
are re-exported so that can be accessed within the Browser bundle.
Those modules normally don't need to be used directly, they are
kind of implementation details of IPLD. Hence remove them.

Now `ipld-dag-cbor` isn't a direct dependency of `jsipfs` anymore.

BREAKING CHANGE: remove `types.dagCBOR` and `dag.dagPB` from public API