### PR TITLE
fix: only dial to unconnected peers

### DIFF
--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -19,10 +19,11 @@ module.exports = function libp2p (self, config) {
   const libp2p = createBundle({ options, config, datastore, peerInfo, peerBook })
   let discoveredPeers = []
 
+  const noop = () => {}
   const putAndDial = peerInfo => {
     peerInfo = peerBook.put(peerInfo)
     if (!peerInfo.isConnected()) {
-      libp2p.dial(peerInfo, () => {})
+      libp2p.dial(peerInfo, noop)
     }
   }
 

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -20,7 +20,7 @@ module.exports = function libp2p (self, config) {
   let discoveredPeers = []
 
   const putAndDial = peerInfo => {
-    peerBook.put(peerInfo)
+    peerInfo = peerBook.put(peerInfo)
     if (!peerInfo.isConnected()) {
       libp2p.dial(peerInfo, () => {})
     }

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -21,7 +21,9 @@ module.exports = function libp2p (self, config) {
 
   const putAndDial = peerInfo => {
     peerBook.put(peerInfo)
-    libp2p.dial(peerInfo, () => {})
+    if (!peerInfo.isConnected()) {
+      libp2p.dial(peerInfo, () => {})
+    }
   }
 
   libp2p.on('start', () => {


### PR DESCRIPTION
Depends on:

* [x] https://github.com/libp2p/js-libp2p-switch/pull/309
* [x] https://github.com/moxystudio/node-proper-lockfile/pull/74