### PR TITLE
chore: update webrtc star

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "libp2p-record": "~0.6.1",
     "libp2p-secio": "~0.11.0",
     "libp2p-tcp": "~0.13.0",
-    "libp2p-webrtc-star": "~0.15.8",
+    "libp2p-webrtc-star": "~0.16.0",
     "libp2p-websocket-star-multi": "~0.4.3",
     "libp2p-websockets": "~0.12.2",
     "lodash": "^4.17.11",


### PR DESCRIPTION
In the context of [libp2p/js-libp2p-webrtc-star#172](https://github.com/libp2p/js-libp2p-webrtc-star/issues/172) and #2008 `libp2p-webrtc-star` was updated with the newest version of hapi for security and performance reasons.