### PR TITLE
chore: disable travis cache temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
-cache: npm
+
+# TODO: enable when windows is faster on travis, currently causes "No output has been received in the last 10m0s"
+# cache: npm
+cache: false
+
 stages:
   - check
   - test


### PR DESCRIPTION
Until windows builds speed up, we can't use the cache because they fail when restoring the cache because "No output has been received in the last 10m0s".

This PR disables the Travis cache until windows perf improves on Travis.