### PR TITLE
fix: only dial if below highwatermark

### DIFF
--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -19,10 +19,11 @@ module.exports = function libp2p (self, config) {
   const libp2p = createBundle({ options, config, datastore, peerInfo, peerBook })
   let discoveredPeers = []
 
+  const noop = () => {}
   const putAndDial = peerInfo => {
     peerInfo = peerBook.put(peerInfo)
     if (!peerInfo.isConnected()) {
-      libp2p.dial(peerInfo, () => {})
+      libp2p.dial(peerInfo, noop)
     }
   }
 

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -20,7 +20,7 @@ module.exports = function libp2p (self, config) {
   let discoveredPeers = []
 
   const putAndDial = peerInfo => {
-    peerBook.put(peerInfo)
+    peerInfo = peerBook.put(peerInfo)
     if (!peerInfo.isConnected()) {
       libp2p.dial(peerInfo, () => {})
     }

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -21,7 +21,9 @@ module.exports = function libp2p (self, config) {
 
   const putAndDial = peerInfo => {
     peerBook.put(peerInfo)
-    libp2p.dial(peerInfo, () => {})
+    if (!peerInfo.isConnected()) {
+      libp2p.dial(peerInfo, () => {})
+    }
   }
 
   libp2p.on('start', () => {

--- a/src/core/components/swarm.js
+++ b/src/core/components/swarm.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const promisify = require('promisify-es6')
-const values = require('lodash/values')
 
 const OFFLINE_ERROR = require('../utils').OFFLINE_ERROR
 
@@ -25,7 +24,7 @@ module.exports = function swarm (self) {
 
       const peers = []
 
-      values(self._peerInfoBook.getAll()).forEach((peer) => {
+      Object.values(self._peerInfoBook.getAll()).forEach((peer) => {
         const connectedAddr = peer.isConnected()
 
         if (!connectedAddr) { return }
@@ -50,7 +49,7 @@ module.exports = function swarm (self) {
         return callback(new Error(OFFLINE_ERROR))
       }
 
-      const peers = values(self._peerInfoBook.getAll())
+      const peers = Object.values(self._peerInfoBook.getAll())
 
       callback(null, peers)
     }),


### PR DESCRIPTION
I feel this dialing logic could be managed by libp2p. We can optimise `connectedSize` - libp2p/the connection manager can keep track of that number so we don't have to iterate over all known peers each time.

You get the idea though, we only dial to a discovered peer if we're below the high water mark. There's not much point dialing if we know the connection will be closed as soon as it's established. **That said, is it better to dial everyone and let the connection manager clear out the less useful connections? Probably right...?**

We could do something similar for incoming connections or leave that to the connection manager also.