### PR TITLE
chore: enable name-pubsub core test

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "homepage": "https://github.com/ipfs/js-ipfs#readme",
   "devDependencies": {
     "aegir": "^18.1.0",
+    "base64url": "^3.0.1",
     "chai": "^4.2.0",
     "delay": "^4.1.0",
     "detect-node": "^2.0.4",

--- a/test/core/node.js
+++ b/test/core/node.js
@@ -3,6 +3,7 @@
 require('./circuit-relay')
 require('./files-regular-utils')
 require('./name')
+require('./name-pubsub')
 require('./key-exchange')
 require('./pin')
 require('./pin-set')


### PR DESCRIPTION
`name-pubsub` core tests were only running on `npm run test:node:core`. Moreover, this suite of tests was currently failing because the `publish` was happening before the subscription message was propagated to the other peer.