### PR TITLE
fix: make ipfs.ping() options optional

### DIFF
--- a/src/core/components/ping.js
+++ b/src/core/components/ping.js
@@ -5,6 +5,11 @@ const pull = require('pull-stream/pull')
 
 module.exports = function ping (self) {
   return promisify((peerId, opts, cb) => {
+    if (typeof opts === 'function') {
+      cb = opts
+      opts = {}
+    }
+
     pull(
       self.pingPullStream(peerId, opts),
       pull.collect(cb)


### PR DESCRIPTION
Without this PR:

```console
$ npm test

...*snip*

     Uncaught TypeError: Cannot read property 'push' of null
      at /Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/pull-stream/sinks/collect.js:7:9
      at /Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/pull-stream/sinks/reduce.js:8:11
      at /Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/pull-stream/sinks/drain.js:24:37
      at callback (/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/pull-pushable/index.js:84:5)
      at Function.push (/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/pull-pushable/index.js:44:7)
      at libp2pNode.ping (src/core/components/ping-pull-stream.js:79:18)
      at _getPeerInfo (/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/libp2p/src/index.js:339:7)
      at setImmediate (/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/libp2p/src/get-peer-info.js:54:24)
      at Immediate.<anonymous> (/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/async/internal/setImmediate.js:27:16)
```

Looks like the same as the second error stack trace posted in #1616