### PR TITLE
docs: ipns publish key

### DIFF
--- a/src/cli/commands/name/publish.js
+++ b/src/cli/commands/name/publish.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     key: {
       alias: 'k',
-      describe: 'Name of the key to be used or a valid PeerID, as listed by "ipfs key list -l". Default: self.',
+      describe: 'Name of the key to be used, as listed by "ipfs key list -l". Default: self.',
       default: 'self'
     },
     ttl: {

--- a/src/core/components/name.js
+++ b/src/core/components/name.js
@@ -52,7 +52,7 @@ module.exports = function name (self) {
      * @param {String} options.ttl time duration this record should be cached for (NOT IMPLEMENTED YET).
      * This accepts durations such as "300s", "1.5h" or "2h45m". Valid time units are
      "ns", "ms", "s", "m", "h" (caution: experimental).
-     * @param {String} options.key name of the key to be used or a valid PeerID, as listed by 'ipfs key list -l'.
+     * @param {String} options.key name of the key to be used, as listed by 'ipfs key list -l'.
      * @param {function(Error)} [callback]
      * @returns {Promise|void}
      */


### PR DESCRIPTION
In the context of [ipfs/js-ipfs#2046](https://github.com/ipfs/js-ipfs/issues/2046), the docs were updated to reflect the current state of the implementation.