### PR TITLE
fix: path to cid-tool commands

### DIFF
--- a/src/cli/commands/cid.js
+++ b/src/cli/commands/cid.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 const cidCommandsPath = path.join(
-  __dirname, '..', '..', '..', 'node_modules', 'cid-tool', 'src', 'cli', 'commands'
+  path.dirname(require.resolve('cid-tool')), 'cli', 'commands'
 )
 
 module.exports = {


### PR DESCRIPTION
In the edge case where IPFS is a dependency of a project and the user attempts to use the IPFS CLI, the `cid-tool` will not be installed at `proj/node_modules/ipfs/node_modules/cid-tool` but will instead be flattened by npm and installed at `proj/node_modules/cid-tool`. i.e. next to `ipfs` in the dependency tree instead of a child of.

This PR fixes this situation by using `require.resolve` to get the path to the `cid-tool` instead of assuming where it is installed.

FYI I found this bug while using the `ipfs cid base32` command with a JS IPFS installed with [`iim`](https://github.com/alanshaw/iim). I was getting the error:

```
$ ipfs cid base32 QmRgXEDv6DL8uchf7h9j8hAGG8Fq5r1UZ6Jy3TQAPxEb76
ENOENT: no such file or directory, scandir '/Users/alan/.iim/dists/js-ipfs@0.34.4/node_modules/ipfs/node_modules/cid-tool/src/cli/commands'
```

Which is correct, the `cid-tool` was actually installed at `/Users/alan/.iim/dists/js-ipfs@0.34.4/node_modules/cid-tool`.