### PR TITLE
refactor: remove maxBytes restriction

### DIFF
--- a/src/http/api/routes/files.js
+++ b/src/http/api/routes/files.js
@@ -37,7 +37,8 @@ module.exports = (server) => {
     config: {
       payload: {
         parse: false,
-        output: 'stream'
+        output: 'stream',
+        maxBytes: Number.MAX_SAFE_INTEGER
       },
       handler: resources.files.add.handler,
       validate: resources.files.add.validate

--- a/test/http-api/inject/pin.js
+++ b/test/http-api/inject/pin.js
@@ -135,7 +135,7 @@ module.exports = (http) => {
           url: '/api/v0/pin/ls'
         }, (res) => {
           expect(res.statusCode).to.equal(200)
-          expect(res.result.Keys).to.have.all.keys(Object.values(pins))
+          expect(res.result.Keys).to.include.all.keys(Object.values(pins))
           done()
         })
       })
@@ -158,14 +158,10 @@ module.exports = (http) => {
           url: `/api/v0/pin/ls?type=recursive`
         }, (res) => {
           expect(res.statusCode).to.equal(200)
-          expect(res.result.Keys).to.deep.eql({
-            QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn: {
-              Type: 'recursive'
-            },
-            QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVzxTt3qVe: {
-              Type: 'recursive'
-            }
-          })
+          expect(res.result.Keys['QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'])
+            .to.deep.eql({ Type: 'recursive' })
+          expect(res.result.Keys['QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVzxTt3qVe'])
+            .to.deep.eql({ Type: 'recursive' })
           done()
         })
       })


### PR DESCRIPTION
Weirdly we're not seeing this when using Node.js - it only happens in the browser.

My _guess_ is that [`maxBytes`](https://github.com/hapijs/hapi/blob/1c9a4f3d7c8cd583650292f4284c87ac5b935107/API.md#-routeoptionspayloadmaxbytes) is actually the max bytes allowed for a given chunk and that in Node.js the underlying stream implementation chunks up the chunks you pass to it even if you only write a single huge chunk. In the browser we know that `stream-http` buffers up all the data and sends it in one go so perhaps that is what is happening.

Anyway, the test in the PR using `inject` proves that with a single buffer we can get a `413` (payload too large) for any request over 1024 * 1024 bytes.

This is feature compatible with go-ipfs which has no such limit.

fixes #1638
refs https://github.com/ipfs-shipyard/ipfs-webui/issues/858