### PR TITLE
fix: add dash case to pin cli

### DIFF
--- a/src/cli/commands/pin/add.js
+++ b/src/cli/commands/pin/add.js
@@ -8,6 +8,7 @@ module.exports = {
   describe: 'Pins object to local storage.',
 
   builder: {
+    'ipfs-path': {}, // Temporary fix for https://github.com/yargs/yargs-parser/issues/151
     recursive: {
       type: 'boolean',
       alias: 'r',

--- a/src/cli/commands/pin/ls.js
+++ b/src/cli/commands/pin/ls.js
@@ -9,6 +9,7 @@ module.exports = {
   describe: 'List objects pinned to local storage.',
 
   builder: {
+    'ipfs-path': {}, // Temporary fix for https://github.com/yargs/yargs-parser/issues/151
     type: {
       type: 'string',
       alias: 't',

--- a/src/cli/commands/pin/rm.js
+++ b/src/cli/commands/pin/rm.js
@@ -8,6 +8,7 @@ module.exports = {
   describe: 'Removes the pinned object from local storage.',
 
   builder: {
+    'ipfs-path': {}, // Temporary fix for https://github.com/yargs/yargs-parser/issues/151
     recursive: {
       type: 'boolean',
       alias: 'r',


### PR DESCRIPTION
`yargs-parser` adds inferred alias when using camelCase notation to command options. As a result of this, `pin` command was failing with `Unknown argument: ipfs-path`

I opened an issue [yargs/yargs-parser#151](https://github.com/yargs/yargs-parser/issues/151), as if it inferres other alias, it should be transparent to the users. This is a temporary fix for this issue, while it is not solved.