### PR TITLE
Decouple HTTP Servers from cli/commands/daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ docs
 # Logs
 logs
 *.log
+# npm pack
+*.tgz
 
 coverage
 

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -44,8 +44,8 @@ module.exports = {
       const repoPath = getRepoPath()
 
       // Required inline to reduce startup time
-      const HttpApi = require('../../http')
-      const api = new HttpApi({
+      const StandaloneDaemon = require('../../cli/standalone-daemon')
+      const daemon = new StandaloneDaemon({
         silent: argv.silent,
         repo: process.env.IPFS_PATH,
         offline: argv.offline,
@@ -60,7 +60,7 @@ module.exports = {
       })
 
       try {
-        await api.start()
+        await daemon.start()
       } catch (err) {
         if (err.code === 'ENOENT' && err.message.match(/uninitialized/i)) {
           print('Error: no initialized ipfs repo found in ' + repoPath)
@@ -74,7 +74,7 @@ module.exports = {
 
       const cleanup = async () => {
         print(`Received interrupt signal, shutting down...`)
-        await api.stop()
+        await daemon.stop()
         process.exit(0)
       }
 

--- a/src/cli/standalone-daemon.js
+++ b/src/cli/standalone-daemon.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const debug = require('debug')
+
+const IPFS = require('../core')
+const HttpApi = require('../http')
+const WStar = require('libp2p-webrtc-star')
+const TCP = require('libp2p-tcp')
+const MulticastDNS = require('libp2p-mdns')
+const WS = require('libp2p-websockets')
+const Bootstrap = require('libp2p-bootstrap')
+
+class StandaloneDaemon {
+  constructor (options) {
+    this._options = options || {}
+    this._log = debug('ipfs:daemon')
+    this._log.error = debug('ipfs:daemon:error')
+
+    if (process.env.IPFS_MONITORING) {
+      // Setup debug metrics collection
+      const prometheusClient = require('prom-client')
+      const prometheusGcStats = require('prometheus-gc-stats')
+      const collectDefaultMetrics = prometheusClient.collectDefaultMetrics
+      collectDefaultMetrics({ timeout: 5000 })
+      prometheusGcStats(prometheusClient.register)()
+    }
+  }
+
+  async start () {
+    this._log('starting')
+
+    const libp2p = { modules: {} }
+
+    // Attempt to use any of the WebRTC versions available globally
+    let electronWebRTC
+    let wrtc
+    try {
+      electronWebRTC = require('electron-webrtc')()
+    } catch (err) {
+      this._log('failed to load optional electron-webrtc dependency')
+    }
+    try {
+      wrtc = require('wrtc')
+    } catch (err) {
+      this._log('failed to load optional webrtc dependency')
+    }
+
+    if (wrtc || electronWebRTC) {
+      const using = wrtc ? 'wrtc' : 'electron-webrtc'
+      this._log(`Using ${using} for webrtc support`)
+      const wstar = new WStar({ wrtc: (wrtc || electronWebRTC) })
+      libp2p.modules.transport = [TCP, WS, wstar]
+      libp2p.modules.peerDiscovery = [MulticastDNS, Bootstrap, wstar.discovery]
+    }
+
+    // start the daemon
+    const ipfsOpts = Object.assign({ init: false }, this._options, { start: true, libp2p })
+    const ipfs = new IPFS(ipfsOpts)
+
+    await new Promise((resolve, reject) => {
+      ipfs.once('error', err => {
+        this._log('error starting core', err)
+        err.code = 'ENOENT'
+        reject(err)
+      })
+      ipfs.once('start', resolve)
+    })
+
+    this._ipfs = ipfs
+
+    // start HTTP servers (if API or Gateway is enabled in options)
+    const httpApi = new HttpApi(ipfs, ipfsOpts)
+    this._httpApi = await httpApi.start()
+
+    this._log('started')
+    return this
+  }
+
+  async stop () {
+    this._log('stopping')
+    await Promise.all([
+      this._httpApi && this._httpApi.stop(),
+      this._ipfs && this._ipfs.stop()
+    ])
+    this._log('stopped')
+    return this
+  }
+}
+
+module.exports = StandaloneDaemon

--- a/src/cli/standalone-daemon.js
+++ b/src/cli/standalone-daemon.js
@@ -69,7 +69,7 @@ class StandaloneDaemon {
     this._ipfs = ipfs
 
     // start HTTP servers (if API or Gateway is enabled in options)
-    const httpApi = new HttpApi(ipfs, ipfsOpts)
+    const httpApi = new HttpApi(ipfs, Object.assign({ announceListeners: true }, ipfsOpts))
     this._httpApi = await httpApi.start()
 
     this._log('started')

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -77,14 +77,15 @@ class HttpApi {
     const gatewayAddrs = config.Addresses.Gateway
     this._gatewayServers = await serverCreator(gatewayAddrs, this._createGatewayServer, ipfs)
 
+    const announce = this._options.announceListeners ? ipfs._print : this._log
     this._apiServers.forEach(apiServer => {
-      ipfs._print('API listening on %s', apiServer.info.ma)
+      announce('API listening on %s', apiServer.info.ma.toString())
     })
     this._gatewayServers.forEach(gatewayServer => {
-      ipfs._print('Gateway (read only) listening on %s', gatewayServer.info.ma)
+      announce('Gateway (read only) listening on %s', gatewayServer.info.ma.toString())
     })
     this._apiServers.forEach(apiServer => {
-      ipfs._print('Web UI available at %s', toUri(apiServer.info.ma) + '/webui')
+      announce('Web UI available at %s', toUri(apiServer.info.ma) + '/webui')
     })
     this._log('started')
     return this

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -4,8 +4,6 @@ const Hapi = require('hapi')
 const Pino = require('hapi-pino')
 const debug = require('debug')
 const multiaddr = require('multiaddr')
-const promisify = require('promisify-es6')
-const toUri = require('multiaddr-to-uri')
 const toMultiaddr = require('uri-to-multiaddr')
 
 const errorHandler = require('./error-handler')
@@ -69,24 +67,9 @@ class HttpApi {
     const apiAddrs = config.Addresses.API
     this._apiServers = await serverCreator(apiAddrs, this._createApiServer, ipfs)
 
-    // for the CLI to know the where abouts of the API
-    if (this._apiServers.length) {
-      await promisify(ipfs._repo.apiAddr.set)(this._apiServers[0].info.ma)
-    }
-
     const gatewayAddrs = config.Addresses.Gateway
     this._gatewayServers = await serverCreator(gatewayAddrs, this._createGatewayServer, ipfs)
 
-    const announce = this._options.announceListeners ? ipfs._print : this._log
-    this._apiServers.forEach(apiServer => {
-      announce('API listening on %s', apiServer.info.ma.toString())
-    })
-    this._gatewayServers.forEach(gatewayServer => {
-      announce('Gateway (read only) listening on %s', gatewayServer.info.ma.toString())
-    })
-    this._apiServers.forEach(apiServer => {
-      announce('Web UI available at %s', toUri(apiServer.info.ma) + '/webui')
-    })
     this._log('started')
     return this
   }

--- a/test/gateway/index.js
+++ b/test/gateway/index.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const API = require('../../src/http')
+const StandaloneDaemon = require('../../src/cli/standalone-daemon')
 const loadFixture = require('aegir/fixtures')
 const os = require('os')
 const path = require('path')
@@ -33,7 +33,7 @@ describe('HTTP Gateway', function () {
     this.timeout(60 * 1000)
     const repoPath = path.join(os.tmpdir(), '/ipfs-' + hat())
 
-    http.api = new API({
+    http.api = new StandaloneDaemon({
       repo: repoPath,
       init: true,
       config: {
@@ -60,7 +60,7 @@ describe('HTTP Gateway', function () {
 
     await http.api.start()
 
-    gateway = http.api._gatewayServers[0]
+    gateway = http.api._httpApi._gatewayServers[0]
 
     // QmbQD7EMEL1zeebwBsWEfA3ndgSS6F7S6iTuwuqasPgVRi
     await http.api._ipfs.add([

--- a/test/gateway/index.js
+++ b/test/gateway/index.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const StandaloneDaemon = require('../../src/cli/standalone-daemon')
+const Daemon = require('../../src/cli/daemon')
 const loadFixture = require('aegir/fixtures')
 const os = require('os')
 const path = require('path')
@@ -33,7 +33,7 @@ describe('HTTP Gateway', function () {
     this.timeout(60 * 1000)
     const repoPath = path.join(os.tmpdir(), '/ipfs-' + hat())
 
-    http.api = new StandaloneDaemon({
+    http.api = new Daemon({
       repo: repoPath,
       init: true,
       config: {

--- a/test/http-api/inject/bitswap.js
+++ b/test/http-api/inject/bitswap.js
@@ -12,7 +12,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     before(async function () {

--- a/test/http-api/inject/block.js
+++ b/test/http-api/inject/block.js
@@ -13,7 +13,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     describe('/block/put', () => {

--- a/test/http-api/inject/bootstrap.js
+++ b/test/http-api/inject/bootstrap.js
@@ -11,7 +11,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
       return api.inject({
         method: 'GET',
         url: '/api/v0/bootstrap/add/default'

--- a/test/http-api/inject/config.js
+++ b/test/http-api/inject/config.js
@@ -17,7 +17,7 @@ module.exports = (http) => {
 
     before(() => {
       updatedConfig = () => JSON.parse(fs.readFileSync(configPath, 'utf8'))
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     after(() => {

--- a/test/http-api/inject/dag.js
+++ b/test/http-api/inject/dag.js
@@ -33,7 +33,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     describe('/dag/get', () => {

--- a/test/http-api/inject/dht.js
+++ b/test/http-api/inject/dht.js
@@ -12,7 +12,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     describe('/findpeer', () => {

--- a/test/http-api/inject/dns.js
+++ b/test/http-api/inject/dns.js
@@ -8,7 +8,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     it('resolve ipfs.io dns', async () => {

--- a/test/http-api/inject/files.js
+++ b/test/http-api/inject/files.js
@@ -13,7 +13,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     describe('/add', () => {

--- a/test/http-api/inject/id.js
+++ b/test/http-api/inject/id.js
@@ -8,7 +8,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     it('get the id', async () => {

--- a/test/http-api/inject/name.js
+++ b/test/http-api/inject/name.js
@@ -16,7 +16,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     it('should publish a record', async function () {

--- a/test/http-api/inject/object.js
+++ b/test/http-api/inject/object.js
@@ -17,7 +17,7 @@ module.exports = (http) => {
     let api
 
     before('api', () => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     describe('/new', () => {

--- a/test/http-api/inject/pin.js
+++ b/test/http-api/inject/pin.js
@@ -37,7 +37,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     describe('rm', () => {

--- a/test/http-api/inject/ping.js
+++ b/test/http-api/inject/ping.js
@@ -13,7 +13,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     it('returns 400 if both n and count are provided', async () => {

--- a/test/http-api/inject/pubsub.js
+++ b/test/http-api/inject/pubsub.js
@@ -16,7 +16,7 @@ module.exports = (http) => {
     const topicNotSubscribed = 'somethingRandom'
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     describe('/sub', () => {

--- a/test/http-api/inject/resolve.js
+++ b/test/http-api/inject/resolve.js
@@ -12,7 +12,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     it('should resolve a path and return a base2 encoded CID', async () => {

--- a/test/http-api/inject/version.js
+++ b/test/http-api/inject/version.js
@@ -9,7 +9,7 @@ module.exports = (http) => {
     let api
 
     before(() => {
-      api = http.api._apiServers[0]
+      api = http.api._httpApi._apiServers[0]
     })
 
     it('get the version', async () => {

--- a/test/http-api/routes.js
+++ b/test/http-api/routes.js
@@ -6,7 +6,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 chai.use(dirtyChai)
 const hat = require('hat')
-const API = require('../../src/http/index')
+const StandaloneDaemon = require('../../src/cli/standalone-daemon')
 const promisify = require('promisify-es6')
 const ncp = promisify(require('ncp').ncp)
 const path = require('path')
@@ -22,7 +22,7 @@ describe('HTTP API', () => {
   let http = {}
 
   const startHttpAPI = async (config) => {
-    http.api = new API({
+    http.api = new StandaloneDaemon({
       repo: repoTests,
       pass: hat(),
       config,

--- a/test/http-api/routes.js
+++ b/test/http-api/routes.js
@@ -6,7 +6,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 chai.use(dirtyChai)
 const hat = require('hat')
-const StandaloneDaemon = require('../../src/cli/standalone-daemon')
+const Daemon = require('../../src/cli/daemon')
 const promisify = require('promisify-es6')
 const ncp = promisify(require('ncp').ncp)
 const path = require('path')
@@ -22,7 +22,7 @@ describe('HTTP API', () => {
   let http = {}
 
   const startHttpAPI = async (config) => {
-    http.api = new StandaloneDaemon({
+    http.api = new Daemon({
       repo: repoTests,
       pass: hat(),
       config,


### PR DESCRIPTION
> Part of an effort to run embedded js-ipfs in Brave :lion: https://github.com/ipfs-shipyard/ipfs-companion/issues/664  

### Summary

This PR decouples HTTP servers from code `jsipfs daemon`.
Apart from cleanup, we need this to enable HTTP server in browser context with [`chrome.sockets`](https://github.com/ipfs-shipyard/ipfs-companion/issues/664).

**There are no functional changes.** I just moved non-HTTP code  to `src/cli/standalone-daemon.js`

### Background

In the past API was exposed via HTTP Server only when jsipfs daemon was run from the commandline, so src/http/index.js was also responsible for orchestration that is not related to HTTP itself. The coupling was quite bad: `HttpApi` basically decided on libp2p configuration: it enabled WebRTC if available, TCP transport, MulticastDNS etc.

### Changes

This refactor moves code that is not related to HTTP Servers into `standalone-daemon.js`, which is easier to reason about, and unlocks use of `HttpApi` in contexts other than CLI  `jsipfs daemon`, such as Firefox with libdweb or [Chromium-based web browser with `chrome.sockets` APIs](https://github.com/ipfs-shipyard/ipfs-companion/issues/664)

With this PR, HttpApi is not only decoupled from Standalone Daemon, but  can also be manually started/stopped in browser context.

I believe only ipfs-companion will be using this for now, but it is a fairly generic code.
Someone else should be able to use this in Chrome App environment:

#### Start
```js
const Ipfs = require('ipfs')
const HttpApi = require('ipfs/src/http')

let node = new Ipfs(ipfsOpts)
let nodeHttpApi

node.on('start', async () => {
  // HttpApi is off in browser context and needs to be started separately
  const httpServers = new HttpApi(node, ipfsOpts)
  nodeHttpApi = await httpServers.start()
})
```
#### Stop
```js
if (nodeHttpApi) {
  await nodeHttpApi.stop()
  nodeHttpApi = null
}
if (node) {
  await node.stop()
  node = null
}
```



### Checklist

- [x] do the thing ;-)
- [x] fix printing of API and Gateway port in browser console
     - DONE: [when run in browser](https://github.com/ipfs-shipyard/ipfs-companion/issues/664#issuecomment-481697875), it will announce using `debug`:
       > ![2019-04-11--15-11-09](https://user-images.githubusercontent.com/157609/55960055-4aa40f80-5c6c-11e9-872d-37d9f38d658c.png)

- [x] ensure issue with returning payload in browser context is not due to js-ipfs
      - DONE: does not block this PR (it was due to Node-specific check in Hapi, will be addressed upstream)


Refs.
https://github.com/ipfs-shipyard/ipfs-companion/issues/664, https://github.com/ipfs/js-ipfs/issues/1855
