### PR TITLE
refactor: use types test from interface-ipfs-core

### DIFF
--- a/test/core/init.spec.js
+++ b/test/core/init.spec.js
@@ -8,14 +8,8 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const isNode = require('detect-node')
 const hat = require('hat')
-const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 const crypto = require('libp2p-crypto')
 const isIPFS = require('is-ipfs')
-const multiaddr = require('multiaddr')
-const multibase = require('multibase')
-const multihash = require('multihashes')
-const CID = require('cids')
 const IPFS = require('../../src/core')
 
 const privateKey = 'CAASqAkwggSkAgEAAoIBAQChVmiObYo6pkKrMSd3OzW1cTL+RDmX1rkETYGKWV9TPXMNgElFTYoYHqT9QZomj5RI8iUmHccjzqr4J0mV+E0NpvHHOLlmDZ82lAw2Zx7saUkeQWvC0S9Z0o3aTx2sSubZV53rSomkZgQH4fYTs4RERejV4ltzLFdzQQBwWrBvlagpPHUCxKDUCnE5oIzdbD26ltWViPBWr7TfotzC8Lyi/tceqCpHMUJGMbsVgypnlgpey07MBvs71dVh5LcRen/ztsQO6Yju4D3QgWoyD0SIUdJFvBzEwL9bSiA3QjUc/fkGd7EcdN5bebYOqAi4ZIiAMLp3i4+B8Tzq/acull43AgMBAAECggEBAIDgZE75o4SsEO9tKWht7L5OeXxxBUyMImkUfJkGQUZd/MzZIC5y/Q+9UvBW+gs5gCsw+onTGaM50Iq/32Ej4nE4XURVxIuH8BmJ86N1hlc010qK2cjajqeCsPulXT+m6XbOLYCpnv+q2idt0cL1EH/1FEPeOEztK8ION4qIdw36SoykfTx/RqtkKHtS01AwN82EOPbWk7huyQT5R5MsCZmRJXBFkpNtiL+8619BH2aVlghHO4NouF9wQjdz/ysVuyYg+3rX2cpGjuHDTZ6hVQiJD1lF6D+dua7UPyHYAG2iRQiKZmCjitt9ywzPxiRaYF/aZ02FEMWckZulR09axskCgYEAzjl6ER8WwxYHn4tHse+CrIIF2z5cscdrh7KSwd3Rse9hIIBDJ/0KkvoYd1IcWrS8ywLrRfSLIjEU9u7IN1m+IRVWJ61fXNqOHm9clAu6qNhCN6W2+JfxDkUygTwmsq0v3huO+qkiMQz+a4nAXJe8Utd36ywgPhVGxFa/7x1v1N0CgYEAyEdiYRFf1aQZcO7+B2FH+tkGJsB30VIBhcpG9EukuQUUulLHhScc/KRj+EFAACLdkTqlVI0xVYIWaaCXwoQCWKixjZ5mYPC+bBLgn4IoDS6XTdHtR7Vn3UUvGTKsM0/z4e8/0eSzGNCHoYez9IoBlPNic0sQuST4jzgS2RYnFCMCgYASWSzSLyjwTJp7CIJlg4Dl5l+tBRxsOOkJVssV8q2AnmLO6HqRKUNylkvs+eJJ88DEc0sJm1txvFo4KkCoJBT1jpduyk8szMlOTew3w99kvHEP0G+6KJKrCV8X/okW5q/WnC8ZgEjpglV0rfnugxWfbUpfIzrvKydzuqAzHzRfBQKBgQDANtKSeoxRjEbmfljLWHAure8bbgkQmfXgI7xpZdfXwqqcECpw/pLxXgycDHOSLeQcJ/7Y4RGCEXHVOk2sX+mokW6mjmmPjD4VlyCBtfcef6KzC1EBS3c9g9KqCln+fTOBmY7UsPu6SxiAzK7HeVP/Un8gS+Dm8DalrZlZQ8uJpQKBgF6mL/Xo/XUOiz2jAD18l8Y6s49bA9H2CoLpBGTV1LfY5yTFxRy4R3qnX/IzsKy567sbtkEFKJxplc/RzCQfrgbdj7k26SbKtHR3yERaFGRYq8UeAHeYC1/N19LF5BMQL4y5R4PJ1SFPeJCL/wXiMqs1maTqvKqtc4bbegNdwlxn'
@@ -109,18 +103,6 @@ describe('init', () => {
         expect(err).to.exist()
         done()
       })
-    })
-  })
-
-  it('data types', () => {
-    expect(ipfs.types).to.be.deep.equal({
-      Buffer: Buffer,
-      PeerId: PeerId,
-      PeerInfo: PeerInfo,
-      multiaddr: multiaddr,
-      multibase: multibase,
-      multihash: multihash,
-      CID: CID
     })
   })
 

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -173,7 +173,7 @@ describe('interface-ipfs-core tests', () => {
     }
   }), { skip: !isNode })
 
-  tests.types(defaultCommonFactory, { skip: { reason: 'FIXME: currently failing' } })
+  tests.types(defaultCommonFactory)
 
   tests.util(defaultCommonFactory, { skip: { reason: 'FIXME: currently failing' } })
 })

--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -106,7 +106,7 @@ describe('interface-ipfs-core over ipfs-api tests', () => {
     }
   }))
 
-  tests.types(defaultCommonFactory, { skip: { reason: 'FIXME: currently failing' } })
+  tests.types(defaultCommonFactory)
 
   tests.util(defaultCommonFactory, { skip: { reason: 'FIXME: currently failing' } })
 })


### PR DESCRIPTION
The test for types also exists in interface-ipfs-core, which is the
central test repository for both js-ipfs and js-http-api tests.
Pulling in the test once from there is enough.