### PR TITLE
Force browserify to load Buffer module

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -176,7 +176,9 @@ class IPFS extends EventEmitter {
 
 module.exports = IPFS
 
-Object.assign(module.exports, { crypto, isIPFS, Buffer, CID, multiaddr, multibase, multihash, multicodec, PeerId, PeerInfo })
+// Note: We need to do this to force browserify to load the Buffer module
+const BufferImpl = Buffer
+Object.assign(module.exports, { crypto, isIPFS, Buffer: BufferImpl, CID, multiaddr, multibase, multihash, multicodec, PeerId, PeerInfo })
 
 module.exports.createNode = (options) => {
   return new IPFS(options)


### PR DESCRIPTION
It seems that browserify does not load the Buffer module unless we explicity assign it to a variable