### PR TITLE
chore: update webui to v2.3.1

### DIFF
--- a/src/http/api/routes/webui.js
+++ b/src/http/api/routes/webui.js
@@ -20,7 +20,7 @@ module.exports = (server) => {
       method: '*',
       path: '/webui',
       handler: (request, reply) => {
-        return reply().redirect().location('/ipfs/QmUnXcWZC5Ve21gUseouJsH5mLAyz5JPp8aHsg8qVUUK8e')
+        return reply().redirect().location('/ipfs/QmZLzKRqjuhERwjL7X72HMpwdw7r1o5MnSWcVSZxYfXcDH')
       }
     }
   ])


### PR DESCRIPTION
Update to [Web UI v2.3.1](https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.3.1) to pull in ipfs-geoip update and make geolocating peers work again.


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>