### PR TITLE
feat: display version info when starting daemon

### DIFF
--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const os = require('os')
 const { getRepoPath, print, ipfsPathHelp } = require('../utils')
 
 module.exports = {
@@ -35,6 +36,9 @@ module.exports = {
   handler (argv) {
     argv.resolve((async () => {
       print('Initializing IPFS daemon...')
+      print(`js-ipfs version: ${require('../../../package.json').version}`)
+      print(`System version: ${os.arch()}/${os.platform()}`)
+      print(`Node.js version: ${process.versions.node}`)
 
       const repoPath = getRepoPath()
 


### PR DESCRIPTION
Similar to what go-ipfs is now doing this prints the js-ipfs version, system arch/platform and Node.js version when a daemon is started. This should help with debugging.

Repo version is not yet included (but also unnecessary right now as we don't have repo migrations yet).

<img width="596" alt="Screenshot 2019-03-11 at 14 21 48" src="https://user-images.githubusercontent.com/152863/54130827-06bdb080-4409-11e9-86f8-b407e77fb4f3.png">
