### PR TITLE
fix: dht browser disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "joi": "^14.3.0",
     "joi-browser": "^13.4.0",
     "joi-multiaddr": "^4.0.0",
-    "libp2p": "~0.25.0-rc.0",
+    "libp2p": "~0.25.0-rc.3",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "~0.16.0",
     "libp2p-kad-dht": "~0.14.4",

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -77,7 +77,7 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
       },
       dht: {
         kBucketSize: get(options, 'dht.kBucketSize', 20),
-        enabled: get(options, 'dht.enabled', true) && !(get(options, 'offline', false)),
+        enabled: get(options, 'offline', false) ? false : undefined, // disable if offline
         randomWalk: {
           enabled: get(options, 'dht.randomWalk.enabled', true)
         },

--- a/test/core/dht.spec.js
+++ b/test/core/dht.spec.js
@@ -7,45 +7,96 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
+const isNode = require('detect-node')
+
 const IPFSFactory = require('ipfsd-ctl')
 const IPFS = require('../../src/core')
 
 describe('dht', () => {
-  let ipfsd, ipfs
+  describe('enabled', () => {
+    let ipfsd, ipfs
 
-  before(function (done) {
-    this.timeout(30 * 1000)
+    before(function (done) {
+      this.timeout(30 * 1000)
 
-    const factory = IPFSFactory.create({ type: 'proc' })
+      const factory = IPFSFactory.create({ type: 'proc' })
 
-    factory.spawn({
-      exec: IPFS,
-      initOptions: { bits: 512 },
-      config: {
-        Bootstrap: []
+      factory.spawn({
+        exec: IPFS,
+        initOptions: { bits: 512 },
+        config: {
+          Bootstrap: []
+        }
+      }, (err, _ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsd = _ipfsd
+        ipfs = _ipfsd.api
+        done()
+      })
+    })
+
+    after((done) => {
+      if (ipfsd) {
+        ipfsd.stop(done)
+      } else {
+        done()
       }
-    }, (err, _ipfsd) => {
-      expect(err).to.not.exist()
-      ipfsd = _ipfsd
-      ipfs = _ipfsd.api
-      done()
+    })
+
+    describe('findprovs', () => {
+      it('should callback with error for invalid CID input', (done) => {
+        ipfs.dht.findProvs('INVALID CID', (err) => {
+          expect(err).to.exist()
+          expect(err.code).to.equal('ERR_INVALID_CID')
+          done()
+        })
+      })
     })
   })
 
-  after((done) => {
-    if (ipfsd) {
-      ipfsd.stop(done)
-    } else {
-      done()
-    }
-  })
+  describe('disabled in browser', () => {
+    if (isNode) { return }
 
-  describe('findprovs', () => {
-    it('should callback with error for invalid CID input', (done) => {
-      ipfs.dht.findProvs('INVALID CID', (err) => {
-        expect(err).to.exist()
-        expect(err.code).to.equal('ERR_INVALID_CID')
+    let ipfsd, ipfs
+
+    before(function (done) {
+      this.timeout(30 * 1000)
+
+      const factory = IPFSFactory.create({ type: 'proc' })
+
+      factory.spawn({
+        exec: IPFS,
+        initOptions: { bits: 512 },
+        config: {
+          Bootstrap: []
+        }
+      }, (err, _ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsd = _ipfsd
+        ipfs = _ipfsd.api
         done()
+      })
+    })
+
+    after((done) => {
+      if (ipfsd) {
+        ipfsd.stop(done)
+      } else {
+        done()
+      }
+    })
+
+    describe('put', () => {
+      it('should callback with error for DHT not available', async () => {
+        let res
+        try {
+          res = await ipfs.dht.put(Buffer.from('a'), Buffer.from('b'))
+        } catch (err) {
+          expect(err).to.exist()
+          expect(err.code).to.equal('ERR_DHT_DISABLED')
+        }
+
+        expect(res).to.not.exist()
       })
     })
   })


### PR DESCRIPTION
The `libp2p` defaults were not allowing the browser config to disable the `dht` for browser nodes. This PR fixes that issue