### PR TITLE
fix: ipns datastore key

### DIFF
--- a/src/core/ipns/routing/utils.js
+++ b/src/core/ipns/routing/utils.js
@@ -3,5 +3,7 @@
 const multibase = require('multibase')
 
 module.exports.encodeBase32 = (buf) => {
-  return multibase.encode('base32', buf).slice(1) // slice off multibase codec
+  const m = multibase.encode('base32', buf).slice(1) // slice off multibase codec
+
+  return m.toString().toUpperCase() // should be uppercase for interop with go
 }


### PR DESCRIPTION
When the `base32` lib was changed, the new one uses `lowercase`, which brokes the interop with `go-ipfs` for the `IPNS working locally`