### PR TITLE
feat: support _dnslink subdomain specified dnslinks

### DIFF
--- a/src/core/runtime/dns-nodejs.js
+++ b/src/core/runtime/dns-nodejs.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const dns = require('dns')
-const _ = require('lodash');
+const _ = require('lodash')
 
 module.exports = (domain, opts, callback) => {
   resolveDnslink(domain)
@@ -16,7 +16,7 @@ module.exports = (domain, opts, callback) => {
         return resolveDnslink(rootDomain)
       }
       // Check the _dnslink subdomain
-      const _dnslinkDomain = `_dnslink.${domain}`;
+      const _dnslinkDomain = `_dnslink.${domain}`
       // If this throws then we propagate the error
       return resolveDnslink(_dnslinkDomain)
     })
@@ -26,9 +26,9 @@ module.exports = (domain, opts, callback) => {
     .catch(callback)
 }
 
-function resolveDnslink(domain) {
+function resolveDnslink (domain) {
   const DNSLINK_REGEX = /^dnslink=.+$/
-  return new Promise( (resolve, reject) => {
+  return new Promise((resolve, reject) => {
     dns.resolveTxt(domain, (err, records) => {
       if (err) return reject(err)
       resolve(records)

--- a/src/core/runtime/dns-nodejs.js
+++ b/src/core/runtime/dns-nodejs.js
@@ -2,12 +2,13 @@
 
 const dns = require('dns')
 const _ = require('lodash')
+const errcode = require('err-code')
 
 module.exports = (domain, opts, callback) => {
   resolveDnslink(domain)
     .catch(err => {
-      // If the code is not ENOTFOUND then throw the error
-      if (err.code !== 'ENOTFOUND') throw err
+      // If the code is not ENOTFOUND or ERR_DNSLINK_NOT_FOUND then throw the error
+      if (err.code !== 'ENOTFOUND' && err.code !== 'ERR_DNSLINK_NOT_FOUND') throw err
 
       if (domain.startsWith('_dnslink.')) {
         // The supplied domain contains a _dnslink component
@@ -43,9 +44,7 @@ function resolveDnslink (domain) {
       // we now have dns text entries as an array of strings
       // only records passing the DNSLINK_REGEX text are included
       if (dnslinkRecords.length === 0) {
-        const err = new Error(`No dnslink records found for domain: ${domain}`)
-        err.code = 'ENOTFOUND'
-        throw err
+        throw errcode(`No dnslink records found for domain: ${domain}`, 'ERR_DNSLINK_NOT_FOUND')
       }
       return dnslinkRecords[0]
     })

--- a/src/core/runtime/dns-nodejs.js
+++ b/src/core/runtime/dns-nodejs.js
@@ -3,19 +3,58 @@
 const dns = require('dns')
 
 module.exports = (domain, opts, callback) => {
-  dns.resolveTxt(domain, (err, records) => {
-    if (err) {
-      return callback(err, null)
-    }
+  resolveDnslink(domain)
+    .catch(err => {
+      // If the code is not ENOTFOUND the throw the error
+      if (err.code !== 'ENOTFOUND') throw err
 
-    // TODO: implement recursive option
-
-    for (const record of records) {
-      if (record[0].startsWith('dnslink=')) {
-        return callback(null, record[0].substr(8, record[0].length - 1))
+      if (domain.indexOf('_dnslink') === -1) {
+        // Check the _dnslink subdomain
+        const _dnslinkDomain = ['_dnslink', ...domain.split('.')].join('.')
+        // If this throws then we propagate the error
+        return resolveDnslink(_dnslinkDomain)
+      } else if (domain.split('.').indexOf('_dnslink') === 0) {
+        // The supplied domain contains a _dnslink component
+        // Check the non-_dnslink domain
+        const rootDomain = domain.split('.').slice(1).join('.')
+        return resolveDnslink(rootDomain)
       }
-    }
+      throw err
+    })
+    .then(dnslinkRecord => {
+      callback(null, dnslinkRecord.substr(8, dnslinkRecord.length - 1))
+    })
+    .catch(callback)
+}
 
-    callback(new Error('domain does not have a txt dnslink entry'))
+function resolveDnslink(domain) {
+  const DNSLINK_REGEX = /^dnslink=.+$/
+  return new Promise((resolve, reject) => {
+    dns.resolveTxt(domain, (err, records) => {
+      if (err) return reject(err)
+      resolve(records)
+    })
   })
+    .then(records => {
+      // records is an array of arrays of strings
+      // the below expression flattens it into an array of strings
+      const flatRecords = [].concat(...records)
+      return flatRecords.filter(record => {
+        return DNSLINK_REGEX.test(record)
+      })
+    })
+    .then(dnslinkRecords => {
+      // we now have dns text entries as an array of strings
+      // only records passing the DNSLINK_REGEX text are included
+      if (dnslinkRecords > 1) {
+        const err = new Error(`Multiple dnslink records found for domain: ${domain}`)
+        err.code = 'EMULTFOUND'
+        throw err
+      } else if (dnslinkRecords.length === 0) {
+        const err = new Error(`No dnslink records found for domain: ${domain}`)
+        err.code = 'ENOTFOUND'
+        throw err
+      }
+      return dnslinkRecords[0]
+    })
 }

--- a/src/core/runtime/dns-nodejs.js
+++ b/src/core/runtime/dns-nodejs.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const dns = require('dns')
+const _ = require('lodash');
 
 module.exports = (domain, opts, callback) => {
   resolveDnslink(domain)
@@ -8,49 +9,40 @@ module.exports = (domain, opts, callback) => {
       // If the code is not ENOTFOUND then throw the error
       if (err.code !== 'ENOTFOUND') throw err
 
-      if (domain.indexOf('_dnslink') === -1) {
-        // Check the _dnslink subdomain
-        const _dnslinkDomain = ['_dnslink', ...domain.split('.')].join('.')
-        // If this throws then we propagate the error
-        return resolveDnslink(_dnslinkDomain)
-      } else if (domain.split('.').indexOf('_dnslink') === 0) {
+      if (domain.startsWith('_dnslink.')) {
         // The supplied domain contains a _dnslink component
         // Check the non-_dnslink domain
-        const rootDomain = domain.split('.').slice(1).join('.')
+        const rootDomain = domain.replace('_dnslink.', '')
         return resolveDnslink(rootDomain)
       }
-      throw err
+      // Check the _dnslink subdomain
+      const _dnslinkDomain = `_dnslink.${domain}`;
+      // If this throws then we propagate the error
+      return resolveDnslink(_dnslinkDomain)
     })
     .then(dnslinkRecord => {
-      callback(null, dnslinkRecord.substr(8, dnslinkRecord.length - 1))
+      callback(null, dnslinkRecord.replace('dnslink=', ''))
     })
     .catch(callback)
 }
 
 function resolveDnslink(domain) {
   const DNSLINK_REGEX = /^dnslink=.+$/
-  return new Promise((resolve, reject) => {
+  return new Promise( (resolve, reject) => {
     dns.resolveTxt(domain, (err, records) => {
       if (err) return reject(err)
       resolve(records)
     })
   })
     .then(records => {
-      // records is an array of arrays of strings
-      // the below expression flattens it into an array of strings
-      const flatRecords = [].concat(...records)
-      return flatRecords.filter(record => {
+      return _.chain(records).flatten().filter(record => {
         return DNSLINK_REGEX.test(record)
-      })
+      }).value()
     })
     .then(dnslinkRecords => {
       // we now have dns text entries as an array of strings
       // only records passing the DNSLINK_REGEX text are included
-      if (dnslinkRecords > 1) {
-        const err = new Error(`Multiple dnslink records found for domain: ${domain}`)
-        err.code = 'EMULTFOUND'
-        throw err
-      } else if (dnslinkRecords.length === 0) {
+      if (dnslinkRecords.length === 0) {
         const err = new Error(`No dnslink records found for domain: ${domain}`)
         err.code = 'ENOTFOUND'
         throw err

--- a/src/core/runtime/dns-nodejs.js
+++ b/src/core/runtime/dns-nodejs.js
@@ -5,7 +5,7 @@ const dns = require('dns')
 module.exports = (domain, opts, callback) => {
   resolveDnslink(domain)
     .catch(err => {
-      // If the code is not ENOTFOUND the throw the error
+      // If the code is not ENOTFOUND then throw the error
       if (err.code !== 'ENOTFOUND') throw err
 
       if (domain.indexOf('_dnslink') === -1) {

--- a/test/cli/dns.js
+++ b/test/cli/dns.js
@@ -19,4 +19,12 @@ describe('dns', () => runOnAndOff((thing) => {
       expect(res.substr(0, 6)).to.eql('/ipns/')
     })
   })
+
+  it('resolve _dnslink.ipfs.io dns', function () {
+    this.timeout(60 * 1000)
+
+    return ipfs('dns _dnslink.ipfs.io').then((res) => {
+      expect(res.substr(0, 6)).to.eql('/ipns/')
+    })
+  })
 }))


### PR DESCRIPTION
Closes #1842

This includes resolution of `_dnslink` subdomains outward and inward. If the supplied domain is `_dnslink.domain.com` and resolution fails then `domain.com` will be checked (inward checking). If the supplied domain is `domain.com` and the resolution fails then `_dnslink.domain.com` will be checked (outward checking).

Inward checking is not specified in the dnslink spec, but seems like it may be useful.

### Tests

I added a test case for `_dnslink.ipfs.io` to ensure that inward resolution works. It probably makes sense to create a dns entry on the `ipfs.io` domain like `_dnslink.dnslink_test.ipfs.io` so a test can be added for `jsipfs dns dnslink_test.ipfs.io`.

The referenced issue contains commands with an example domain config for testing. I checked the go-ipfs test suite for guidance on testing but didn't find anything.