### PR TITLE
fix: race condition causing Database is not open error

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -59,7 +59,11 @@ if (args[0] === 'daemon' || args[0] === 'init') {
     .completion()
     .command(require('./commands/daemon'))
     .command(require('./commands/init'))
-    .parse(args)
+
+  new YargsPromise(cli).parse(args)
+    .then(({ data }) => {
+      if (data) print(data)
+    })
 } else {
   // here we have to make a separate yargs instance with
   // only the `api` option because we need this before doing

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -17,12 +17,9 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, cidBase }) {
-    ipfs.bitswap.stat((err, stats) => {
-      if (err) {
-        throw err
-      }
-
+  handler ({ ipfs, cidBase, resolve }) {
+    resolve((async () => {
+      const stats = await ipfs.bitswap.stat()
       stats.wantlist = stats.wantlist.map(k => cidToString(k['/'], { base: cidBase, upgrade: false }))
       stats.peers = stats.peers || []
 
@@ -34,6 +31,6 @@ module.exports = {
     ${stats.wantlist.join('\n    ')}
   partners [${stats.peers.length}]
     ${stats.peers.join('\n    ')}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/bitswap/unwant.js
+++ b/src/cli/commands/bitswap/unwant.js
@@ -21,12 +21,10 @@ module.exports = {
       choices: multibase.names
     }
   },
-  handler ({ ipfs, key, cidBase }) {
-    ipfs.bitswap.unwant(key, (err) => {
-      if (err) {
-        throw err
-      }
+  handler ({ ipfs, key, cidBase, resolve }) {
+    resolve((async () => {
+      await ipfs.bitswap.unwant(key)
       print(`Key ${cidToString(key, { base: cidBase, upgrade: false })} removed from wantlist`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -22,12 +22,10 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, peer, cidBase }) {
-    ipfs.bitswap.wantlist(peer, (err, list) => {
-      if (err) {
-        throw err
-      }
+  handler ({ ipfs, peer, cidBase, resolve }) {
+    resolve((async () => {
+      const list = await ipfs.bitswap.wantlist(peer)
       list.Keys.forEach(k => print(cidToString(k['/'], { base: cidBase, upgrade: false })))
-    })
+    })())
   }
 }

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -9,17 +9,14 @@ module.exports = {
 
   builder: {},
 
-  handler ({ ipfs, key }) {
-    ipfs.block.get(key, (err, block) => {
-      if (err) {
-        throw err
-      }
-
+  handler ({ ipfs, key, resolve }) {
+    resolve((async () => {
+      const block = await ipfs.block.get(key)
       if (block) {
         print(block.data, false)
       } else {
         print('Block was unwanted before it could be remotely retrieved')
       }
-    })
+    })())
   }
 }

--- a/src/cli/commands/block/rm.js
+++ b/src/cli/commands/block/rm.js
@@ -9,18 +9,15 @@ module.exports = {
 
   builder: {},
 
-  handler ({ ipfs, key }) {
-    if (isDaemonOn()) {
-      // TODO implement this once `js-ipfs-http-client` supports it
-      throw new Error('rm block with daemon running is not yet implemented')
-    }
-
-    ipfs.block.rm(key, (err) => {
-      if (err) {
-        throw err
+  handler ({ ipfs, key, resolve }) {
+    resolve((async () => {
+      if (isDaemonOn()) {
+        // TODO implement this once `js-ipfs-http-client` supports it
+        throw new Error('rm block with daemon running is not yet implemented')
       }
 
+      await ipfs.block.rm(key)
       print('removed ' + key)
-    })
+    })())
   }
 }

--- a/src/cli/commands/block/stat.js
+++ b/src/cli/commands/block/stat.js
@@ -17,14 +17,11 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, key, cidBase }) {
-    ipfs.block.stat(key, (err, stats) => {
-      if (err) {
-        throw err
-      }
-
+  handler ({ ipfs, key, cidBase, resolve }) {
+    resolve((async () => {
+      const stats = await ipfs.block.stat(key)
       print('Key: ' + cidToString(stats.key, { base: cidBase }))
       print('Size: ' + stats.size)
-    })
+    })())
   }
 }

--- a/src/cli/commands/bootstrap/add.js
+++ b/src/cli/commands/bootstrap/add.js
@@ -16,14 +16,9 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.bootstrap.add(argv.peer, {
-      default: argv.default
-    }, (err, list) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const list = await argv.ipfs.bootstrap.add(argv.peer, { default: argv.default })
       list.Peers.forEach((peer) => print(peer))
-    })
+    })())
   }
 }

--- a/src/cli/commands/bootstrap/list.js
+++ b/src/cli/commands/bootstrap/list.js
@@ -10,12 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.bootstrap.list((err, list) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const list = await argv.ipfs.bootstrap.list()
       list.Peers.forEach((node) => print(node))
-    })
+    })())
   }
 }

--- a/src/cli/commands/bootstrap/rm.js
+++ b/src/cli/commands/bootstrap/rm.js
@@ -19,14 +19,9 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.bootstrap.rm(argv.peer, {
-      all: argv.all
-    }, (err, list) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const list = await argv.ipfs.bootstrap.rm(argv.peer, { all: argv.all })
       list.Peers.forEach((peer) => print(peer))
-    })
+    })())
   }
 }

