### PR TITLE
chore: "copy release notes to github release" step

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,6 +39,7 @@
     - [ ] IRC
     - [ ] Reddit
   - [ ] Blog post
+  - [ ] Copy release notes to the [GitHub Release description](https://github.com/ipfs/js-ipfs/releases)
 
 # 🙌🏽 Want to contribute?
 


### PR DESCRIPTION
js-ipfs has amazing release issues. Let's copy the release notes highlights to the github release description for posterity. 

Web UI now links to the release url for a given version of js-ipfs, so it's be great to put those notes there.

I've taken the liberty of copying it over for 0.33.0 https://github.com/ipfs/js-ipfs/releases/tag/v0.33.0