### PR TITLE
fix: use libp2p auto dial

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ You can see the bundle in action in the [custom libp2p example](examples/custom-
     - `peerDiscovery` (Array<[libp2p.PeerDiscovery](https://github.com/libp2p/interface-peer-discovery)>): An array of Libp2p peer discovery classes/instances to use _instead_ of the defaults. See [libp2p/peer-discovery](https://github.com/libp2p/interface-peer-discovery) for details. If passing a class, configuration can be passed using the config section below under the key corresponding to you module's unique `tag` (a static property on the class)
 - `config` (object):
     - `peerDiscovery` (object):
+        - `autoDial` (boolean): Dial to discovered peers when under the Connection Manager min peer count watermark. (default `true`)
         - `[PeerDiscovery.tag]` (object): configuration for a peer discovery module
             - `enabled` (boolean): whether this module is enabled or disabled
             - `[custom config]` (any): other keys are specific to the module

--- a/examples/custom-libp2p/index.js
+++ b/examples/custom-libp2p/index.js
@@ -44,7 +44,8 @@ const libp2pBundle = (opts) => {
     peerBook,
     // Lets limit the connection managers peers and have it check peer health less frequently
     connectionManager: {
-      maxPeers: 25,
+      minPeers: 25,
+      maxPeers: 100,
       pollInterval: 5000
     },
     modules: {
@@ -68,12 +69,13 @@ const libp2pBundle = (opts) => {
     },
     config: {
       peerDiscovery: {
+        autoDial: true, // auto dial to peers we find when we have less peers than `connectionManager.minPeers`
         mdns: {
           interval: 10000,
           enabled: true
         },
         bootstrap: {
-          interval: 10000,
+          interval: 30e3,
           enabled: true,
           list: bootstrapList
         }
@@ -87,10 +89,15 @@ const libp2pBundle = (opts) => {
         }
       },
       dht: {
-        kBucketSize: 20
+        enabled: true,
+        kBucketSize: 20,
+        randomWalk: {
+          enabled: true,
+          interval: 10e3, // This is set low intentionally, so more peers are discovered quickly. Higher intervals are recommended
+          timeout: 2e3 // End the query quickly since we're running so frequently
+        }
       },
       EXPERIMENTAL: {
-        dht: true,
         pubsub: true
       }
     }

--- a/examples/custom-libp2p/package.json
+++ b/examples/custom-libp2p/package.json
@@ -10,14 +10,14 @@
   "license": "MIT",
   "dependencies": {
     "ipfs": "file:../../",
-    "libp2p": "~0.24.0",
-    "libp2p-bootstrap": "~0.9.3",
-    "libp2p-kad-dht": "~0.11.1",
-    "libp2p-mdns": "~0.12.0",
-    "libp2p-mplex": "~0.8.4",
-    "libp2p-secio": "~0.10.1",
-    "libp2p-spdy": "~0.13.0",
+    "libp2p": "~0.25.0",
+    "libp2p-bootstrap": "~0.9.7",
+    "libp2p-kad-dht": "~0.14.12",
+    "libp2p-mdns": "~0.12.2",
+    "libp2p-mplex": "~0.8.5",
+    "libp2p-secio": "~0.11.1",
+    "libp2p-spdy": "~0.13.3",
     "libp2p-tcp": "~0.13.0",
-    "libp2p-websocket-star": "~0.9.0"
+    "libp2p-websocket-star": "~0.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "joi": "^14.3.0",
     "just-flatten-it": "^2.1.0",
     "just-safe-set": "^2.1.0",
-    "libp2p": "~0.25.0-rc.5",
+    "libp2p": "github:libp2p/js-libp2p#feat/disco-strategies",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "~0.16.0",
     "libp2p-kad-dht": "~0.14.12",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "joi": "^14.3.0",
     "just-flatten-it": "^2.1.0",
     "just-safe-set": "^2.1.0",
-    "libp2p": "github:libp2p/js-libp2p#feat/disco-strategies",
+    "libp2p": "~0.25.0-rc.6",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "~0.16.0",
     "libp2p-kad-dht": "~0.14.12",

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -17,15 +17,6 @@ module.exports = function libp2p (self, config) {
   const peerInfo = self._peerInfo
   const peerBook = self._peerInfoBook
   const libp2p = createBundle({ options, config, datastore, peerInfo, peerBook })
-  let discoveredPeers = []
-
-  const noop = () => {}
-  const putAndDial = peerInfo => {
-    peerInfo = peerBook.put(peerInfo)
-    if (!peerInfo.isConnected()) {
-      libp2p.dial(peerInfo, noop)
-    }
-  }
 
   libp2p.on('stop', () => {
     // Clear our addresses so we can start clean
@@ -36,16 +27,6 @@ module.exports = function libp2p (self, config) {
     peerInfo.multiaddrs.forEach((ma) => {
       self._print('Swarm listening on', ma.toString())
     })
-    discoveredPeers.forEach(putAndDial)
-    discoveredPeers = []
-  })
-
-  libp2p.on('peer:discovery', (peerInfo) => {
-    if (self.isOnline()) {
-      putAndDial(peerInfo)
-    } else {
-      discoveredPeers.push(peerInfo)
-    }
   })
 
   libp2p.on('peer:connect', peerInfo => peerBook.put(peerInfo))
@@ -108,7 +89,6 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
   }
 
   const libp2pOptions = mergeOptions(libp2pDefaults, get(options, 'libp2p', {}))
-
   // Required inline to reduce startup time
   // Note: libp2p-nodejs gets replaced by libp2p-browser when webpacked/browserified
   const Node = require('../runtime/libp2p-nodejs')

--- a/src/core/runtime/libp2p-browser.js
+++ b/src/core/runtime/libp2p-browser.js
@@ -43,6 +43,7 @@ class Node extends libp2p {
       },
       config: {
         peerDiscovery: {
+          autoDial: true,
           bootstrap: {
             enabled: true
           },

--- a/src/core/runtime/libp2p-nodejs.js
+++ b/src/core/runtime/libp2p-nodejs.js
@@ -42,6 +42,7 @@ class Node extends libp2p {
       },
       config: {
         peerDiscovery: {
+          autoDial: true,
           mdns: {
             enabled: true
           },

--- a/test/core/libp2p.spec.js
+++ b/test/core/libp2p.spec.js
@@ -106,7 +106,9 @@ describe('libp2p customization', function () {
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        expect(_libp2p._config).to.not.have.property('peerDiscovery')
+        expect(_libp2p._config.peerDiscovery).to.eql({
+          autoDial: true
+        })
         expect(_libp2p._transport).to.have.length(1)
         done()
       })
@@ -130,6 +132,7 @@ describe('libp2p customization', function () {
         expect(err).to.not.exist()
         expect(_libp2p._config).to.deep.include({
           peerDiscovery: {
+            autoDial: true,
             bootstrap: {
               enabled: true,
               list: []
@@ -193,6 +196,7 @@ describe('libp2p customization', function () {
         expect(err).to.not.exist()
         expect(_libp2p._config).to.deep.include({
           peerDiscovery: {
+            autoDial: true,
             bootstrap: {
               enabled: true,
               list: []


### PR DESCRIPTION
Moves all peer discovery dialing logic to libp2p, which prevents dialing discovered nodes when we have enough peers.

* [x] depends on https://github.com/libp2p/js-libp2p/pull/349