### PR TITLE
fix: handle subdomains for ipfs.dns

### DIFF
--- a/src/core/runtime/dns-nodejs.js
+++ b/src/core/runtime/dns-nodejs.js
@@ -7,8 +7,8 @@ const errcode = require('err-code')
 module.exports = (domain, opts, callback) => {
   resolveDnslink(domain)
     .catch(err => {
-      // If the code is not ENOTFOUND or ERR_DNSLINK_NOT_FOUND then throw the error
-      if (err.code !== 'ENOTFOUND' && err.code !== 'ERR_DNSLINK_NOT_FOUND') throw err
+      // If the code is not ENOTFOUND or ERR_DNSLINK_NOT_FOUND or ENODATA then throw the error
+      if (err.code !== 'ENOTFOUND' && err.code !== 'ERR_DNSLINK_NOT_FOUND' && err.code !== 'ENODATA') throw err
 
       if (domain.startsWith('_dnslink.')) {
         // The supplied domain contains a _dnslink component

--- a/test/cli/dns.js
+++ b/test/cli/dns.js
@@ -27,4 +27,20 @@ describe('dns', () => runOnAndOff((thing) => {
       expect(res.substr(0, 6)).to.eql('/ipns/')
     })
   })
+
+  it('resolve subdomain docs.ipfs.io dns', function () {
+    this.timeout(60 * 1000)
+
+    return ipfs('dns docs.ipfs.io').then(res => {
+      expect(res.substr(0, 6)).to.eql('/ipfs/')
+    })
+  })
+
+  it('resolve subdomain _dnslink.docs.ipfs.io dns', function () {
+    this.timeout(60 * 1000)
+
+    return ipfs('dns _dnslink.docs.ipfs.io').then(res => {
+      expect(res.substr(0, 6)).to.eql('/ipfs/')
+    })
+  })
 }))


### PR DESCRIPTION
resolves #1932 

`dns.requireTxt` throws 'ENODATA' if no txt records are found, so I included a condition to check for that error and check the `_dnslink.<domain>` so that subdomain is resolved correctly. 

Also added a few tests for checking if subdomain resolves correctly. 