### PR TITLE
feat: exit command line tool on unhandled Promise rejections

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -17,6 +17,12 @@ updateNotifier({
   updateCheckInterval: 1000 * 60 * 60 * 24 * 7 // 1 week
 }).notify()
 
+// Exit if there were undhandled Promise rejections
+process.on('unhandledRejection', (error) => {
+  print(error.message)
+  process.exit(1)
+})
+
 const args = process.argv.slice(2)
 
 const cli = yargs


### PR DESCRIPTION
Currently the code base is slowly switching from callback style to
async/await. This means that there are more cases where there are
unhandled Promise rejections, sometime they even can't easilt be
prevented.

The command line interface now exits just like there was a normal
exception.