### PR TITLE
chore: update stream-to-pull-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "pump": "^3.0.0",
     "readable-stream": "^3.1.1",
     "receptacle": "^1.3.2",
-    "stream-to-pull-stream": "^1.7.2",
+    "stream-to-pull-stream": "github:pull-stream/stream-to-pull-stream#fix/remove-unused-destroy",
     "tar-stream": "^2.0.0",
     "temp": "~0.9.0",
     "update-notifier": "^2.5.0",


### PR DESCRIPTION
Pending resolution of https://github.com/pull-stream/stream-to-pull-stream/pull/16. The extra `destroy` function causes babel to throw after https://github.com/babel/babel/pull/9493 was merged and released.