### PR TITLE
docs: add service-worker-gateway to release checks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,6 +29,7 @@
     - [ ] [peer-star-app](https://github.com/ipfs-shipyard/peer-star-app)
     - [ ] [ipfs-log](https://github.com/orbitdb/ipfs-log)
     - [ ] [orbit-db](https://github.com/orbitdb/orbit-db)
+    - [ ] [service-worker-gateway](https://github.com/ipfs-shipyard/service-worker-gateway)
 - Documentation
   - [ ] Ensure that README.md is up to date
   - [ ] Ensure that all the examples run


### PR DESCRIPTION
This is one of the flagship features for JS IPFS. We can do more to ensure it works with every release.