### PR TITLE
refactor: enable DHT by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "execa": "^1.0.0",
     "form-data": "^2.3.3",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.104.1",
+    "interface-ipfs-core": "~0.104.2",
     "ipfsd-ctl": "~0.42.0",
     "libp2p-websocket-star": "~0.10.2",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "execa": "^1.0.0",
     "form-data": "^2.3.3",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.104.0",
+    "interface-ipfs-core": "~0.104.1",
     "ipfsd-ctl": "~0.42.0",
     "libp2p-websocket-star": "~0.10.2",
     "ncp": "^2.0.0",

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -66,10 +66,9 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
       },
       dht: {
         kBucketSize: get(options, 'dht.kBucketSize', 20),
-        // enabled: !get(options, 'offline', false), // disable if offline, on by default
-        enabled: false,
+        enabled: !get(options, 'offline', false), // disable if offline, on by default
         randomWalk: {
-          enabled: false // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
+          enabled: true
         },
         validators: {
           ipns: ipnsUtils.validator

--- a/src/core/ipns/routing/config.js
+++ b/src/core/ipns/routing/config.js
@@ -22,7 +22,7 @@ module.exports = (ipfs) => {
   }
 
   // DHT should not be added as routing if we are offline or it is disabled
-  if (get(ipfs._options, 'offline') || !get(ipfs._options, 'libp2p.dht.enabled', false)) {
+  if (get(ipfs._options, 'offline') || !get(ipfs._options, 'libp2p.dht.enabled', true)) {
     const offlineDatastore = new OfflineDatastore(ipfs._repo)
     ipnsStores.push(offlineDatastore)
   } else {

--- a/src/core/runtime/config-browser.js
+++ b/src/core/runtime/config-browser.js
@@ -28,8 +28,8 @@ module.exports = () => ({
   ],
   Swarm: {
     ConnMgr: {
-      LowWater: 200,
-      HighWater: 500
+      LowWater: 20,
+      HighWater: 50
     }
   }
 })

--- a/src/core/runtime/libp2p-browser.js
+++ b/src/core/runtime/libp2p-browser.js
@@ -62,7 +62,7 @@ class Node extends libp2p {
           }
         },
         dht: {
-          enabled: false
+          enabled: true
         },
         EXPERIMENTAL: {
           pubsub: false

--- a/src/core/runtime/libp2p-browser.js
+++ b/src/core/runtime/libp2p-browser.js
@@ -62,7 +62,15 @@ class Node extends libp2p {
           }
         },
         dht: {
-          enabled: true
+          enabled: true,
+          concurrency: 3,
+          kBucketSize: 20,
+          randomWalk: {
+            enabled: false,
+            interval: 600e3, // 10minutes
+            delay: 10e3,
+            timeout: 30e3
+          }
         },
         EXPERIMENTAL: {
           pubsub: false

--- a/src/core/runtime/libp2p-nodejs.js
+++ b/src/core/runtime/libp2p-nodejs.js
@@ -62,9 +62,9 @@ class Node extends libp2p {
         },
         dht: {
           kBucketSize: 20,
-          enabled: false,
+          enabled: true,
           randomWalk: {
-            enabled: false
+            enabled: true
           }
         },
         EXPERIMENTAL: {

--- a/src/core/runtime/libp2p-nodejs.js
+++ b/src/core/runtime/libp2p-nodejs.js
@@ -63,8 +63,12 @@ class Node extends libp2p {
         dht: {
           kBucketSize: 20,
           enabled: true,
+          concurrency: 4,
           randomWalk: {
-            enabled: true
+            enabled: true,
+            interval: 600e3,
+            delay: 5e3,
+            timeout: 20e3
           }
         },
         EXPERIMENTAL: {

--- a/test/cli/dht.js
+++ b/test/cli/dht.js
@@ -31,8 +31,7 @@ const daemonOpts = {
   initOptions: { bits: 512 }
 }
 
-// TODO: unskip when DHT is enabled in 0.36
-describe.skip('dht', () => {
+describe('dht', () => {
   let nodes = []
   let ipfsA
   let ipfsB

--- a/test/core/dht.spec.js
+++ b/test/core/dht.spec.js
@@ -12,8 +12,7 @@ const isNode = require('detect-node')
 const IPFSFactory = require('ipfsd-ctl')
 const IPFS = require('../../src/core')
 
-// TODO: unskip when DHT is enabled in 0.36
-describe.skip('dht', () => {
+describe('dht', () => {
   describe('enabled', () => {
     let ipfsd, ipfs
 

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -57,9 +57,13 @@ describe('interface-ipfs-core tests', function () {
       initOptions: { bits: 512 }
     }
   }), {
-    skip: {
-      reason: 'TODO: unskip when DHT is enabled in 0.36'
-    }
+    skip: isNode ? [
+      // dht.get
+      {
+        name: 'should get a value after it was put on another node',
+        reason: 'Needs https://github.com/ipfs/interface-ipfs-core/pull/383'
+      }
+    ] : true
   })
 
   tests.filesRegular(defaultCommonFactory, {

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -57,13 +57,7 @@ describe('interface-ipfs-core tests', function () {
       initOptions: { bits: 512 }
     }
   }), {
-    skip: isNode ? [
-      // dht.get
-      {
-        name: 'should get a value after it was put on another node',
-        reason: 'Needs https://github.com/ipfs/interface-ipfs-core/pull/383'
-      }
-    ] : true
+    skip: !isNode
   })
 
   tests.filesRegular(defaultCommonFactory, {

--- a/test/core/name.js
+++ b/test/core/name.js
@@ -537,8 +537,16 @@ describe('name', function () {
   })
 
   describe('ipns.routing', function () {
-    it('should use only the offline datastore by default', function (done) {
-      const ipfs = {}
+    it('should use offline datastore if DHT is disabled', function (done) {
+      const ipfs = {
+        _options: {
+          libp2p: {
+            dht: {
+              enabled: false
+            }
+          }
+        }
+      }
       const config = ipnsRouting(ipfs)
 
       expect(config.stores).to.have.lengthOf(1)
@@ -562,8 +570,11 @@ describe('name', function () {
     })
 
     it('should use the pubsub datastore if enabled', function (done) {
+      const dht = {}
+
       const ipfs = {
         libp2p: {
+          dht,
           pubsub: {}
         },
         _peerInfo: {
@@ -581,8 +592,8 @@ describe('name', function () {
       const config = ipnsRouting(ipfs)
 
       expect(config.stores).to.have.lengthOf(2)
-      expect(config.stores[0] instanceof PubsubDatastore).to.eql(true)
-      expect(config.stores[1] instanceof OfflineDatastore).to.eql(true)
+      expect(config.stores.some(s => s instanceof PubsubDatastore)).to.eql(true)
+      expect(config.stores).to.include(dht)
 
       done()
     })
@@ -609,6 +620,17 @@ describe('name', function () {
         }
       }
 
+      const config = ipnsRouting(ipfs)
+
+      expect(config.stores).to.have.lengthOf(1)
+      expect(config.stores[0]).to.eql(dht)
+
+      done()
+    })
+
+    it('should use the dht by default', function (done) {
+      const dht = {}
+      const ipfs = { libp2p: { dht } }
       const config = ipnsRouting(ipfs)
 
       expect(config.stores).to.have.lengthOf(1)

--- a/test/core/name.js
+++ b/test/core/name.js
@@ -196,8 +196,7 @@ describe('name', function () {
     })
   })
 
-  // TODO: unskip when DHT is enabled in 0.36
-  describe.skip('work with dht', () => {
+  describe('work with dht', () => {
     let nodes
     let nodeA
     let nodeB

--- a/test/core/ping.spec.js
+++ b/test/core/ping.spec.js
@@ -194,8 +194,7 @@ describe('ping', function () {
     })
   })
 
-  // TODO: unskip when DHT enabled in 0.36
-  describe.skip('DHT enabled', function () {
+  describe('DHT enabled', function () {
     // Our bootstrap process will run 3 IPFS daemons where
     // A ----> B ----> C
     // Allowing us to test the ping command using the DHT peer routing

--- a/test/http-api/inject/dht.js
+++ b/test/http-api/inject/dht.js
@@ -8,8 +8,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 module.exports = (http) => {
-  // TODO: unskip when DHT is enabled in 0.36
-  describe.skip('/dht', () => {
+  describe('/dht', () => {
     let api
 
     before(() => {

--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -49,9 +49,13 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
       }
     }
   }), {
-    skip: {
-      reason: 'TODO: unskip when DHT is enabled in 0.36'
-    }
+    skip: [
+      // dht.get
+      {
+        name: 'should get a value after it was put on another node',
+        reason: 'Needs https://github.com/ipfs/interface-ipfs-core/pull/383'
+      }
+    ]
   })
 
   tests.filesRegular(defaultCommonFactory)

--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -48,15 +48,7 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
         }
       }
     }
-  }), {
-    skip: [
-      // dht.get
-      {
-        name: 'should get a value after it was put on another node',
-        reason: 'Needs https://github.com/ipfs/interface-ipfs-core/pull/383'
-      }
-    ]
-  })
+  }))
 
   tests.filesRegular(defaultCommonFactory)
 


### PR DESCRIPTION
Note: also enables `randomWalk` and lowers connection manager limits in the browser.

Roadmap to getting DHT enabled by default in JS IPFS (TODO create issues/PRs for all of these):

* [x] Config changes (see [changes here](https://github.com/ipfs/js-ipfs/pull/1994/commits/7e242ece1642fb20efbfb5d5031baa6e73ef8555))
* [x] Daemon connection keepalive for long DHT requests (will arrive with the switch to using the fetch API in the http client which adds timeout option)
* [ ] [DHT reprovide](https://github.com/ipfs/js-ipfs/pull/2184)
* [ ] [Connection prioritisaton](https://github.com/libp2p/js-libp2p/issues/369) (do not prune preload nodes)
* Bug fixes:
    * [x] https://github.com/ipfs/js-ipfs-bitswap/pull/194
    * [x] https://github.com/libp2p/js-libp2p-kad-dht/pull/127
* Testing:
    * [x] DHT interface tests https://github.com/ipfs/interface-js-ipfs-core/pull/486
    * [ ] Merge interop tests https://github.com/ipfs/interop/pull/36
    * [ ] Create [DHT integration](https://github.com/ipfs/js-ipfs/issues/2093#issuecomment-495238655) tests
    * [ ] Manual DHT testing call