### PR TITLE
chore: update webui to 2.4.3

### DIFF
--- a/src/http/api/routes/webui.js
+++ b/src/http/api/routes/webui.js
@@ -17,7 +17,7 @@ module.exports = [
     method: '*',
     path: '/webui',
     handler (request, h) {
-      return h.redirect('/ipfs/QmZepbAvvUvCqKmNjgf3dStoSToXCW9uQopx4vd2HFMELR')
+      return h.redirect('/ipfs/QmRvPGBVDBEUvrXrinMKgh8Vu8mVBbTZk3C1jJGfgWchSP')
     }
   }
 ]


### PR DESCRIPTION
2.4.1 left debug logging enabled. 2.4.3 fixes that.

https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.4.3

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>