### PR TITLE
docs: fix browser video streaming example

### DIFF
--- a/examples/browser-video-streaming/README.md
+++ b/examples/browser-video-streaming/README.md
@@ -39,8 +39,6 @@ The most important piece of information to note down is the name you choose for 
 
 ## Putting it all together
 
-For a demo of the final result, see https://ipfs.io/ipfs/QmdBZhDLEsooVKkmgRgNzjo2JirSbddp8FvnccJ4c2orH2/
-
 *Note:* If you try to run the example straight from disk, some browsers (e.g Chrome) might, for security reasons, prevent some resources from loading correctly. To get around this, simply cd into the directory of this example and use http-server from npm:
 
 ```bash
@@ -53,4 +51,3 @@ You should then be able to stream Big Buck Bunny by pointing your browser at htt
 In addition to video streaming, plain audio streaming works fine as well. Simply use the same ffmpeg + ipfs procedure as described above, but with your audio file as input. You may also want to change the video tag to `audio` (video tags will play plain audio as well, but the player looks a bit strange).
 
 On a final note, without diving too deep into what the specific ffmpeg HLS options above mean, it's worth mentioning the `hls_time` option, which defines the length of each HLS chunk (in seconds) and is potentially interesting for performance tuning (see for example [this article](https://bitmovin.com/mpeg-dash-hls-segment-length/)).
-

--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -2,7 +2,7 @@
   <body>
     <video id="video" controls></video>
     <script src="https://unpkg.com/ipfs/dist/index.js"></script>
-    <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.2/dist/index.js"></script>
+    <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.3/dist/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>
   </body>


### PR DESCRIPTION
https://github.com/moshisushi/hlsjs-ipfs-loader/pull/7 was merged and released so this can now be fixed.