### PR TITLE
chore: disable dht discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "libp2p": "~0.25.0-rc.3",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "~0.16.0",
-    "libp2p-kad-dht": "~0.14.5",
+    "libp2p-kad-dht": "~0.14.7",
     "libp2p-keychain": "~0.3.3",
     "libp2p-mdns": "~0.12.0",
     "libp2p-mplex": "~0.8.4",

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -79,7 +79,7 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
         kBucketSize: get(options, 'dht.kBucketSize', 20),
         enabled: get(options, 'offline', false) ? false : undefined, // disable if offline
         randomWalk: {
-          enabled: get(options, 'dht.randomWalk.enabled', true)
+          enabled: false // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
         },
         validators: {
           ipns: ipnsUtils.validator


### PR DESCRIPTION
Currently `js-ipfs` was having a bad time with CPU usage. 

In this context, we decided to go with a temporary change on `dht.put`, as well as disabling the `random-walk` discovery. We will benefit from discovery through the queries that we will be running for now. 

With this, we will get `js-ipfs` stable again, as well as have the DHT available and have time to implement a proper solution to solve this issue.

More details about the problem and discussion of the solution:

- [libp2p/js-libp2p-kad-dht#86](https://github.com/libp2p/js-libp2p-kad-dht/issues/86)