### PR TITLE
feat: add support to pass config in the init cmd

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -4,13 +4,15 @@ const utils = require('../utils')
 const print = utils.print
 
 module.exports = {
-  command: 'init',
-
+  command: 'init [config] [options]',
   describe: 'Initialize a local IPFS node',
-
   builder (yargs) {
     return yargs
       .epilog(utils.ipfsPathHelp)
+      .positional('config', {
+        describe: 'Node config, this should JSON and will be merged with the default config. Check https://github.com/ipfs/js-ipfs#optionsconfig',
+        type: 'string'
+      })
       .option('bits', {
         type: 'number',
         alias: 'b',
@@ -41,7 +43,8 @@ module.exports = {
     const node = new IPFS({
       repo: new Repo(path),
       init: false,
-      start: false
+      start: false,
+      config: argv.config
     })
 
     node.init({

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -4,6 +4,7 @@ const peerId = require('peer-id')
 const waterfall = require('async/waterfall')
 const parallel = require('async/parallel')
 const promisify = require('promisify-es6')
+const extend = require('deep-extend')
 const defaultConfig = require('../runtime/config-nodejs.js')
 const Keychain = require('libp2p-keychain')
 
@@ -50,7 +51,8 @@ module.exports = function init (self) {
     opts.emptyRepo = opts.emptyRepo || false
     opts.bits = Number(opts.bits) || 2048
     opts.log = opts.log || function () {}
-    const config = defaultConfig()
+
+    const config = extend(defaultConfig(), self._options.config)
     let privateKey
 
     waterfall([

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -4,7 +4,7 @@ const peerId = require('peer-id')
 const waterfall = require('async/waterfall')
 const parallel = require('async/parallel')
 const promisify = require('promisify-es6')
-const extend = require('deep-extend')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 const defaultConfig = require('../runtime/config-nodejs.js')
 const Keychain = require('libp2p-keychain')
 
@@ -52,7 +52,7 @@ module.exports = function init (self) {
     opts.bits = Number(opts.bits) || 2048
     opts.log = opts.log || function () {}
 
-    const config = extend(defaultConfig(), self._options.config)
+    const config = defaultsDeep(self._options.config, defaultConfig())
     let privateKey
 
     waterfall([


### PR DESCRIPTION
This PR adds support to pass node config in the init cmd. The main purpose for this is to improve the speed of ipfsd-ctl and all the tests that use ctl.

example: `ipfs init '{"Addresses":{"Swarm":["/ip4/0.0.0.0/tcp/4003"]}}'`
This merges the input config with the default config, just like the node api already does.

Check ipfsd-ctl PR related to this one for speed improvements https://github.com/ipfs/js-ipfsd-ctl/pull/303

Right now we need to spawn 4 child_processes to start a node in ctl
- ipfs init
- ipfs config show
- ipfs config replace
- ipfs daemon

With this PR we would only need 2
- ipfs init <condig>
- ipfs daemon

And with further changes we could do `ipfs daemon --init --config "{}"`

Right now i think we have a couple of problems with this
- go ipfs init needs the config to be in a file and needs it to be a full config, no merging 
- other config changing cmds only do replacing no merging

Questions: 
- How can we get the Go default config to manually do the merging? 
- Can we get Go to do merging? 
- Can we do this change in js without Go supporting it?
- Shouldn't we have a `ipfs config merge` ?

Go version works like this https://docs.ipfs.io/reference/api/cli/#ipfs-init