### PR TITLE
feat: better error message on ipfs cat

### DIFF
--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -436,6 +436,16 @@ describe('files', () => runOnAndOff((thing) => {
       .then(() => expect.fail(0, 1, 'Should have thrown an error'))
       .catch((err) => {
         expect(err).to.exist()
+        expect(err.stdout).to.contain('no file named "dummy" under QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
+      })
+  })
+
+  it('cat non-existent file (nested)', () => {
+    return ipfs('cat Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z/init-docs/wrong-dir/dummy')
+      .then(() => expect.fail(0, 1, 'Should have thrown an error'))
+      .catch((err) => {
+        expect(err).to.exist()
+        expect(err.stdout).to.contain('no file named "wrong-dir/dummy" under Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z/init-docs')
       })
   })
 


### PR DESCRIPTION
resolves: #1145 

The command `ipfs cat <hash>/wrong-dir/wrong-file` 
previously returned error message: `No such file`

Following the suggestions given in [this thread](https://github.com/ipfs/js-ipfs/pull/1270#pullrequestreview-105635422), I changed the error message to:
`no file named "wrong-dir/wrong-file" under <hash>`
 
Also, the CI check will fail because test case for this is in [interface-ipfs-core](https://github.com/ipfs/interface-js-ipfs-core/blob/0f256bf399a8e3318dab5927f2670882d5551640/src/files-regular/cat.js#L192-L194). So we'll need to change the tests in interface-ipfs-core repo.