### PR TITLE
chore: update libp2p version

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "joi": "^14.3.0",
     "just-flatten-it": "^2.1.0",
     "just-safe-set": "^2.1.0",
-    "libp2p": "~0.25.0-rc.6",
+    "libp2p": "~0.25.0",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "~0.16.0",
     "libp2p-kad-dht": "~0.14.12",

--- a/src/core/runtime/libp2p-browser.js
+++ b/src/core/runtime/libp2p-browser.js
@@ -22,6 +22,13 @@ class Node extends libp2p {
     const wsstar = new WebSocketStarMulti({ servers: wsstarServers, id: _options.peerInfo.id, ignore_no_online: !wsstarServers.length || _options.wsStarIgnoreErrors })
 
     const defaults = {
+      switch: {
+        blacklistTTL: 2 * 60 * 1e3, // 2 minute base
+        blackListAttempts: 5, // back off 5 times
+        maxParallelDials: 100,
+        maxColdCalls: 25,
+        dialTimeout: 20e3
+      },
       modules: {
         transport: [
           WS,

--- a/src/core/runtime/libp2p-nodejs.js
+++ b/src/core/runtime/libp2p-nodejs.js
@@ -21,6 +21,13 @@ class Node extends libp2p {
     const wsstar = new WebSocketStarMulti({ servers: wsstarServers, id: _options.peerInfo.id, ignore_no_online: !wsstarServers.length || _options.wsStarIgnoreErrors })
 
     const defaults = {
+      switch: {
+        blacklistTTL: 2 * 60 * 1e3, // 2 minute base
+        blackListAttempts: 5, // back off 5 times
+        maxParallelDials: 150,
+        maxColdCalls: 50,
+        dialTimeout: 10e3 // Be strict with dial time
+      },
       modules: {
         transport: [
           TCP,


### PR DESCRIPTION
fix: update configurations for libp2p-switch


Libp2p 0.25 is out! This updates the dependency and adds configuration for libp2p switch to better help with connection creation and management.