### PR TITLE
fix: print valid ipv6 multiaddrs in terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "mime-types": "^2.1.21",
     "mkdirp": "~0.5.1",
     "multiaddr": "^6.0.0",
-    "multiaddr-to-uri": "^4.0.0",
+    "multiaddr-to-uri": "^4.0.1",
     "multibase": "~0.6.0",
     "multihashes": "~0.4.14",
     "multihashing-async": "~0.5.1",
@@ -175,6 +175,7 @@
     "tar-stream": "^2.0.0",
     "temp": "~0.9.0",
     "update-notifier": "^2.5.0",
+    "uri-to-multiaddr": "^3.0.1",
     "varint": "^5.0.0",
     "yargs": "^12.0.5",
     "yargs-promise": "^1.1.0"


### PR DESCRIPTION
Fixes #1853
(easy enough to do it as a drive-by, let me know if I should rebase this after #1844  is merged)
 
Before:
```
API listening on /ip4//tcp/
Gateway (read only) listening on /ip4//tcp/
Web UI available at http://::1:5002/webui
```

After:
```
API listening on /ip6/::1/tcp/5002/http
Gateway (read only) listening on /ip6/::1/tcp/9090/http
Web UI available at http://[::1]:5002/webui
```

