### PR TITLE
feat: make ipfs.libp2p the libp2p node rather than component

### DIFF
--- a/src/core/components/dht.js
+++ b/src/core/components/dht.js
@@ -30,7 +30,7 @@ module.exports = (self) => {
 
       options = options || {}
 
-      self._libp2pNode.dht.get(key, options.timeout, callback)
+      self.libp2p.dht.get(key, options.timeout, callback)
     }),
 
     /**
@@ -50,7 +50,7 @@ module.exports = (self) => {
         return callback(new Error('Not valid key'))
       }
 
-      self._libp2pNode.dht.put(key, value, callback)
+      self.libp2p.dht.put(key, value, callback)
     }),
 
     /**
@@ -83,7 +83,7 @@ module.exports = (self) => {
 
       opts = opts || {}
 
-      self._libp2pNode.contentRouting.findProviders(key, opts.timeout || null, callback)
+      self.libp2p.contentRouting.findProviders(key, opts.timeout || null, callback)
     }),
 
     /**
@@ -98,7 +98,7 @@ module.exports = (self) => {
         peer = PeerId.createFromB58String(peer)
       }
 
-      self._libp2pNode.peerRouting.findPeer(peer, (err, info) => {
+      self.libp2p.peerRouting.findPeer(peer, (err, info) => {
         if (err) {
           return callback(err)
         }
@@ -154,7 +154,7 @@ module.exports = (self) => {
           // TODO: Implement recursive providing
         } else {
           each(keys, (cid, cb) => {
-            self._libp2pNode.contentRouting.provide(cid, cb)
+            self.libp2p.contentRouting.provide(cid, cb)
           }, callback)
         }
       })
@@ -173,7 +173,7 @@ module.exports = (self) => {
       }
 
       // TODO expose this method in peerRouting
-      self._libp2pNode._dht.getClosestPeers(peerId.toBytes(), (err, peerIds) => {
+      self.libp2p._dht.getClosestPeers(peerId.toBytes(), (err, peerIds) => {
         if (err) {
           return callback(err)
         }

--- a/src/core/components/is-online.js
+++ b/src/core/components/is-online.js
@@ -2,6 +2,6 @@
 
 module.exports = function isOnline (self) {
   return () => {
-    return Boolean(self._bitswap && self._libp2pNode && self._libp2pNode.isStarted())
+    return Boolean(self._bitswap && self.libp2p && self.libp2p.isStarted())
   }
 }

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -79,7 +79,7 @@ module.exports = function libp2p (self) {
           libp2pBundle = defaultBundle
         }
 
-        self._libp2pNode = libp2pBundle({
+        self.libp2p = libp2pBundle({
           options: self._options,
           config: config,
           datastore: self._repo.datastore,
@@ -91,15 +91,15 @@ module.exports = function libp2p (self) {
 
         const putAndDial = peerInfo => {
           self._peerInfoBook.put(peerInfo)
-          self._libp2pNode.dial(peerInfo, () => {})
+          self.libp2p.dial(peerInfo, () => {})
         }
 
-        self._libp2pNode.on('start', () => {
+        self.libp2p.on('start', () => {
           discoveredPeers.forEach(putAndDial)
           discoveredPeers = []
         })
 
-        self._libp2pNode.on('peer:discovery', (peerInfo) => {
+        self.libp2p.on('peer:discovery', (peerInfo) => {
           if (self.isOnline()) {
             putAndDial(peerInfo)
           } else {
@@ -107,14 +107,14 @@ module.exports = function libp2p (self) {
           }
         })
 
-        self._libp2pNode.on('peer:connect', (peerInfo) => {
+        self.libp2p.on('peer:connect', (peerInfo) => {
           self._peerInfoBook.put(peerInfo)
         })
 
-        self._libp2pNode.start((err) => {
+        self.libp2p.start((err) => {
           if (err) { return callback(err) }
 
-          self._libp2pNode.peerInfo.multiaddrs.forEach((ma) => {
+          self.libp2p.peerInfo.multiaddrs.forEach((ma) => {
             self._print('Swarm listening on', ma.toString())
           })
 
@@ -123,7 +123,7 @@ module.exports = function libp2p (self) {
       }
     }),
     stop: promisify((callback) => {
-      self._libp2pNode.stop(callback)
+      self.libp2p.stop(callback)
     })
   }
 }

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -20,7 +20,7 @@ module.exports = function libp2p (self, config) {
   let discoveredPeers = []
 
   const putAndDial = peerInfo => {
-    peerInfo.put(peerInfo)
+    peerBook.put(peerInfo)
     libp2p.dial(peerInfo, () => {})
   }
 

--- a/src/core/components/ping-pull-stream.js
+++ b/src/core/components/ping-pull-stream.js
@@ -19,14 +19,14 @@ module.exports = function pingPullStream (self) {
 
     const source = Pushable()
 
-    getPeer(self._libp2pNode, source, peerId, (err, peer) => {
+    getPeer(self.libp2p, source, peerId, (err, peer) => {
       if (err) {
         log.error(err)
         source.end(err)
         return
       }
 
-      runPing(self._libp2pNode, source, opts.count, peer, (err) => {
+      runPing(self.libp2p, source, opts.count, peer, (err) => {
         if (err) {
           log.error(err)
           source.push(getPacket({ success: false, text: err.toString() }))

--- a/src/core/components/pubsub.js
+++ b/src/core/components/pubsub.js
@@ -24,7 +24,7 @@ module.exports = function pubsub (self) {
 
       if (!callback) {
         return new Promise((resolve, reject) => {
-          self._libp2pNode.pubsub.subscribe(topic, options, handler, (err) => {
+          self.libp2p.pubsub.subscribe(topic, options, handler, (err) => {
             if (err) {
               return reject(err)
             }
@@ -33,7 +33,7 @@ module.exports = function pubsub (self) {
         })
       }
 
-      self._libp2pNode.pubsub.subscribe(topic, options, handler, callback)
+      self.libp2p.pubsub.subscribe(topic, options, handler, callback)
     },
 
     unsubscribe: (topic, handler, callback) => {
@@ -43,7 +43,7 @@ module.exports = function pubsub (self) {
           : Promise.reject(errPubsubDisabled())
       }
 
-      self._libp2pNode.pubsub.unsubscribe(topic, handler)
+      self.libp2p.pubsub.unsubscribe(topic, handler)
 
       if (!callback) {
         return Promise.resolve()
@@ -56,28 +56,28 @@ module.exports = function pubsub (self) {
       if (!self._options.EXPERIMENTAL.pubsub) {
         return setImmediate(() => callback(errPubsubDisabled()))
       }
-      self._libp2pNode.pubsub.publish(topic, data, callback)
+      self.libp2p.pubsub.publish(topic, data, callback)
     }),
 
     ls: promisify((callback) => {
       if (!self._options.EXPERIMENTAL.pubsub) {
         return setImmediate(() => callback(errPubsubDisabled()))
       }
-      self._libp2pNode.pubsub.ls(callback)
+      self.libp2p.pubsub.ls(callback)
     }),
 
     peers: promisify((topic, callback) => {
       if (!self._options.EXPERIMENTAL.pubsub) {
         return setImmediate(() => callback(errPubsubDisabled()))
       }
-      self._libp2pNode.pubsub.peers(topic, callback)
+      self.libp2p.pubsub.peers(topic, callback)
     }),
 
     setMaxListeners (n) {
       if (!self._options.EXPERIMENTAL.pubsub) {
         throw errPubsubDisabled()
       }
-      self._libp2pNode.pubsub.setMaxListeners(n)
+      self.libp2p.pubsub.setMaxListeners(n)
     }
   }
 }

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -46,7 +46,7 @@ module.exports = (self) => {
         // Add IPNS pubsub if enabled
         let pubsubDs
         if (get(self._options, 'EXPERIMENTAL.ipnsPubsub', false)) {
-          const pubsub = self._libp2pNode.pubsub
+          const pubsub = self.libp2p.pubsub
           const localDatastore = self._repo.datastore
           const peerId = self._peerInfo.id
 
@@ -57,7 +57,7 @@ module.exports = (self) => {
         // DHT should be added as routing if we are not running with local flag
         // TODO: Need to change this logic once DHT is enabled by default, for now fallback to Offline datastore
         if (get(self._options, 'EXPERIMENTAL.dht', false) && !self._options.local) {
-          ipnsStores.push(self._libp2pNode.dht)
+          ipnsStores.push(self.libp2p.dht)
         } else {
           const offlineDatastore = new OfflineDatastore(self._repo)
           ipnsStores.push(offlineDatastore)
@@ -68,7 +68,7 @@ module.exports = (self) => {
         self._ipns = new IPNS(routing, self._repo.datastore, self._peerInfo, self._keychain, self._options)
 
         self._bitswap = new Bitswap(
-          self._libp2pNode,
+          self.libp2p,
           self._repo.blocks,
           { statsEnabled: true }
         )

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -38,7 +38,7 @@ module.exports = (self) => {
           ? self._repo.open(cb)
           : cb()
       },
-      (cb) => self.libp2p.start(cb),
+      (cb) => self._libp2p.start(cb),
       (cb) => {
         // Setup online routing for IPNS with a tiered routing composed by a DHT and a Pubsub router (if properly enabled)
         const ipnsStores = []

--- a/src/core/components/stats.js
+++ b/src/core/components/stats.js
@@ -12,11 +12,11 @@ function bandwidthStats (self, opts) {
     let stats
 
     if (opts.peer) {
-      stats = self._libp2pNode.stats.forPeer(opts.peer)
+      stats = self.libp2p.stats.forPeer(opts.peer)
     } else if (opts.proto) {
-      stats = self._libp2pNode.stats.forProtocol(opts.proto)
+      stats = self.libp2p.stats.forProtocol(opts.proto)
     } else {
-      stats = self._libp2pNode.stats.global
+      stats = self.libp2p.stats.global
     }
 
     if (!stats) {

--- a/src/core/components/stop.js
+++ b/src/core/components/stop.js
@@ -35,7 +35,7 @@ module.exports = (self) => {
     series([
       (cb) => self._ipns.republisher.stop(cb),
       (cb) => self._mfsPreload.stop(cb),
-      (cb) => self.libp2p.stop(cb),
+      (cb) => self._libp2p.stop(cb),
       (cb) => self._repo.close(cb)
     ], done)
   })

--- a/src/core/components/stop.js
+++ b/src/core/components/stop.js
@@ -35,7 +35,11 @@ module.exports = (self) => {
     series([
       (cb) => self._ipns.republisher.stop(cb),
       (cb) => self._mfsPreload.stop(cb),
-      (cb) => self._libp2p.stop(cb),
+      (cb) => {
+        const libp2p = self.libp2p
+        self.libp2p = null
+        libp2p.stop(cb)
+      },
       (cb) => self._repo.close(cb)
     ], done)
   })

--- a/src/core/components/swarm.js
+++ b/src/core/components/swarm.js
@@ -60,7 +60,7 @@ module.exports = function swarm (self) {
         return callback(new Error(OFFLINE_ERROR))
       }
 
-      callback(null, self._libp2pNode.peerInfo.multiaddrs.toArray())
+      callback(null, self.libp2p.peerInfo.multiaddrs.toArray())
     }),
 
     connect: promisify((maddr, callback) => {
@@ -68,7 +68,7 @@ module.exports = function swarm (self) {
         return callback(new Error(OFFLINE_ERROR))
       }
 
-      self._libp2pNode.dial(maddr, callback)
+      self.libp2p.dial(maddr, callback)
     }),
 
     disconnect: promisify((maddr, callback) => {
@@ -76,7 +76,7 @@ module.exports = function swarm (self) {
         return callback(new Error(OFFLINE_ERROR))
       }
 
-      self._libp2pNode.hangUp(maddr, callback)
+      self.libp2p.hangUp(maddr, callback)
     }),
 
     filters: promisify((callback) => callback(new Error('Not implemented')))

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -113,7 +113,6 @@ class IPFS extends EventEmitter {
     // this._repo - assigned above
     this._peerInfoBook = new PeerBook()
     this._peerInfo = undefined
-    this._libp2pNode = undefined
     this._bitswap = undefined
     this._blockService = new BlockService(this._repo)
     this._ipld = new Ipld({
@@ -150,6 +149,7 @@ class IPFS extends EventEmitter {
     this.object = components.object(this)
     this.dag = components.dag(this)
     this.files = components.filesMFS(this)
+    this.libp2p = undefined // Initialised at _libp2p.start()
     this.swarm = components.swarm(this)
     this.name = components.name(this)
     this.bitswap = components.bitswap(this)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -126,7 +126,6 @@ class IPFS extends EventEmitter {
     this._preload = preload(this)
     this._mfsPreload = mfsPreload(this)
     this._ipns = undefined
-    this._libp2p = components.libp2p(this)
     // eslint-disable-next-line no-console
     this._print = this._options.silent ? this.log : console.log
 
@@ -149,7 +148,7 @@ class IPFS extends EventEmitter {
     this.object = components.object(this)
     this.dag = components.dag(this)
     this.files = components.filesMFS(this)
-    this.libp2p = undefined // Initialised at _libp2p.start()
+    this.libp2p = null // assigned on start
     this.swarm = components.swarm(this)
     this.name = components.name(this)
     this.bitswap = components.bitswap(this)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -127,6 +127,7 @@ class IPFS extends EventEmitter {
     this._preload = preload(this)
     this._mfsPreload = mfsPreload(this)
     this._ipns = undefined
+    this._libp2p = components.libp2p(this)
     // eslint-disable-next-line no-console
     this._print = this._options.silent ? this.log : console.log
 
@@ -149,7 +150,6 @@ class IPFS extends EventEmitter {
     this.object = components.object(this)
     this.dag = components.dag(this)
     this.files = components.filesMFS(this)
-    this.libp2p = components.libp2p(this)
     this.swarm = components.swarm(this)
     this.name = components.name(this)
     this.bitswap = components.bitswap(this)

--- a/test/core/libp2p.spec.js
+++ b/test/core/libp2p.spec.js
@@ -108,8 +108,8 @@ describe('libp2p customization', function () {
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        expect(ipfs._libp2pNode._config).to.not.have.property('peerDiscovery')
-        expect(ipfs._libp2pNode._transport).to.have.length(1)
+        expect(ipfs.libp2p._config).to.not.have.property('peerDiscovery')
+        expect(ipfs.libp2p._transport).to.have.length(1)
         done()
       })
     })
@@ -131,7 +131,7 @@ describe('libp2p customization', function () {
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        expect(ipfs._libp2pNode._config).to.deep.include({
+        expect(ipfs.libp2p._config).to.deep.include({
           peerDiscovery: {
             bootstrap: {
               enabled: true,
@@ -152,7 +152,7 @@ describe('libp2p customization', function () {
             pubsub: false
           }
         })
-        expect(ipfs._libp2pNode._transport).to.have.length(3)
+        expect(ipfs.libp2p._transport).to.have.length(3)
         done()
       })
     })
@@ -197,7 +197,7 @@ describe('libp2p customization', function () {
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        expect(ipfs._libp2pNode._config).to.deep.include({
+        expect(ipfs.libp2p._config).to.deep.include({
           peerDiscovery: {
             bootstrap: {
               enabled: true,
@@ -218,7 +218,7 @@ describe('libp2p customization', function () {
             pubsub: true
           }
         })
-        expect(ipfs._libp2pNode._transport).to.have.length(1)
+        expect(ipfs.libp2p._transport).to.have.length(1)
         done()
       })
     })

--- a/test/core/libp2p.spec.js
+++ b/test/core/libp2p.spec.js
@@ -24,31 +24,27 @@ describe('libp2p customization', function () {
   let datastore
   let peerInfo
   let peerBook
-  let mockConfig
+  let testConfig
   let _libp2p
 
-  before((done) => {
-    mockConfig = {
-      get: (callback) => {
-        callback(null, {
-          Addresses: {
-            Swarm: ['/ip4/0.0.0.0/tcp/4002'],
-            API: '/ip4/127.0.0.1/tcp/5002',
-            Gateway: '/ip4/127.0.0.1/tcp/9090'
-          },
-          Discovery: {
-            MDNS: {
-              Enabled: false
-            },
-            webRTCStar: {
-              Enabled: false
-            }
-          },
-          EXPERIMENTAL: {
-            dht: false,
-            pubsub: false
-          }
-        })
+  beforeEach((done) => {
+    testConfig = {
+      Addresses: {
+        Swarm: ['/ip4/0.0.0.0/tcp/4002'],
+        API: '/ip4/127.0.0.1/tcp/5002',
+        Gateway: '/ip4/127.0.0.1/tcp/9090'
+      },
+      Discovery: {
+        MDNS: {
+          Enabled: false
+        },
+        webRTCStar: {
+          Enabled: false
+        }
+      },
+      EXPERIMENTAL: {
+        dht: false,
+        pubsub: false
       }
     }
     datastore = new MemoryStore()
@@ -77,7 +73,6 @@ describe('libp2p customization', function () {
         _peerInfo: peerInfo,
         _peerBook: peerBook,
         _print: console.log,
-        config: mockConfig,
         _options: {
           libp2p: (opts) => {
             const wsstar = new WebSocketStar({ id: opts.peerInfo.id })
@@ -104,12 +99,12 @@ describe('libp2p customization', function () {
         }
       }
 
-      _libp2p = libp2pComponent(ipfs)
+      _libp2p = libp2pComponent(ipfs, testConfig)
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        expect(ipfs.libp2p._config).to.not.have.property('peerDiscovery')
-        expect(ipfs.libp2p._transport).to.have.length(1)
+        expect(_libp2p._config).to.not.have.property('peerDiscovery')
+        expect(_libp2p._transport).to.have.length(1)
         done()
       })
     })
@@ -123,15 +118,14 @@ describe('libp2p customization', function () {
         },
         _peerInfo: peerInfo,
         _peerBook: peerBook,
-        _print: console.log,
-        config: mockConfig
+        _print: console.log
       }
 
-      _libp2p = libp2pComponent(ipfs)
+      _libp2p = libp2pComponent(ipfs, testConfig)
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        expect(ipfs.libp2p._config).to.deep.include({
+        expect(_libp2p._config).to.deep.include({
           peerDiscovery: {
             bootstrap: {
               enabled: true,
@@ -152,7 +146,7 @@ describe('libp2p customization', function () {
             pubsub: false
           }
         })
-        expect(ipfs.libp2p._transport).to.have.length(3)
+        expect(_libp2p._transport).to.have.length(3)
         done()
       })
     })
@@ -167,7 +161,6 @@ describe('libp2p customization', function () {
         _peerInfo: peerInfo,
         _peerBook: peerBook,
         _print: console.log,
-        config: mockConfig,
         _options: {
           config: {
             Discovery: {
@@ -193,11 +186,11 @@ describe('libp2p customization', function () {
         }
       }
 
-      _libp2p = libp2pComponent(ipfs)
+      _libp2p = libp2pComponent(ipfs, testConfig)
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        expect(ipfs.libp2p._config).to.deep.include({
+        expect(_libp2p._config).to.deep.include({
           peerDiscovery: {
             bootstrap: {
               enabled: true,
@@ -218,7 +211,7 @@ describe('libp2p customization', function () {
             pubsub: true
           }
         })
-        expect(ipfs.libp2p._transport).to.have.length(1)
+        expect(_libp2p._transport).to.have.length(1)
         done()
       })
     })


### PR DESCRIPTION
This is an attempt on #1664–see discussion there. It may not be complete as I had trouble running unit tests (at master). I am posting this by way of abandoning it and welcome someone taking it over to finish it off.

I'm not sure this is 100% the right approach; in particular the `this.libp2p = undefined` in `core/index.js` is different to surrounding code. I don't know the project well enough to suggest an improvement here.

resolves https://github.com/ipfs/js-ipfs/issues/1664