--- a/src/cli/commands/cat.js
+++ b/src/cli/commands/cat.js
@@ -18,13 +18,14 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, ipfsPath, offset, length }) {
-    const stream = ipfs.catReadableStream(ipfsPath, { offset, length })
+  handler ({ ipfs, ipfsPath, offset, length, resolve }) {
+    resolve(new Promise((resolve, reject) => {
+      const stream = ipfs.catReadableStream(ipfsPath, { offset, length })
 
-    stream.once('error', (err) => {
-      throw err
-    })
+      stream.on('error', reject)
+      stream.on('end', resolve)
 
-    stream.pipe(process.stdout)
+      stream.pipe(process.stdout)
+    }))
   }
 }

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -24,47 +24,39 @@ module.exports = {
   },
 
   handler (argv) {
-    if (argv._handled) {
-      return
-    }
-    argv._handled = true
+    argv.resolve((async () => {
+      if (argv._handled) {
+        return
+      }
+      argv._handled = true
 
-    const bool = argv.bool
-    const json = argv.json
-    const key = argv.key
-    let value = argv.value
+      const { bool, json, key } = argv
+      let value = argv.value
 
-    if (!value) {
-      // Get the value of a given key
-      argv.ipfs.config.get(key, (err, value) => {
-        if (err) {
-          throw new Error('failed to read the config')
-        }
+      if (!value) {
+        // Get the value of a given key
+        value = await argv.ipfs.config.get(key)
 
         if (typeof value === 'object') {
           print(JSON.stringify(value, null, 2))
         } else {
           print(value)
         }
-      })
-    } else {
-      // Set the new value of a given key
+      } else {
+        // Set the new value of a given key
 
-      if (bool) {
-        value = (value === 'true')
-      } else if (json) {
-        try {
-          value = JSON.parse(value)
-        } catch (err) {
-          throw new Error('invalid JSON provided')
+        if (bool) {
+          value = (value === 'true')
+        } else if (json) {
+          try {
+            value = JSON.parse(value)
+          } catch (err) {
+            throw new Error('invalid JSON provided')
+          }
         }
+
+        await argv.ipfs.config.set(key, value)
       }
-
-      argv.ipfs.config.set(key, value, (err) => {
-        if (err) {
-          throw err
-        }
-      })
-    }
+    })())
   }
 }

--- a/src/cli/commands/config/replace.js
+++ b/src/cli/commands/config/replace.js
@@ -12,18 +12,16 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    if (argv._handled) return
-    argv._handled = true
+    argv.resolve((async () => {
+      if (argv._handled) return
+      argv._handled = true
 
-    const filePath = path.resolve(process.cwd(), argv.file)
+      const filePath = path.resolve(process.cwd(), argv.file)
 
-    const config = utils.isDaemonOn()
-      ? filePath : JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      const config = utils.isDaemonOn()
+        ? filePath : JSON.parse(fs.readFileSync(filePath, 'utf8'))
 
-    argv.ipfs.config.replace(config, (err) => {
-      if (err) {
-        throw err
-      }
-    })
+      return argv.ipfs.config.replace(config)
+    })())
   }
 }

--- a/src/cli/commands/config/show.js
+++ b/src/cli/commands/config/show.js
@@ -13,15 +13,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    if (argv._handled) return
-    argv._handled = true
+    argv.resolve((async () => {
+      if (argv._handled) return
+      argv._handled = true
 
-    argv.ipfs.config.get((err, config) => {
-      if (err) {
-        throw err
-      }
-
+      const config = await argv.ipfs.config.get()
       print(JSON.stringify(config, null, 4))
-    })
+    })())
   }
 }

--- a/src/cli/commands/dag/get.js
+++ b/src/cli/commands/dag/get.js
@@ -16,17 +16,21 @@ module.exports = {
   },
 
   handler (argv) {
-    const refParts = argv.cidpath.split('/')
-    const cidString = refParts[0]
-    const path = refParts.slice(1).join('/')
-    const cid = new CID(cidString)
+    argv.resolve((async () => {
+      const refParts = argv.cidpath.split('/')
+      const cidString = refParts[0]
+      const path = refParts.slice(1).join('/')
+      const cid = new CID(cidString)
 
-    const options = {
-      localResolve: argv.localResolve
-    }
+      const options = {
+        localResolve: argv.localResolve
+      }
 
-    argv.ipfs.dag.get(cid, path, options, (err, result) => {
-      if (err) {
+      let result
+
+      try {
+        result = await argv.ipfs.dag.get(cid, path, options)
+      } catch (err) {
         return print(`dag get failed: ${err.message}`)
       }
 
@@ -56,6 +60,6 @@ module.exports = {
       } else {
         print(node)
       }
-    })
+    })())
   }
 }

