### PR TITLE
chore: upgrade libp2p record version

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "libp2p-keychain": "~0.3.1",
     "libp2p-mdns": "~0.12.0",
     "libp2p-mplex": "~0.8.0",
-    "libp2p-record": "~0.5.1",
+    "libp2p-record": "~0.6.0",
     "libp2p-secio": "~0.10.0",
     "libp2p-tcp": "~0.12.0",
     "libp2p-webrtc-star": "~0.15.3",

--- a/src/core/ipns/publisher.js
+++ b/src/core/ipns/publisher.js
@@ -102,7 +102,7 @@ class IpnsPublisher {
       // Marshal record
       const entryData = ipns.marshal(entry)
       // Marshal to libp2p record
-      rec = new Record(key.toBuffer(), entryData, peerId)
+      rec = new Record(key.toBuffer(), entryData)
     } catch (err) {
       log.error(err)
       return callback(err)
@@ -140,7 +140,7 @@ class IpnsPublisher {
     let rec
     try {
       // Marshal to libp2p record
-      rec = new Record(key.toBuffer(), publicKey.bytes, peerId)
+      rec = new Record(key.toBuffer(), publicKey.bytes)
     } catch (err) {
       log.error(err)
       return callback(err)


### PR DESCRIPTION
The `libp2p-record` module was updated to interop with `go-libp2p-record`.  As a result, the author and signature were removed, as well as all the logic inherent to the signature.

More info [js-libp2p-record#8](https://github.com/libp2p/js-libp2p-record/pull/8)