### PR TITLE
perf: lower connection manager limits

### DIFF
--- a/src/core/runtime/config-browser.js
+++ b/src/core/runtime/config-browser.js
@@ -28,8 +28,8 @@ module.exports = () => ({
   ],
   Swarm: {
     ConnMgr: {
-      LowWater: 600,
-      HighWater: 900
+      LowWater: 200,
+      HighWater: 500
     }
   }
 })

--- a/src/core/runtime/config-nodejs.js
+++ b/src/core/runtime/config-nodejs.js
@@ -41,8 +41,8 @@ module.exports = () => ({
   ],
   Swarm: {
     ConnMgr: {
-      LowWater: 600,
-      HighWater: 900
+      LowWater: 200,
+      HighWater: 500
     }
   }
 })


### PR DESCRIPTION
I've observed that over ~600 peers the node becomes less stable, this lowers the default limits until we can address performance issues in libp2p.