### PR TITLE
chore: add renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,26 @@
     "coverage-publish": "aegir-coverage publish",
     "dep-check": "npx dependency-check package.json './test/**/*.js' './src/**/*.js'"
   },
+  "renovate": {
+    "extends": [
+      "config:base",
+      ":preserveSemverRanges"
+    ],
+    "packageRules": [
+      {
+        "packagePatterns": [
+          ".*"
+        ],
+        "enabled": false
+      },
+      {
+        "packageNames": [
+          "^ipfs"
+        ],
+        "enabled": true
+      }
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfs/js-ipfs.git"


### PR DESCRIPTION
This PR adds renovate service config.

Renovate works like greenkeeper but has filters. We have been talking about having a dependencies checker service to automatically do PRs with new versions but only for our packages. 

The config in the PR only enables packages matching `^ipfs` for now so we can test if this works well for us. 

Check this https://github.com/hugomrdias/js-ipfs/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc to see what the PRs look like.

for this to work we need this service https://github.com/marketplace/renovate active for this repo. /cc @daviddias 