### PR TITLE
feat: add slient option

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ Instead of a boolean, you may provide an object with custom initialization optio
 
 A passphrase to encrypt/decrypt your keys.
 
+##### `options.silent`
+
+| Type | Default |
+|------|---------|
+| string | `null` |
+
+The silent option prevents swarm info output in the cli and http client.
+
 ##### `options.relay`
 
 | Type | Default |

--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ A passphrase to encrypt/decrypt your keys.
 
 | Type | Default |
 |------|---------|
-| string | `null` |
+| Boolean | `false` |
 
-The silent option prevents swarm info output in the cli and http client.
+Prevents all logging output from the IPFS node.
 
 ##### `options.relay`
 

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -24,7 +24,12 @@ const cli = yargs
     desc: 'Write no output',
     type: 'boolean',
     default: false,
-    coerce: ('silent', silent => silent ? utils.disablePrinting() : silent)
+    coerce: ('silent', silent => {
+      if (silent) {
+        utils.disablePrinting()
+      }
+      return silent
+    })
   })
   .option('pass', {
     desc: 'Pass phrase for the keys',

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -44,10 +44,11 @@ exports.getIPFS = (argv, callback) => {
     return callback(null, getAPICtl(argv.api), promisify((cb) => cb()))
   }
 
+  debugger
   // Required inline to reduce startup time
   const IPFS = require('../core')
   const node = new IPFS({
-    print: argv.print,
+    silent: argv.silent,
     repo: exports.getRepoPath(),
     init: false,
     start: false,

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -44,7 +44,6 @@ exports.getIPFS = (argv, callback) => {
     return callback(null, getAPICtl(argv.api), promisify((cb) => cb()))
   }
 
-  debugger
   // Required inline to reduce startup time
   const IPFS = require('../core')
   const node = new IPFS({

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -47,6 +47,7 @@ exports.getIPFS = (argv, callback) => {
   // Required inline to reduce startup time
   const IPFS = require('../core')
   const node = new IPFS({
+    print: argv.print,
     repo: exports.getRepoPath(),
     init: false,
     start: false,

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -107,7 +107,7 @@ module.exports = function libp2p (self) {
           if (err) { return callback(err) }
 
           self._libp2pNode.peerInfo.multiaddrs.forEach((ma) => {
-            console.log('Swarm listening on', ma.toString())
+            self._print('Swarm listening on ', console.log(ma.toString()))
           })
 
           callback()

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -107,7 +107,7 @@ module.exports = function libp2p (self) {
           if (err) { return callback(err) }
 
           self._libp2pNode.peerInfo.multiaddrs.forEach((ma) => {
-            self._print('Swarm listening on ', console.log(ma.toString()))
+            self._print('Swarm listening on', ma.toString())
           })
 
           callback()

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -127,6 +127,7 @@ class IPFS extends EventEmitter {
     this._preload = preload(this)
     this._mfsPreload = mfsPreload(this)
     this._ipns = undefined
+    this._print = this._options.silent ? this.log : console.log
 
     // IPFS Core exposed components
     //   - for booting up a node

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -158,9 +158,9 @@ function HttpApi (repo, config, cliArgs) {
         api.info.ma = uriToMultiaddr(api.info.uri)
         gateway.info.ma = uriToMultiaddr(gateway.info.uri)
 
-        console.log('API listening on %s', api.info.ma)
-        console.log('Gateway (read only) listening on %s', gateway.info.ma)
-        console.log('Web UI available at %s', api.info.uri + '/webui')
+        this.node._print('API listening on %s', api.info.ma)
+        this.node._print('Gateway (read only) listening on %s', gateway.info.ma)
+        this.node._print('Web UI available at %s', api.info.uri + '/webui')
 
         // for the CLI to know the where abouts of the API
         this.node._repo.apiAddr.set(api.info.ma, cb)

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -68,6 +68,7 @@ function HttpApi (repo, config, cliArgs) {
         try {
           // start the daemon
           this.node = new IPFS({
+            silent: cliArgs.silent,
             repo: repo,
             init: init,
             start: true,

--- a/test/cli/daemon.js
+++ b/test/cli/daemon.js
@@ -126,6 +126,21 @@ describe('daemon', () => {
     })
   })
 
+  it('should be silent', function (done) {
+    this.timeout(10 * 1000)
+    const res = ipfs('daemon --silent')
+    res.catch(function () {}) // Handles the unhandled promise rejection
+    let output = ''
+    const onData = (d) => { output += d }
+    res.stdout.on('data', onData)
+    res.stderr.on('data', onData)
+    setTimeout(function () {
+      res.kill()
+      expect(output).to.be.empty()
+      done()
+    }, 5 * 1000)
+  })
+
   it('should present ipfs path help when option help is received', function (done) {
     this.timeout(100 * 1000)
 

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -7,6 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const series = require('async/series')
+const sinon = require('sinon')
 const waterfall = require('async/waterfall')
 const parallel = require('async/parallel')
 const os = require('os')
@@ -128,6 +129,21 @@ describe('create node', function () {
         node.once('stop', done)
         node.stop()
       })
+    })
+  })
+
+  it('should be silent', (done) => {
+    sinon.spy(console, 'log')
+
+    const ipfs = new IPFS({
+      silent: true,
+      repo: tempRepo
+    })
+
+    ipfs.on('ready', () => {
+      expect(console.log.called).to.be.false()
+      console.log.restore()
+      done()
     })
   })
 

--- a/test/core/libp2p.spec.js
+++ b/test/core/libp2p.spec.js
@@ -76,6 +76,7 @@ describe('libp2p customization', function () {
         },
         _peerInfo: peerInfo,
         _peerBook: peerBook,
+        _print: console.log,
         config: mockConfig,
         _options: {
           libp2p: (opts) => {
@@ -122,6 +123,7 @@ describe('libp2p customization', function () {
         },
         _peerInfo: peerInfo,
         _peerBook: peerBook,
+        _print: console.log,
         config: mockConfig
       }
 
@@ -164,6 +166,7 @@ describe('libp2p customization', function () {
         },
         _peerInfo: peerInfo,
         _peerBook: peerBook,
+        _print: console.log,
         config: mockConfig,
         _options: {
           config: {


### PR DESCRIPTION
This PR resolves https://github.com/ipfs/js-ipfs/issues/1683. This PR is not merge-ready and I wanted to highlight some of the issues I've currently ran into.

`node src/cli/bin daemon --silent` does not disable printing "Swarming listening on..." and I'm not sure exactly why this option is not picked up by the core library. 

Also, when I use `print` as a property the peer address is printed on a new line. Not sure how to remedy this behavior but I did try using `process.stdout.write()`. https://stackoverflow.com/questions/6157497/node-js-printing-to-console-without-a-trailing-newline

However when I implemented `process.stdout.write()` the address came before the print statement `process.stdout.write()`
```
Initializing IPFS daemon...
/ip4/127.0.0.1/tcp/4003/ws/ipfs/QmYT3Sv3paCcitjsSbBaeCuXRjcpTs4J87hVPyS4YLiji6Swarm listening on
/ip4/127.0.0.1/tcp/4002/ipfs/QmYT3Sv3paCcitjsSbBaeCuXRjcpTs4J87hVPyS4YLiji6Swarm listening on
/ip4/192.168.1.27/tcp/4002/ipfs/QmYT3Sv3paCcitjsSbBaeCuXRjcpTs4J87hVPyS4YLiji6Swarm listening on
/ip4/10.52.0.22/tcp/4002/ipfs/QmYT3Sv3paCcitjsSbBaeCuXRjcpTs4J87hVPyS4YLiji6Swarm listening on
API listening on /ip4/127.0.0.1/tcp/5002
Gateway (read only) listening on /ip4/127.0.0.1/tcp/9090
Web UI available at http://127.0.0.1:5002/webui
```