--- a/src/cli/commands/dns.js
+++ b/src/cli/commands/dns.js
@@ -12,13 +12,10 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, domain }) {
-    ipfs.dns(domain, (err, path) => {
-      if (err) {
-        throw err
-      }
-
+  handler ({ ipfs, domain, resolve }) {
+    resolve((async () => {
+      const path = await ipfs.dns(domain)
       print(path)
-    })
+    })())
   }
 }

--- a/src/cli/commands/file/ls.js
+++ b/src/cli/commands/file/ls.js
@@ -10,13 +10,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    let path = argv.key
-    // `ipfs file ls` is deprecated. See https://ipfs.io/docs/commands/#ipfs-file-ls
-    print(`This functionality is deprecated, and will be removed in future versions. If possible, please use 'ipfs ls' instead.`)
-    argv.ipfs.ls(path, (err, links) => {
-      if (err) {
-        throw err
-      }
+    argv.resolve((async () => {
+      const path = argv.key
+      // `ipfs file ls` is deprecated. See https://ipfs.io/docs/commands/#ipfs-file-ls
+      print(`This functionality is deprecated, and will be removed in future versions. If possible, please use 'ipfs ls' instead.`)
+
+      let links = await argv.ipfs.ls(path)
 
       // Single file? Then print its hash
       if (links.length === 0) {
@@ -24,6 +23,6 @@ module.exports = {
       }
 
       links.forEach((file) => print(file.hash))
-    })
+    })())
   }
 }

--- a/src/cli/commands/get.js
+++ b/src/cli/commands/get.js
@@ -58,20 +58,20 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, ipfsPath, output }) {
-    const dir = checkArgs(ipfsPath, output)
-    const stream = ipfs.getReadableStream(ipfsPath)
+  handler ({ ipfs, ipfsPath, output, resolve }) {
+    resolve(new Promise((resolve, reject) => {
+      const dir = checkArgs(ipfsPath, output)
+      const stream = ipfs.getReadableStream(ipfsPath)
 
-    stream.once('error', (err) => {
-      if (err) { throw err }
-    })
-    print(`Saving file(s) ${ipfsPath}`)
-    pull(
-      toPull.source(stream),
-      pull.asyncMap(fileHandler(dir)),
-      pull.onEnd((err) => {
-        if (err) { throw err }
-      })
-    )
+      print(`Saving file(s) ${ipfsPath}`)
+      pull(
+        toPull.source(stream),
+        pull.asyncMap(fileHandler(dir)),
+        pull.onEnd((err) => {
+          if (err) return reject(err)
+          resolve()
+        })
+      )
+    }))
   }
 }

--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -14,13 +14,9 @@ module.exports = {
   },
 
   handler (argv) {
-    // TODO: handle argv.format
-    argv.ipfs.id((err, id) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const id = await argv.ipfs.id()
       print(JSON.stringify(id, '', 2))
-    })
+    })())
   }
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -32,34 +32,36 @@ module.exports = {
   },
 
   handler (argv) {
-    const path = utils.getRepoPath()
+    argv.resolve((async () => {
+      const path = utils.getRepoPath()
 
-    print(`initializing ipfs node at ${path}`)
+      print(`initializing ipfs node at ${path}`)
 
-    // Required inline to reduce startup time
-    const IPFS = require('../../core')
-    const Repo = require('ipfs-repo')
+      // Required inline to reduce startup time
+      const IPFS = require('../../core')
+      const Repo = require('ipfs-repo')
 
-    const node = new IPFS({
-      repo: new Repo(path),
-      init: false,
-      start: false,
-      config: argv.config || {}
-    })
+      const node = new IPFS({
+        repo: new Repo(path),
+        init: false,
+        start: false,
+        config: argv.config || {}
+      })
 
-    node.init({
-      bits: argv.bits,
-      privateKey: argv.privateKey,
-      emptyRepo: argv.emptyRepo,
-      pass: argv.pass,
-      log: print
-    }, (err) => {
-      if (err) {
+      try {
+        await node.init({
+          bits: argv.bits,
+          privateKey: argv.privateKey,
+          emptyRepo: argv.emptyRepo,
+          pass: argv.pass,
+          log: print
+        })
+      } catch (err) {
         if (err.code === 'EACCES') {
           err.message = `EACCES: permission denied, stat $IPFS_PATH/version`
         }
         throw err
       }
-    })
+    })())
   }
 }

--- a/src/cli/commands/key/export.js
+++ b/src/cli/commands/key/export.js
@@ -23,15 +23,13 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.key.export(argv.name, argv.passout, (err, pem) => {
-      if (err) {
-        throw err
-      }
+    argv.resolve((async () => {
+      const pem = await argv.ipfs.key.export(argv.name, argv.passout)
       if (argv.output === 'stdout') {
         process.stdout.write(pem)
       } else {
         fs.writeFileSync(argv.output, pem)
       }
-    })
+    })())
   }
 }

