### PR TITLE
Update browser script tag example

### DIFF
--- a/examples/browser-script-tag/index.html
+++ b/examples/browser-script-tag/index.html
@@ -28,7 +28,8 @@
   <p>Try adding a new file:</p>
 
   <code style="display:block; white-space:pre-wrap; background-color:#d7d6d6">
-    node.add(new node.types.Buffer('Hello world!'), (err, filesAdded) => {
+    const { Buffer } = Ipfs
+    node.add(new Buffer('Hello world!'), (err, filesAdded) => {
       if (err) {
         return console.error('Error - ipfs add', err, res)
       }


### PR DESCRIPTION
It was using node.types.Buffer, this changes it to use `const { Buffer } = Ipfs`

Needed for 0.35 release: https://github.com/ipfs/js-ipfs/issues/1826