### PR TITLE
test: dont bootstrap unless it's needed

### DIFF
--- a/test/cli/name.js
+++ b/test/cli/name.js
@@ -32,7 +32,9 @@ describe('name', () => {
 
     df.spawn({
       exec: `./src/cli/bin.js`,
-      config: {},
+      config: {
+        Bootstrap: []
+      },
       args: pass.split(' '),
       initOptions: { bits: 512 }
     }, (err, _ipfsd) => {

--- a/test/core/block.spec.js
+++ b/test/core/block.spec.js
@@ -21,7 +21,8 @@ describe('block', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/core/dag.spec.js
+++ b/test/core/dag.spec.js
@@ -20,7 +20,8 @@ describe('dag', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/core/dht.spec.js
+++ b/test/core/dht.spec.js
@@ -20,7 +20,8 @@ describe('dht', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/core/files.spec.js
+++ b/test/core/files.spec.js
@@ -21,7 +21,8 @@ describe('files', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -39,6 +39,9 @@ describe('interface-ipfs-core tests', () => {
       initOptions: { bits: 512 },
       EXPERIMENTAL: {
         dht: true
+      },
+      config: {
+        Bootstrap: []
       }
     }
   })
@@ -154,7 +157,10 @@ describe('interface-ipfs-core tests', () => {
 
             if (typeof config === 'function') {
               cb = config
-              config = undefined
+            }
+
+            config = config || {
+              Bootstrap: []
             }
 
             const spawnOptions = { repoPath, config, initOptions: { bits: 512 } }

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -157,6 +157,7 @@ describe('interface-ipfs-core tests', () => {
 
             if (typeof config === 'function') {
               cb = config
+              config = null
             }
 
             config = config || {

--- a/test/core/name.js
+++ b/test/core/name.js
@@ -32,7 +32,8 @@ describe('name', function () {
     this.timeout(40 * 1000)
     df.spawn({
       exec: IPFS,
-      args: [`--pass ${hat()}`]
+      args: [`--pass ${hat()}`],
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
@@ -168,7 +169,8 @@ describe('ipns.path', function () {
     this.timeout(40 * 1000)
     df.spawn({
       exec: IPFS,
-      args: [`--pass ${hat()}`]
+      args: [`--pass ${hat()}`],
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       node = _ipfsd.api

--- a/test/core/object.spec.js
+++ b/test/core/object.spec.js
@@ -21,7 +21,8 @@ describe('object', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/core/pin.spec.js
+++ b/test/core/pin.spec.js
@@ -20,7 +20,8 @@ describe('pin', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/core/stats.spec.js
+++ b/test/core/stats.spec.js
@@ -21,7 +21,8 @@ describe('stats', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/core/swarm.spec.js
+++ b/test/core/swarm.spec.js
@@ -20,7 +20,8 @@ describe('swarm', () => {
 
     factory.spawn({
       exec: IPFS,
-      initOptions: { bits: 512 }
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
     }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd

--- a/test/http-api/block.js
+++ b/test/http-api/block.js
@@ -19,7 +19,10 @@ describe('block endpoint', () => {
   before(function (done) {
     this.timeout(20 * 1000)
 
-    df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+    df.spawn({
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
+    }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsd.api

--- a/test/http-api/bootstrap.js
+++ b/test/http-api/bootstrap.js
@@ -16,7 +16,10 @@ describe('bootstrap endpoint', () => {
   before(function (done) {
     this.timeout(20 * 1000)
 
-    df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+    df.spawn({
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
+    }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsd.api

--- a/test/http-api/dns.js
+++ b/test/http-api/dns.js
@@ -14,7 +14,10 @@ describe('dns endpoint', () => {
   let ipfsd = null
   before(function (done) {
     this.timeout(20 * 1000)
-    df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+    df.spawn({
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
+    }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsd.api

--- a/test/http-api/files.js
+++ b/test/http-api/files.js
@@ -18,7 +18,10 @@ describe('.files', () => {
   let ipfsd = null
   before(function (done) {
     this.timeout(20 * 1000)
-    df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+    df.spawn({
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
+    }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsd.api

--- a/test/http-api/id.js
+++ b/test/http-api/id.js
@@ -33,6 +33,7 @@ skipOnWindows('id endpoint', () => {
         (cb) => df.spawn({
           repoPath: repoPath,
           initOptions: { bits: 512 },
+          config: { Bootstrap: [] },
           disposable: false,
           start: true
         }, cb),

--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -90,6 +90,10 @@ describe('interface-ipfs-core over ipfs-api tests', () => {
               config = undefined
             }
 
+            config = config || {
+              Bootstrap: []
+            }
+
             const spawnOptions = { repoPath, config, initOptions: { bits: 512 } }
 
             ipfsFactory.spawn(spawnOptions, (err, _ipfsd) => {

--- a/test/http-api/object.js
+++ b/test/http-api/object.js
@@ -28,7 +28,10 @@ describe('object endpoint', () => {
   before(function (done) {
     this.timeout(20 * 1000)
 
-    df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+    df.spawn({
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
+    }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsd.api

--- a/test/http-api/version.js
+++ b/test/http-api/version.js
@@ -14,7 +14,10 @@ describe('version endpoint', () => {
   let ipfsd = null
   before(function (done) {
     this.timeout(20 * 1000)
-    df.spawn({ initOptions: { bits: 512 } }, (err, _ipfsd) => {
+    df.spawn({
+      initOptions: { bits: 512 },
+      config: { Bootstrap: [] }
+    }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsd.api

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -10,7 +10,7 @@ function createFactory (options) {
   options = options || {}
 
   options.factoryOptions = options.factoryOptions || { type: 'proc', exec: IPFS }
-  options.spawnOptions = options.spawnOptions || { initOptions: { bits: 512 } }
+  options.spawnOptions = options.spawnOptions || { initOptions: { bits: 512 }, config: { Bootstrap: [] } }
 
   if (options.factoryOptions.type !== 'proc') {
     options.factoryOptions.IpfsApi = options.factoryOptions.IpfsApi || IpfsApi

--- a/test/utils/on-and-off.js
+++ b/test/utils/on-and-off.js
@@ -52,7 +52,8 @@ function on (tests) {
       df.spawn({
         type: 'js',
         exec: `./src/cli/bin.js`,
-        initOptions: { bits: 512 }
+        initOptions: { bits: 512 },
+        config: { Bootstrap: [] }
       }, (err, node) => {
         expect(err).to.not.exist()
         ipfsd = node


### PR DESCRIPTION
This removes bootstrap nodes from all tests that don't need them. This should also help improve test determinism by preventing outside node influence. This also has the pleasant side effect of not having test nodes connect to our production bootstrap nodes.

A nice **future** update would be to set up specific bootstrap nodes when we do need to test bootstrapping so we're not hitting production at all.