--- a/src/cli/commands/key/gen.js
+++ b/src/cli/commands/key/gen.js
@@ -22,15 +22,13 @@ module.exports = {
   },
 
   handler (argv) {
-    const opts = {
-      type: argv.type,
-      size: argv.size
-    }
-    argv.ipfs.key.gen(argv.name, opts, (err, key) => {
-      if (err) {
-        throw err
+    argv.resolve((async () => {
+      const opts = {
+        type: argv.type,
+        size: argv.size
       }
+      const key = await argv.ipfs.key.gen(argv.name, opts)
       print(`generated ${key.id} ${key.name}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/key/import.js
+++ b/src/cli/commands/key/import.js
@@ -24,11 +24,9 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.key.import(argv.name, argv.input, argv.passin, (err, key) => {
-      if (err) {
-        throw err
-      }
+    argv.resolve((async () => {
+      const key = await argv.ipfs.key.import(argv.name, argv.input, argv.passin)
       print(`imported ${key.id} ${key.name}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/key/list.js
+++ b/src/cli/commands/key/list.js
@@ -10,11 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.key.list((err, keys) => {
-      if (err) {
-        throw err
-      }
+    argv.resolve((async () => {
+      const keys = await argv.ipfs.key.list()
       keys.forEach((ki) => print(`${ki.id} ${ki.name}`))
-    })
+    })())
   }
 }

--- a/src/cli/commands/key/rename.js
+++ b/src/cli/commands/key/rename.js
@@ -10,11 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.key.rename(argv.name, argv.newName, (err, res) => {
-      if (err) {
-        throw err
-      }
+    argv.resolve((async () => {
+      const res = await argv.ipfs.key.rename(argv.name, argv.newName)
       print(`renamed to ${res.id} ${res.now}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/key/rm.js
+++ b/src/cli/commands/key/rm.js
@@ -10,11 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.key.rm(argv.name, (err, key) => {
-      if (err) {
-        throw err
-      }
+    argv.resolve((async () => {
+      const key = await argv.ipfs.key.rm(argv.name)
       print(`${key.id} ${key.name}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/ls.js
+++ b/src/cli/commands/ls.js
@@ -34,11 +34,9 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, key, recursive, headers, cidBase }) {
-    ipfs.ls(key, { recursive }, (err, links) => {
-      if (err) {
-        throw err
-      }
+  handler ({ ipfs, key, recursive, headers, cidBase, resolve }) {
+    resolve((async () => {
+      let links = await ipfs.ls(key, { recursive })
 
       links = links.map(file => Object.assign(file, { hash: cidToString(file.hash, { base: cidBase }) }))
 
@@ -64,6 +62,6 @@ module.exports = {
           '  '.repeat(padding) + fileName
         )
       })
-    })
+    })())
   }
 }

--- a/src/cli/commands/name/publish.js
+++ b/src/cli/commands/name/publish.js
@@ -30,27 +30,24 @@ module.exports = {
   },
 
   handler (argv) {
-    // yargs-promise adds resolve/reject properties to argv
-    // resolve should use the alias as resolve will always be overwritten to a function
-    let resolve = true
+    argv.resolve((async () => {
+      // yargs-promise adds resolve/reject properties to argv
+      // resolve should use the alias as resolve will always be overwritten to a function
+      let resolve = true
 
-    if (argv.r === false || argv.r === 'false') {
-      resolve = false
-    }
-
-    const opts = {
-      resolve,
-      lifetime: argv.lifetime,
-      key: argv.key,
-      ttl: argv.ttl
-    }
-
-    argv.ipfs.name.publish(argv.ipfsPath, opts, (err, result) => {
-      if (err) {
-        throw err
+      if (argv.r === false || argv.r === 'false') {
+        resolve = false
       }
 
+      const opts = {
+        resolve,
+        lifetime: argv.lifetime,
+        key: argv.key,
+        ttl: argv.ttl
+      }
+
+      const result = await argv.ipfs.name.publish(argv.ipfsPath, opts)
       print(`Published to ${result.name}: ${result.value}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/name/pubsub/cancel.js
+++ b/src/cli/commands/name/pubsub/cancel.js
@@ -8,12 +8,9 @@ module.exports = {
   describe: 'Cancel a name subscription.',
 
   handler (argv) {
-    argv.ipfs.name.pubsub.cancel(argv.name, (err, result) => {
-      if (err) {
-        throw err
-      } else {
-        print(result.canceled ? 'canceled' : 'no subscription')
-      }
-    })
+    argv.resolve((async () => {
+      const result = await argv.ipfs.name.pubsub.cancel(argv.name)
+      print(result.canceled ? 'canceled' : 'no subscription')
+    })())
   }
 }

--- a/src/cli/commands/name/pubsub/state.js
+++ b/src/cli/commands/name/pubsub/state.js
@@ -8,12 +8,9 @@ module.exports = {
   describe: 'Query the state of IPNS pubsub.',
 
   handler (argv) {
-    argv.ipfs.name.pubsub.state((err, result) => {
-      if (err) {
-        throw err
-      } else {
-        print(result.enabled ? 'enabled' : 'disabled')
-      }
-    })
+    argv.resolve((async () => {
+      const result = await argv.ipfs.name.pubsub.state()
+      print(result.enabled ? 'enabled' : 'disabled')
+    })())
   }
 }

--- a/src/cli/commands/name/pubsub/subs.js
+++ b/src/cli/commands/name/pubsub/subs.js
@@ -8,14 +8,9 @@ module.exports = {
   describe: 'Show current name subscriptions.',
 
   handler (argv) {
-    argv.ipfs.name.pubsub.subs((err, result) => {
-      if (err) {
-        throw err
-      } else {
-        result.forEach((s) => {
-          print(s)
-        })
-      }
-    })
+    argv.resolve((async () => {
+      const result = await argv.ipfs.name.pubsub.subs()
+      result.forEach(s => print(s))
+    })())
   }
 }

--- a/src/cli/commands/name/resolve.js
+++ b/src/cli/commands/name/resolve.js
@@ -21,21 +21,19 @@ module.exports = {
   },
 
   handler (argv) {
-    const opts = {
-      nocache: argv.nocache,
-      recursive: argv.recursive
-    }
-
-    argv.ipfs.name.resolve(argv.name, opts, (err, result) => {
-      if (err) {
-        throw err
+    argv.resolve((async () => {
+      const opts = {
+        nocache: argv.nocache,
+        recursive: argv.recursive
       }
+
+      const result = await argv.ipfs.name.resolve(argv.name, opts)
 
       if (result && result.path) {
         print(result.path)
       } else {
         print(result)
       }
-    })
+    })())
   }
 }

--- a/src/cli/commands/object/data.js
+++ b/src/cli/commands/object/data.js
@@ -10,14 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.object.data(argv.key, {
-      enc: 'base58'
-    }, (err, data) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const data = await argv.ipfs.object.data(argv.key, { enc: 'base58' })
       print(data, false)
-    })
+    })())
   }
 }

--- a/src/cli/commands/object/get.js
+++ b/src/cli/commands/object/get.js
@@ -21,12 +21,9 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, key, dataEncoding, cidBase }) {
-    ipfs.object.get(key, { enc: 'base58' }, (err, node) => {
-      if (err) {
-        throw err
-      }
-
+  handler ({ ipfs, key, dataEncoding, cidBase, resolve }) {
+    resolve((async () => {
+      const node = await ipfs.object.get(key, { enc: 'base58' })
       let data = node.data
 
       if (Buffer.isBuffer(data)) {
@@ -47,6 +44,6 @@ module.exports = {
       }
 
       print(JSON.stringify(answer))
-    })
+    })())
   }
 }

--- a/src/cli/commands/object/links.js
+++ b/src/cli/commands/object/links.js
@@ -17,15 +17,14 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, key, cidBase }) {
-    ipfs.object.links(key, { enc: 'base58' }, (err, links) => {
-      if (err) {
-        throw err
-      }
+  handler ({ ipfs, key, cidBase, resolve }) {
+    resolve((async () => {
+      const links = await ipfs.object.links(key, { enc: 'base58' })
 
       links.forEach((link) => {
-        print(`${cidToString(link.cid, { base: cidBase, upgrade: false })} ${link.size} ${link.name}`)
+        const cidStr = cidToString(link.cid, { base: cidBase, upgrade: false })
+        print(`${cidStr} ${link.size} ${link.name}`)
       })
-    })
+    })())
   }
 }

--- a/src/cli/commands/object/new.js
+++ b/src/cli/commands/object/new.js
@@ -17,13 +17,10 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, template, cidBase }) {
-    ipfs.object.new(template, (err, cid) => {
-      if (err) {
-        throw err
-      }
-
+  handler ({ ipfs, template, cidBase, resolve }) {
+    resolve((async () => {
+      const cid = await ipfs.object.new(template)
       print(cidToString(cid, { base: cidBase, upgrade: false }))
-    })
+    })())
   }
 }

--- a/src/cli/commands/object/patch/append-data.js
+++ b/src/cli/commands/object/patch/append-data.js
@@ -6,18 +6,6 @@ const multibase = require('multibase')
 const { print } = require('../../../utils')
 const { cidToString } = require('../../../../utils/cid')
 
-function appendData (key, data, ipfs, options) {
-  ipfs.object.patch.appendData(key, data, {
-    enc: 'base58'
-  }, (err, cid) => {
-    if (err) {
-      throw err
-    }
-
-    print(cidToString(cid, { base: options.cidBase, upgrade: false }))
-  })
-}
-
 module.exports = {
   command: 'append-data <root> [data]',
 
@@ -32,17 +20,25 @@ module.exports = {
   },
 
   handler (argv) {
-    const ipfs = argv.ipfs
-    if (argv.data) {
-      return appendData(argv.root, fs.readFileSync(argv.data), ipfs, argv)
-    }
+    argv.resolve((async () => {
+      let data
 
-    process.stdin.pipe(bl((err, input) => {
-      if (err) {
-        throw err
+      if (argv.data) {
+        data = fs.readFileSync(argv.data)
+      } else {
+        data = await new Promise((resolve, reject) => {
+          process.stdin.pipe(bl((err, input) => {
+            if (err) return reject(err)
+            resolve(input)
+          }))
+        })
       }
 
-      appendData(argv.root, input, ipfs, argv)
-    }))
+      const cid = await argv.ipfs.object.patch.appendData(argv.root, data, {
+        enc: 'base58'
+      })
+
+      print(cidToString(cid, { base: argv.cidBase, upgrade: false }))
+    })())
   }
 }

--- a/src/cli/commands/object/patch/rm-link.js
+++ b/src/cli/commands/object/patch/rm-link.js
@@ -17,15 +17,13 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, root, link, cidBase }) {
-    ipfs.object.patch.rmLink(root, { name: link }, {
-      enc: 'base58'
-    }, (err, cid) => {
-      if (err) {
-        throw err
-      }
+  handler ({ ipfs, root, link, cidBase, resolve }) {
+    resolve((async () => {
+      const cid = await ipfs.object.patch.rmLink(root, { name: link }, {
+        enc: 'base58'
+      })
 
       print(cidToString(cid, { base: cidBase, upgrade: false }))
-    })
+    })())
   }
 }

--- a/src/cli/commands/object/stat.js
+++ b/src/cli/commands/object/stat.js
@@ -9,17 +9,11 @@ module.exports = {
 
   builder: {},
 
-  handler ({ ipfs, key, cidBase }) {
-    ipfs.object.stat(key, { enc: 'base58' }, (err, stats) => {
-      if (err) {
-        throw err
-      }
-
+  handler ({ ipfs, key, cidBase, resolve }) {
+    resolve((async () => {
+      const stats = await ipfs.object.stat(key, { enc: 'base58' })
       delete stats.Hash // only for js-ipfs-http-client output
-
-      Object.keys(stats).forEach((key) => {
-        print(`${key}: ${stats[key]}`)
-      })
-    })
+      Object.keys(stats).forEach((key) => print(`${key}: ${stats[key]}`))
+    })())
   }
 }

--- a/src/cli/commands/pin/add.js
+++ b/src/cli/commands/pin/add.js
@@ -23,14 +23,13 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, ipfsPath, recursive, cidBase }) {
-    const type = recursive ? 'recursive' : 'direct'
-
-    ipfs.pin.add(ipfsPath, { recursive }, (err, results) => {
-      if (err) { throw err }
+  handler ({ ipfs, ipfsPath, recursive, cidBase, resolve }) {
+    resolve((async () => {
+      const type = recursive ? 'recursive' : 'direct'
+      const results = await ipfs.pin.add(ipfsPath, { recursive })
       results.forEach((res) => {
         print(`pinned ${cidToString(res.hash, { base: cidBase })} ${type}ly`)
       })
-    })
+    })())
   }
 }

--- a/src/cli/commands/pin/ls.js
+++ b/src/cli/commands/pin/ls.js
@@ -31,11 +31,10 @@ module.exports = {
     }
   },
 
-  handler: ({ ipfs, ipfsPath, type, quiet, cidBase }) => {
-    const paths = ipfsPath
-
-    ipfs.pin.ls(paths, { type }, (err, results) => {
-      if (err) { throw err }
+  handler: ({ ipfs, ipfsPath, type, quiet, cidBase, resolve }) => {
+    resolve((async () => {
+      const paths = ipfsPath
+      const results = await ipfs.pin.ls(paths, { type })
       results.forEach((res) => {
         let line = cidToString(res.hash, { base: cidBase })
         if (!quiet) {
@@ -43,6 +42,6 @@ module.exports = {
         }
         print(line)
       })
-    })
+    })())
   }
 }

--- a/src/cli/commands/pin/rm.js
+++ b/src/cli/commands/pin/rm.js
@@ -23,12 +23,12 @@ module.exports = {
     }
   },
 
-  handler: ({ ipfs, ipfsPath, recursive, cidBase }) => {
-    ipfs.pin.rm(ipfsPath, { recursive }, (err, results) => {
-      if (err) { throw err }
+  handler: ({ ipfs, ipfsPath, recursive, cidBase, resolve }) => {
+    resolve((async () => {
+      const results = await ipfs.pin.rm(ipfsPath, { recursive })
       results.forEach((res) => {
         print(`unpinned ${cidToString(res.hash, { base: cidBase })}`)
       })
-    })
+    })())
   }
 }

--- a/src/cli/commands/ping.js
+++ b/src/cli/commands/ping.js
@@ -17,19 +17,24 @@ module.exports = {
   },
 
   handler (argv) {
-    const peerId = argv.peerId
-    const count = argv.count || 10
-    pull(
-      argv.ipfs.pingPullStream(peerId, { count }),
-      pull.drain(({ success, time, text }) => {
-        // Check if it's a pong
-        if (success && !text) {
-          print(`Pong received: time=${time} ms`)
-        // Status response
-        } else {
-          print(text)
-        }
-      })
-    )
+    argv.resolve(new Promise((resolve, reject) => {
+      const peerId = argv.peerId
+      const count = argv.count || 10
+      pull(
+        argv.ipfs.pingPullStream(peerId, { count }),
+        pull.drain(({ success, time, text }) => {
+          // Check if it's a pong
+          if (success && !text) {
+            print(`Pong received: time=${time} ms`)
+          // Status response
+          } else {
+            print(text)
+          }
+        }, err => {
+          if (err) return reject(err)
+          resolve()
+        })
+      )
+    }))
   }
 }

--- a/src/cli/commands/pubsub/ls.js
+++ b/src/cli/commands/pubsub/ls.js
@@ -10,14 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.pubsub.ls((err, subscriptions) => {
-      if (err) {
-        throw err
-      }
-
-      subscriptions.forEach((sub) => {
-        print(sub)
-      })
-    })
+    argv.resolve((async () => {
+      const subscriptions = await argv.ipfs.pubsub.ls()
+      subscriptions.forEach(sub => print(sub))
+    })())
   }
 }

--- a/src/cli/commands/pubsub/peers.js
+++ b/src/cli/commands/pubsub/peers.js
@@ -10,12 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.pubsub.peers(argv.topic, (err, peers) => {
-      if (err) {
-        throw err
-      }
-
-      peers.forEach((peer) => print(peer))
-    })
+    argv.resolve((async () => {
+      const peers = await argv.ipfs.pubsub.peers(argv.topic)
+      peers.forEach(peer => print(peer))
+    })())
   }
 }

--- a/src/cli/commands/pubsub/pub.js
+++ b/src/cli/commands/pubsub/pub.js
@@ -8,12 +8,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    const data = Buffer.from(String(argv.data))
-
-    argv.ipfs.pubsub.publish(argv.topic, data, (err) => {
-      if (err) {
-        throw err
-      }
-    })
+    argv.resolve((async () => {
+      const data = Buffer.from(String(argv.data))
+      await argv.ipfs.pubsub.publish(argv.topic, data)
+    })())
   }
 }

--- a/src/cli/commands/pubsub/sub.js
+++ b/src/cli/commands/pubsub/sub.js
@@ -10,14 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    const handler = (msg) => {
-      print(msg.data.toString())
-    }
-
-    argv.ipfs.pubsub.subscribe(argv.topic, handler, (err) => {
-      if (err) {
-        throw err
-      }
-    })
+    argv.resolve((async () => {
+      const handler = msg => print(msg.data.toString())
+      await argv.ipfs.pubsub.subscribe(argv.topic, handler)
+    })())
   }
 }

--- a/src/cli/commands/repo/gc.js
+++ b/src/cli/commands/repo/gc.js
@@ -8,10 +8,8 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.repo.gc((err) => {
-      if (err) {
-        throw err
-      }
-    })
+    argv.resolve((async () => {
+      await argv.ipfs.repo.gc()
+    })())
   }
 }

--- a/src/cli/commands/repo/stat.js
+++ b/src/cli/commands/repo/stat.js
@@ -15,17 +15,14 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.repo.stat({ human: argv.human }, (err, stats) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const stats = await argv.ipfs.repo.stat({ human: argv.human })
       print(`repo status
   number of objects: ${stats.numObjects}
   repo size: ${stats.repoSize}
   repo path: ${stats.repoPath}
   version: ${stats.version}
   maximum storage: ${stats.storageMax}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/repo/version.js
+++ b/src/cli/commands/repo/version.js
@@ -10,12 +10,9 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.repo.version((err, version) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const version = await argv.ipfs.repo.version()
       print(version)
-    })
+    })())
   }
 }

--- a/src/cli/commands/resolve.js
+++ b/src/cli/commands/resolve.js
@@ -21,11 +21,10 @@ module.exports = {
     }
   },
 
-  handler (argv) {
-    const { recursive, cidBase } = argv
-    argv.ipfs.resolve(argv.name, { recursive, cidBase }, (err, res) => {
-      if (err) throw err
+  handler ({ ipfs, name, recursive, cidBase, resolve }) {
+    resolve((async () => {
+      const res = await ipfs.resolve(name, { recursive, cidBase })
       print(res)
-    })
+    })())
   }
 }

--- a/src/cli/commands/shutdown.js
+++ b/src/cli/commands/shutdown.js
@@ -8,10 +8,6 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    argv.ipfs.shutdown((err) => {
-      if (err) {
-        throw err
-      }
-    })
+    argv.resolve(argv.ipfs.shutdown())
   }
 }

--- a/src/cli/commands/stats/bw.js
+++ b/src/cli/commands/stats/bw.js
@@ -27,18 +27,24 @@ module.exports = {
     }
   },
 
-  handler ({ ipfs, peer, proto, poll, interval }) {
-    const stream = ipfs.stats.bwPullStream({ peer, proto, poll, interval })
+  handler ({ ipfs, peer, proto, poll, interval, resolve }) {
+    resolve(new Promise((resolve, reject) => {
+      const stream = ipfs.stats.bwPullStream({ peer, proto, poll, interval })
 
-    pull(
-      stream,
-      pull.drain((chunk) => {
+      const onChunk = chunk => {
         print(`bandwidth status
   total in: ${chunk.totalIn}B
   total out: ${chunk.totalOut}B
   rate in: ${chunk.rateIn}B/s
   rate out: ${chunk.rateOut}B/s`)
-      })
-    )
+      }
+
+      const onEnd = err => {
+        if (err) return reject(err)
+        resolve()
+      }
+
+      pull(stream, pull.drain(onChunk, onEnd))
+    }))
   }
 }

--- a/src/cli/commands/stats/repo.js
+++ b/src/cli/commands/stats/repo.js
@@ -15,17 +15,14 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.stats.repo({ human: argv.human }, (err, stats) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const stats = await argv.ipfs.stats.repo({ human: argv.human })
       print(`repo status
   number of objects: ${stats.numObjects}
   repo size: ${stats.repoSize}
   repo path: ${stats.repoPath}
   version: ${stats.version}
   maximum storage: ${stats.storageMax}`)
-    })
+    })())
   }
 }

