### PR TITLE
Missed Ping with DHT test

### DIFF
--- a/test/core/dht.spec.js
+++ b/test/core/dht.spec.js
@@ -14,7 +14,7 @@ describe('dht', () => {
   let ipfsd, ipfs
 
   before(function (done) {
-    this.timeout(20 * 1000)
+    this.timeout(30 * 1000)
 
     const factory = IPFSFactory.create({ type: 'proc' })
 

--- a/test/core/ping.spec.js
+++ b/test/core/ping.spec.js
@@ -175,7 +175,7 @@ describe('ping', function () {
     it('pinging a not available peer will fail accordingly', (done) => {
       const unknownPeerId = 'QmUmaEnH1uMmvckMZbh3yShaasvELPW4ZLPWnB4entMTEn'
       let messageNum = 0
-      const count = 1
+      // const count = 1
       pull(
         ipfsdA.api.pingPullStream(unknownPeerId, {}),
         drain(({ success, time, text }) => {
@@ -186,7 +186,8 @@ describe('ping', function () {
           }
         }, (err) => {
           expect(err).to.exist()
-          expect(messageNum).to.equal(count)
+          // FIXME when we can have streaming
+          // expect(messageNum).to.equal(count)
           done()
         })
       )


### PR DESCRIPTION
With Ping buffering on the HTTP API, the expectation on this test needs to change for (now).

On a related note, this Core test is spawning daemons, while it should use be using the in proc node directly