### PR TITLE
fix: streaming cat over http api

### DIFF
--- a/src/core/components/files-regular.js
+++ b/src/core/components/files-regular.js
@@ -249,6 +249,10 @@ module.exports = function (self) {
           return d.abort(new Error('this dag node is a directory'))
         }
 
+        if (!file.content) {
+          return d.abort(new Error('this dag node has no content'))
+        }
+
         d.resolve(file.content)
       })
     )

--- a/src/core/components/files-regular.js
+++ b/src/core/components/files-regular.js
@@ -232,21 +232,24 @@ module.exports = function (self) {
 
     pull(
       exporter(ipfsPath, self._ipld, options),
+      pull.filter(filterFile),
+      pull.take(1),
       pull.collect((err, files) => {
-        if (err) { return d.abort(err) }
-        if (files && files.length > 1) {
-          files = files.filter(filterFile)
+        if (err) {
+          return d.abort(err)
         }
-        if (!files || !files.length) {
+
+        if (!files.length) {
           return d.abort(new Error('No such file'))
         }
 
         const file = files[0]
-        const content = file.content
-        if (!content && file.type === 'dir') {
+
+        if (!file.content && file.type === 'dir') {
           return d.abort(new Error('this dag node is a directory'))
         }
-        d.resolve(content)
+
+        d.resolve(file.content)
       })
     )
 


### PR DESCRIPTION
`/api/v0/cat` calls `ipfs.cat`, but `ipfs.cat` returns a buffer of file output. This changes `/api/v0/cat` to actually stream output by calling `ipfs.catPullStream` instead.

It uses `pull-pushable` in order to catch an initial error in the stream before it starts flowing and instead return a plain JSON response with an appropriate HTTP status.

This isn't ideal as it means there's no backpressure - if the consumer doesn't consume fast enough then data will start to get buffered into memory. However this is significantly better than buffering _everything_ into memory before replying.

This reduces memory usage and time to first byte significantly. e.g.

```sh
$ jsipfs object stat QmTtBrkubV9M914kgYrjTDCWTkN4TjnwYDJYb3dwK7ErXR
NumLinks: 22
BlockSize: 1110
LinksSize: 992
DataSize: 118
CumulativeSize: 965374843 # i.e. ~965MB

# I modified jsipfs cat to print out the time it takes before it receives the first byte:
# (note we are talking to the daemon here so are going over the HTTP API)

# Before:
$ jsipfs cat QmTtBrkubV9M914kgYrjTDCWTkN4TjnwYDJYb3dwK7ErXR
time to first chunk: 2961.353ms

# After:
$ jsipfs cat QmTtBrkubV9M914kgYrjTDCWTkN4TjnwYDJYb3dwK7ErXR
time to first chunk: 127.899ms
```

resolves #1755