### PR TITLE
fix: cat deeply nested file

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "execa": "^1.0.0",
     "form-data": "^2.3.3",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.97.1",
+    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#test/add-test-for-deeply-nested-file",
     "ipfsd-ctl": "~0.41.0",
     "libp2p-websocket-star": "~0.10.2",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "execa": "^1.0.0",
     "form-data": "^2.3.3",
     "hat": "0.0.3",
-    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#test/add-test-for-deeply-nested-file",
+    "interface-ipfs-core": "~0.98.1",
     "ipfsd-ctl": "~0.41.0",
     "libp2p-websocket-star": "~0.10.2",
     "ncp": "^2.0.0",

--- a/src/core/components/files-regular/cat-pull-stream.js
+++ b/src/core/components/files-regular/cat-pull-stream.js
@@ -15,8 +15,7 @@ module.exports = function (self) {
 
     ipfsPath = normalizePath(ipfsPath)
     const pathComponents = ipfsPath.split('/')
-    const restPath = normalizePath(pathComponents.slice(1).join('/'))
-    const filterFile = (file) => (restPath && file.path === restPath) || (file.path === ipfsPath)
+    const fileNameOrHash = pathComponents[pathComponents.length - 1]
 
     if (options.preload !== false) {
       self._preload(pathComponents[0])
@@ -26,7 +25,7 @@ module.exports = function (self) {
 
     pull(
       exporter(ipfsPath, self._ipld, options),
-      pull.filter(filterFile),
+      pull.filter(file => file.path === fileNameOrHash),
       pull.take(1),
       pull.collect((err, files) => {
         if (err) {


### PR DESCRIPTION
The exporter was exporting the file, but the filter was filtering it out because the exported path includes only `file.txt` but the filter was expecting `path/file.txt`.

So when you cat `/ipfs/QmHash/file.txt` it worked, but when you cat `/ipfs/QmHash/path/file.txt` it did not because the exported file had path `file.txt` but the filter was looking for `path/file.txt`.

Depends on:

* [x] https://github.com/ipfs/interface-js-ipfs-core/pull/448