### PR TITLE
fix: correct output in webpack example

### DIFF
--- a/examples/browser-webpack/src/components/app.js
+++ b/examples/browser-webpack/src/components/app.js
@@ -53,7 +53,7 @@ class App extends React.Component {
 
         node.files.cat(hash, (err, data) => {
           if (err) { throw err }
-          self.setState({added_file_contents: data})
+          self.setState({added_file_contents: data.toString()})
         })
       })
     }


### PR DESCRIPTION
The webpack example printed out the contents of the file in hex
(`1041011081081113211911111410810032102114111109321191019811297991071011003273807083`)
instead of a properly formated string (`hello world from webpacked IPFS`).