### PR TITLE
[WIP] refactor: object APIs write methods now return CIDs

### DIFF
--- a/src/core/components/object.js
+++ b/src/core/components/object.js
@@ -98,7 +98,7 @@ module.exports = function object (self) {
                 self._preload(cid)
               }
 
-              cb(null, node)
+              cb(null, cid)
             })
           })
         }
@@ -150,7 +150,7 @@ module.exports = function object (self) {
             self._preload(cid)
           }
 
-          callback(null, node)
+          callback(null, cid)
         })
       })
     }),
@@ -209,9 +209,11 @@ module.exports = function object (self) {
             return callback(err)
           }
 
-          self.object.get(cid, {
-            preload: options.preload
-          }, callback)
+          if (options.preload !== false) {
+            self._preload(cid)
+          }
+
+          callback(null, cid)
         })
       }
     }),

--- a/src/http/api/resources/object.js
+++ b/src/http/api/resources/object.js
@@ -37,7 +37,7 @@ exports.new = (request, reply) => {
 
   waterfall([
     (cb) => ipfs.object.new(template, cb),
-    (node, cb) => dagPB.util.cid(node, (err, cid) => cb(err, { node, cid }))
+    (cid, cb) => ipfs.object.get(cid, (err, node) => cb(err, { node, cid }))
   ], (err, results) => {
     if (err) {
       log.error(err)
@@ -200,8 +200,7 @@ exports.put = {
 
     waterfall([
       (cb) => DAGNode.create(Buffer.from(node.Data), node.Links, cb),
-      (node, cb) => ipfs.object.put(node, cb),
-      (node, cb) => dagPB.util.cid(node, (err, cid) => cb(err, { cid, node }))
+      (node, cb) => ipfs.object.put(node, (err, cid) => cb(err, { cid, node }))
     ], (err, results) => {
       if (err) {
         log.error(err)
@@ -366,7 +365,7 @@ exports.patchAppendData = {
 
     waterfall([
       (cb) => ipfs.object.patch.appendData(key, data, cb),
-      (node, cb) => dagPB.util.cid(node, (err, cid) => cb(err, { node, cid }))
+      (cid, cb) => ipfs.object.get(cid, (err, node) => cb(err, { node, cid }))
     ], (err, results) => {
       if (err) {
         log.error(err)
@@ -409,7 +408,7 @@ exports.patchSetData = {
 
     waterfall([
       (cb) => ipfs.object.patch.setData(key, data, cb),
-      (node, cb) => dagPB.util.cid(node, (err, cid) => cb(err, { node, cid }))
+      (cid, cb) => ipfs.object.get(cid, (err, node) => cb(err, { node, cid }))
     ], (err, results) => {
       if (err) {
         log.error(err)
@@ -477,7 +476,7 @@ exports.patchAddLink = {
     waterfall([
       (cb) => ipfs.object.get(ref, cb),
       (node, cb) => ipfs.object.patch.addLink(root, new DAGLink(name, node.size, ref), cb),
-      (node, cb) => dagPB.util.cid(node, (err, cid) => cb(err, { node, cid }))
+      (cid, cb) => ipfs.object.get(cid, (err, node) => cb(err, { node, cid }))
     ], (err, results) => {
       if (err) {
         log.error(err)
@@ -544,7 +543,7 @@ exports.patchRmLink = {
 
     waterfall([
       (cb) => ipfs.object.patch.rmLink(root, { name: link }, cb),
-      (node, cb) => dagPB.util.cid(node, (err, cid) => cb(err, { node, cid }))
+      (cid, cb) => ipfs.object.get(cid, (err, node) => cb(err, { node, cid }))
     ], (err, results) => {
       if (err) {
         log.error(err)


### PR DESCRIPTION
For the back story on this change, please see: https://github.com/ipfs/interface-ipfs-core/pull/388#pullrequestreview-173866270

BREAKING CHANGE: Object API refactor.

Object API methods that write DAG nodes now return a [CID](https://www.npmjs.com/package/cids) instead of a DAG node. Affected methods:

* `ipfs.object.new`
* `ipfs.object.patch.addLink`
* `ipfs.object.patch.appendData`
* `ipfs.object.patch.rmLink`
* `ipfs.object.patch.setData`
* `ipfs.object.put`

Example:

```js
// Before
const dagNode = await ipfs.object.new()
```

```js
// After
const cid = await ipfs.object.new() // now returns a CID
const dagNode = await ipfs.object.get(cid) // fetch the DAG node that was created
```

IMPORTANT: `DAGNode` instances, which are part of the IPLD dag-pb format have been refactored.

These instances no longer have `multihash`, `cid` or `serialized` properties.

This effects the following API methods that return these types of objects:

* `ipfs.object.get`
* `ipfs.dag.get`

See https://github.com/ipld/js-ipld-dag-pb/pull/99 for more information.