### PR TITLE
[WIP] feat: Try out CircleCI's new infrastructure for test & release flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,175 @@
+version: 2
+
+aliases:
+  - &github_auth: |
+    export GH_RELEASE_GITHUB_API_TOKEN=$GITHUB_TOKEN
+    git remote add upstream https://$USER:$GITHUB_TOKEN@github.com/$USER/$CI_PROJECT_NAME.git
+    git config --global user.email $EMAIL
+    git config --global user.name $USER
+    git checkout $CI_COMMIT_REF_NAME
+    git fetch upstream
+    git branch -u upstream/$CI_COMMIT_REF_NAME
+    echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+
+jobs:
+  check:
+    docker:
+      - image: node:10
+    steps:
+      - checkout
+      - run: npm run lint
+      - store_artifacts:
+          path: dist/
+
+  build_macos:
+    macos:
+      xcode: "10.0.0"
+    steps:
+      - checkout
+      - run: npm run build
+      - store_artifacts:
+          path: dist/
+
+  build_linux:
+    docker:
+      - image: node:10
+    steps:
+      - checkout
+      - run: npm run build
+      - store_artifacts:
+          path: dist/
+
+  test-node-8:
+    docker:
+      - image: node:8
+    steps:
+      - checkout
+      - run: npx nyc -s npm run test:node
+      - save_cache:
+          key: ipfs-{{ .BuildNum }}
+          paths:
+            - .nyc_output/
+
+  test-node-10:
+    docker:
+      - image: node:10
+    steps:
+      - checkout
+      - run: npx nyc -s npm run test:node
+      - save_cache:
+          key: ipfs-{{ .BuildNum }}
+          paths:
+            - .nyc_output/
+
+  test-browser-chrome:
+    docker:
+      - image: hugomrdias/node-chrome:test]
+    steps:
+      - checkout
+      - run: AEGIR_BROWSERS=ChromeDocker npm run test:browser
+      - store_artifacts:
+          path: coverage/
+
+  test-browser-firefox:
+    docker:
+      - image: hugomrdias/node-firefox:test
+    steps:
+      - checkout
+      - run: AEGIR_BROWSERS=FirefoxHeadless npm run test:browser
+      - store_artifacts:
+          path: coverage/
+
+  cov:
+    docker:
+      - image: node:10-alpine
+    steps:
+      - checkout
+      - run: |
+          cp coverage/coverage-final.json .nyc_output/browser.json
+          npx nyc report --reporter text-summary --reporter html
+      - store_artifacts:
+          path: coverage/
+
+  pre-release:
+    docker:
+      - image: hugomrdias/node-alpine:test
+    steps:
+      - run: |
+          *github_auth
+          npm --no-git-tag-version version prerelease --preid=rc &>/dev/null
+          npx conventional-changelog-cli -i CHANGELOG.md -r 0 -s -p angular
+          git add CHANGELOG.md
+          export version=`node -p "require('./package.json').version"`
+          echo $version
+          git commit -am "chore(pre-release) $version"
+
+  release:
+    docker:
+      - image: hugomrdias/node-alpine:test
+    steps:
+      - run: |
+          *github_auth
+          cp package.json _package.json
+          bump=`npx conventional-recommended-bump -p angular`
+          echo $bump
+          npm --no-git-tag-version version $bump &>/dev/null
+          npx conventional-changelog -i CHANGELOG.md -r 0 -s -p angular
+          git add CHANGELOG.md
+          version=`node -p "require('./package.json').version"`
+          mv -f _package.json package.json
+          git commit -am "docs(CHANGELOG) $version"
+          npm version $bump -m "chore(release) v%s"
+          git push --follow-tags upstream master
+          npm publish
+          npx gh-release -y
+
+  interop:
+    docker:
+      - image: node:10
+    steps:
+      - run: curl --request POST --form "token=$CI_JOB_TOKEN" --form ref=master https://circleci.com/api/v1.1/project/github/$CIRCLE_ORG/$CIRCLE_REPO/tree/$CIRCLE_BRANCH
+
+experimental:
+  notify:
+    branches:
+      only:
+        - master
+
+workflows:
+  version: 2
+  build_all:
+    jobs:
+      - build_linux:
+          filters:
+            branches:
+              only: master
+      - build_macos
+      # - pre-release
+      # - release
+
+  interop:
+    jobs:
+      - interop
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            tags:
+              only: /^v*/
+
+  test_all:
+    jobs:
+      - check:
+          filters:
+            branches:
+              only: master
+      - test
+      # - build_macos
+      - build_linux
+      - cov:
+          requires:
+            - test
+      - test-node-8
+      - test-node-10
+      - test-browser-chrome
+      - test-browser-firefox


### PR DESCRIPTION
Based off of @hugomrdias's [gitlab prototyping](https://github.com/hugomrdias/js-ipfs) (along with [jenkins](https://ci.ipfs.team/blue/organizations/jenkins/IPFS%2Fjs-ipfs/detail/master/22/)) and inspired by our internal use of Circle CI.

This prototypes out what a modern CircleCI setup would look like for our testing & release needs.

TODO:
 - [x] artifacts
 - [x] caching
 - [x] mac os x (node{8, 10})
 - [x] linux (node{8, 10})
 - [ ] (pre-)release flow to github+npm
 - [ ] interop with go-ipfs test releases