### PR TITLE
chore: update libp2p

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,11 @@ Prevents all logging output from the IPFS node.
 
 | Type | Default |
 |------|---------|
-| object | `{ enabled: false, hop: { enabled: false, active: false } }` |
+| object | `{ enabled: true, hop: { enabled: false, active: false } }` |
 
 Configure circuit relay (see the [circuit relay tutorial](https://github.com/ipfs/js-ipfs/tree/master/examples/circuit-relaying) to learn more).
 
-- `enabled` (boolean): Enable circuit relay dialer and listener. (Default: `false`)
+- `enabled` (boolean): Enable circuit relay dialer and listener. (Default: `true`)
 - `hop` (object)
     - `enabled` (boolean): Make this node a relay (other nodes can connect *through* it). (Default: `false`)
     - `active` (boolean): Make this an *active* relay node. Active relay nodes will attempt to dial a destination peer even if that peer is not yet connected to the relay. (Default: `false`)

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "joi": "^14.3.0",
     "joi-browser": "^13.4.0",
     "joi-multiaddr": "^4.0.0",
-    "libp2p": "~0.25.0-rc.3",
+    "libp2p": "github:libp2p/js-libp2p#feat/new-switch",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "~0.16.0",
     "libp2p-kad-dht": "~0.14.8",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "joi": "^14.3.0",
     "joi-browser": "^13.4.0",
     "joi-multiaddr": "^4.0.0",
-    "libp2p": "github:libp2p/js-libp2p#feat/new-switch",
+    "libp2p": "~0.25.0-rc.5",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "~0.16.0",
     "libp2p-kad-dht": "~0.14.8",

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -27,6 +27,11 @@ module.exports = function libp2p (self, config) {
     }
   }
 
+  libp2p.on('stop', () => {
+    // Clear our addresses so we can start clean
+    peerInfo.multiaddrs.clear()
+  })
+
   libp2p.on('start', () => {
     peerInfo.multiaddrs.forEach((ma) => {
       self._print('Swarm listening on', ma.toString())

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -70,7 +70,7 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
       },
       relay: {
         enabled: get(options, 'relay.enabled',
-          get(config, 'relay.enabled', false)),
+          get(config, 'relay.enabled', true)),
         hop: {
           enabled: get(options, 'relay.hop.enabled',
             get(config, 'relay.hop.enabled', false)),
@@ -80,7 +80,7 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
       },
       dht: {
         kBucketSize: get(options, 'dht.kBucketSize', 20),
-        enabled: get(options, 'offline', false) ? false : undefined, // disable if offline
+        enabled: get(options, 'offline', false) ? false : true, // disable if offline, on by default
         randomWalk: {
           enabled: false // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
         },

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -80,7 +80,7 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
       },
       dht: {
         kBucketSize: get(options, 'dht.kBucketSize', 20),
-        enabled: get(options, 'offline', false) ? false : true, // disable if offline, on by default
+        enabled: !get(options, 'offline', false), // disable if offline, on by default
         randomWalk: {
           enabled: false // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
         },

--- a/test/cli/name.js
+++ b/test/cli/name.js
@@ -158,7 +158,8 @@ describe('name', () => {
         })
     })
 
-    it('should go recursively until finding an ipfs hash', function () {
+    // FIXME: currently failing, resolve before 0.35 release!
+    it.skip('should go recursively until finding an ipfs hash', function () {
       this.timeout(90 * 1000)
 
       return ipfs(`name publish ${cidAdded}`)

--- a/test/cli/name.js
+++ b/test/cli/name.js
@@ -158,8 +158,7 @@ describe('name', () => {
         })
     })
 
-    // FIXME: currently failing, resolve before 0.35 release!
-    it.skip('should go recursively until finding an ipfs hash', function () {
+    it('should go recursively until finding an ipfs hash', function () {
       this.timeout(90 * 1000)
 
       return ipfs(`name publish ${cidAdded}`)


### PR DESCRIPTION
This updates to the latest libp2p version.

* DHT needed to be disabled by default in libp2p since libp2p doesn't actually come with the dht bundled, so it's turned on here by default.
* Relay should be enabled by default as it allows us to dial other relays. HOP is not turned on, so we don't act as a relay.
* ~~The IPNS test is added back in, which needs to be resolved for the 0.35 release~~