--- a/src/cli/commands/swarm/addrs.js
+++ b/src/cli/commands/swarm/addrs.js
@@ -13,11 +13,8 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.swarm.addrs((err, res) => {
-      if (err) {
-        throw err
-      }
-
+    argv.resolve((async () => {
+      const res = await argv.ipfs.swarm.addrs()
       res.forEach((peer) => {
         const count = peer.multiaddrs.size
         print(`${peer.id.toB58String()} (${count})`)
@@ -27,6 +24,6 @@ module.exports = {
           print(`\t${res}`)
         })
       })
-    })
+    })())
   }
 }

--- a/src/cli/commands/swarm/addrs/local.js
+++ b/src/cli/commands/swarm/addrs/local.js
@@ -14,18 +14,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    if (!utils.isDaemonOn()) {
-      throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
-    }
-
-    argv.ipfs.swarm.localAddrs((err, res) => {
-      if (err) {
-        throw err
+    argv.resolve((async () => {
+      if (!utils.isDaemonOn()) {
+        throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
-
-      res.forEach((addr) => {
-        print(addr.toString())
-      })
-    })
+      const res = await argv.ipfs.swarm.localAddrs()
+      res.forEach(addr => print(addr.toString()))
+    })())
   }
 }

--- a/src/cli/commands/swarm/connect.js
+++ b/src/cli/commands/swarm/connect.js
@@ -11,16 +11,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    if (!utils.isDaemonOn()) {
-      throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
-    }
-
-    argv.ipfs.swarm.connect(argv.address, (err, res) => {
-      if (err) {
-        throw err
+    argv.resolve((async () => {
+      if (!utils.isDaemonOn()) {
+        throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
-
+      const res = await argv.ipfs.swarm.connect(argv.address)
       print(res.Strings[0])
-    })
+    })())
   }
 }

