### PR TITLE
fix: ipns using offline datastore if no dht

### DIFF
--- a/src/core/ipns/routing/config.js
+++ b/src/core/ipns/routing/config.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { TieredDatastore } = require('datastore-core')
+const get = require('dlv')
+
+const PubsubDatastore = require('./pubsub-datastore')
+const OfflineDatastore = require('./offline-datastore')
+
+module.exports = (ipfs) => {
+  // Setup online routing for IPNS with a tiered routing composed by a DHT and a Pubsub router (if properly enabled)
+  const ipnsStores = []
+
+  // Add IPNS pubsub if enabled
+  let pubsubDs
+  if (get(ipfs._options, 'EXPERIMENTAL.ipnsPubsub', false)) {
+    const pubsub = ipfs.libp2p.pubsub
+    const localDatastore = ipfs._repo.datastore
+    const peerId = ipfs._peerInfo.id
+
+    pubsubDs = new PubsubDatastore(pubsub, localDatastore, peerId)
+    ipnsStores.push(pubsubDs)
+  }
+
+  // DHT should not be added as routing if we are offline or it is disabled
+  if (get(ipfs._options, 'offline') || !get(ipfs._options, 'libp2p.dht.enabled', false)) {
+    const offlineDatastore = new OfflineDatastore(ipfs._repo)
+    ipnsStores.push(offlineDatastore)
+  } else {
+    ipnsStores.push(ipfs.libp2p.dht)
+  }
+
+  // Create ipns routing with a set of datastores
+  return new TieredDatastore(ipnsStores)
+}

--- a/test/core/name.js
+++ b/test/core/name.js
@@ -196,7 +196,8 @@ describe('name', function () {
     })
   })
 
-  describe('work with dht', () => {
+  // TODO: unskip when dht is enabled - https://github.com/ipfs/js-ipfs/issues/1984
+  describe.skip('work with dht', () => {
     let nodes
     let nodeA
     let nodeB

--- a/test/core/name.js
+++ b/test/core/name.js
@@ -16,6 +16,9 @@ const series = require('async/series')
 const isNode = require('detect-node')
 const IPFS = require('../../src')
 const ipnsPath = require('../../src/core/ipns/path')
+const ipnsRouting = require('../../src/core/ipns/routing/config')
+const OfflineDatastore = require('../../src/core/ipns/routing/offline-datastore')
+const PubsubDatastore = require('../../src/core/ipns/routing/pubsub-datastore')
 const { Key } = require('interface-datastore')
 
 const DaemonFactory = require('ipfsd-ctl')
@@ -530,6 +533,88 @@ describe('name', function () {
           })
         })
       })
+    })
+  })
+
+  describe('ipns.routing', function () {
+    it('should use only the offline datastore by default', function (done) {
+      const ipfs = {}
+      const config = ipnsRouting(ipfs)
+
+      expect(config.stores).to.have.lengthOf(1)
+      expect(config.stores[0] instanceof OfflineDatastore).to.eql(true)
+
+      done()
+    })
+
+    it('should use only the offline datastore if offline', function (done) {
+      const ipfs = {
+        _options: {
+          offline: true
+        }
+      }
+      const config = ipnsRouting(ipfs)
+
+      expect(config.stores).to.have.lengthOf(1)
+      expect(config.stores[0] instanceof OfflineDatastore).to.eql(true)
+
+      done()
+    })
+
+    it('should use the pubsub datastore if enabled', function (done) {
+      const ipfs = {
+        libp2p: {
+          pubsub: {}
+        },
+        _peerInfo: {
+          id: {}
+        },
+        _repo: {
+          datastore: {}
+        },
+        _options: {
+          EXPERIMENTAL: {
+            ipnsPubsub: true
+          }
+        }
+      }
+      const config = ipnsRouting(ipfs)
+
+      expect(config.stores).to.have.lengthOf(2)
+      expect(config.stores[0] instanceof PubsubDatastore).to.eql(true)
+      expect(config.stores[1] instanceof OfflineDatastore).to.eql(true)
+
+      done()
+    })
+
+    it('should use the dht if enabled', function (done) {
+      const dht = {}
+
+      const ipfs = {
+        libp2p: {
+          dht
+        },
+        _peerInfo: {
+          id: {}
+        },
+        _repo: {
+          datastore: {}
+        },
+        _options: {
+          libp2p: {
+            dht: {
+              enabled: true
+            }
+          }
+        }
+      }
+
+      const config = ipnsRouting(ipfs)
+
+      expect(config.stores).to.have.lengthOf(1)
+      expect(config.stores[0]).to.eql(dht)
+
+      done()
     })
   })
 })


### PR DESCRIPTION
When the DHT is not enabled, we must add the `OfflineDatastore` to for IPNS instead of the DHT