--- a/src/cli/commands/swarm/disconnect.js
+++ b/src/cli/commands/swarm/disconnect.js
@@ -11,16 +11,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    if (!utils.isDaemonOn()) {
-      throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
-    }
-
-    argv.ipfs.swarm.disconnect(argv.address, (err, res) => {
-      if (err) {
-        throw err
+    argv.resolve((async () => {
+      if (!utils.isDaemonOn()) {
+        throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
-
+      const res = await argv.ipfs.swarm.disconnect(argv.address)
       print(res.Strings[0])
-    })
+    })())
   }
 }

--- a/src/cli/commands/swarm/peers.js
+++ b/src/cli/commands/swarm/peers.js
@@ -13,14 +13,12 @@ module.exports = {
   builder: {},
 
   handler (argv) {
-    if (!utils.isDaemonOn()) {
-      throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
-    }
-
-    argv.ipfs.swarm.peers((err, result) => {
-      if (err) {
-        throw err
+    argv.resolve((async () => {
+      if (!utils.isDaemonOn()) {
+        throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
+
+      const result = await argv.ipfs.swarm.peers()
 
       result.forEach((item) => {
         let ma = multiaddr(item.addr.toString())
@@ -30,6 +28,6 @@ module.exports = {
         const addr = ma.toString()
         print(addr)
       })
-    })
+    })())
   }
 }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -33,10 +33,8 @@ module.exports = {
   },
 
   handler (argv) {
-    argv.ipfs.version((err, data) => {
-      if (err) {
-        throw err
-      }
+    argv.resolve((async () => {
+      const data = await argv.ipfs.version()
 
       const withCommit = argv.all || argv.commit
       const parsedVersion = `${data.version}${withCommit ? `-${data.commit}` : ''}`
@@ -54,6 +52,6 @@ module.exports = {
       } else {
         print(`js-ipfs version: ${parsedVersion}`)
       }
-    })
+    })())
   }
 }


### PR DESCRIPTION
[`cleanup`](https://github.com/ipfs/js-ipfs/blob/7d9b006d0b0542651cbaa540d5f22a0112ae09bd/src/cli/bin.js#L109) closes the DB but `yargs-promise` does not wait for async stuff in the command handler to finish, and executes that promise chain immediately after the handler is executed. So it's a race condition. In windows, _sometimes_, the database is closed before the async stuff from the handler completes.

This PR changes the CLI command handlers to always pass a promise to `resolve` function that `yargs-promise` adds to the context (`argv`). This makes `yargs-promise` wait for it to be resolved before continuing the promise chain and closing the DB.

Since I had to edit all of the commands to make them use the `resolve` function and introduce promises, I decided to take the opportunity to refactor the CLI commands to use async/await. It should help towards https://github.com/ipfs/js-ipfs/issues/1670.

Also, w00t! - removed almost 200 LOC