### PR TITLE
fix(cli): make swarm addrs more resilient

### DIFF
--- a/src/cli/commands/swarm/addrs.js
+++ b/src/cli/commands/swarm/addrs.js
@@ -21,7 +21,14 @@ module.exports = {
         print(`${peer.id.toB58String()} (${count})`)
 
         peer.multiaddrs.forEach((addr) => {
-          const res = addr.decapsulate('ipfs').toString()
+          let res
+          try {
+            res = addr.decapsulate('ipfs').toString()
+          } catch (_) {
+            // peer addresses dont need to have /ipfs/ as we know their peerId
+            // and can encapsulate on dial.
+            res = addr.toString()
+          }
           print(`\t${res}`)
         })
       })

--- a/src/cli/commands/swarm/addrs.js
+++ b/src/cli/commands/swarm/addrs.js
@@ -35,7 +35,7 @@ module.exports = {
       })
 
       // Return the output for printing
-      return { data: output.join('\n'), argv}
+      return { data: output.join('\n'), argv }
     })())
   }
 }

--- a/src/cli/commands/swarm/addrs.js
+++ b/src/cli/commands/swarm/addrs.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'addrs',
 
@@ -16,11 +14,12 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const res = await ipfs.swarm.addrs()
-      res.forEach((peer) => {
-        const count = peer.multiaddrs.size
-        print(`${peer.id.toB58String()} (${count})`)
 
-        peer.multiaddrs.forEach((addr) => {
+      const output = res.map((peer) => {
+        const count = peer.multiaddrs.size
+        const peerAddrs = [`${peer.id.toB58String()} (${count})`]
+
+        peer.multiaddrs.toArray().map((addr) => {
           let res
           try {
             res = addr.decapsulate('ipfs').toString()
@@ -29,9 +28,14 @@ module.exports = {
             // and can encapsulate on dial.
             res = addr.toString()
           }
-          print(`\t${res}`)
+          peerAddrs.push(`\t${res}`)
         })
+
+        return peerAddrs.join('\n')
       })
+
+      // Return the output for printing
+      return { data: output.join('\n'), argv}
     })())
   }
 }

--- a/test/cli/swarm.js
+++ b/test/cli/swarm.js
@@ -138,16 +138,13 @@ describe('swarm', () => {
       })
 
       it('should return addresses for all peers', (done) => {
-        const printSpy = sinon.stub(process.stdout, 'write')
         sinon.stub(argv, 'resolve').callsFake(promise => {
-          promise.then(() => {
-            const output = printSpy.getCalls().map(call => call.args[0])
-            printSpy.restore()
-            expect(output).to.eql([
-              `${peerInfo.id.toB58String()} (2)\n`,
-              `\t/ip4/127.0.0.1/tcp/4001\n`,
-              `\t/ip4/127.0.0.1/tcp/4001/ws\n`
-            ])
+          promise.then(({ data }) => {
+            expect(data).to.eql([
+              `${peerInfo.id.toB58String()} (2)`,
+              `\t/ip4/127.0.0.1/tcp/4001`,
+              `\t/ip4/127.0.0.1/tcp/4001/ws`
+            ].join('\n'))
             done()
           })
         })

--- a/test/cli/swarm.js
+++ b/test/cli/swarm.js
@@ -6,10 +6,15 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const series = require('async/series')
+const sinon = require('sinon')
 const ipfsExec = require('../utils/ipfs-exec')
 const path = require('path')
 const parallel = require('async/parallel')
+const addrsCommand = require('../../src/cli/commands/swarm/addrs')
+
+const multiaddr = require('multiaddr')
+const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
 
 const DaemonFactory = require('ipfsd-ctl')
 const df = DaemonFactory.create({ type: 'js' })
@@ -25,50 +30,54 @@ const config = {
 }
 
 describe('swarm', () => {
-  let bMultiaddr
-  let ipfsA
-
-  let nodes = []
-  before(function (done) {
-    // CI takes longer to instantiate the daemon, so we need to increase the
-    // timeout for the before step
-    this.timeout(80 * 1000)
-
-    series([
-      (cb) => {
-        df.spawn({
-          exec: path.resolve(`${__dirname}/../../src/cli/bin.js`),
-          config,
-          initOptions: { bits: 512 }
-        }, (err, node) => {
-          expect(err).to.not.exist()
-          ipfsA = ipfsExec(node.repoPath)
-          nodes.push(node)
-          cb()
-        })
-      },
-      (cb) => {
-        df.spawn({
-          exec: path.resolve(`${__dirname}/../../src/cli/bin.js`),
-          config,
-          initOptions: { bits: 512 }
-        }, (err, node) => {
-          expect(err).to.not.exist()
-          node.api.id((err, id) => {
-            expect(err).to.not.exist()
-            bMultiaddr = id.addresses[0]
-            nodes.push(node)
-            cb()
-          })
-        })
-      }
-    ], done)
+  afterEach(() => {
+    sinon.restore()
   })
-
-  after((done) => parallel(nodes.map((node) => (cb) => node.stop(cb)), done))
 
   describe('daemon on (through http-api)', function () {
     this.timeout(60 * 1000)
+
+    let bMultiaddr
+    let ipfsA
+
+    let nodes = []
+    before(function (done) {
+      // CI takes longer to instantiate the daemon, so we need to increase the
+      // timeout for the before step
+      this.timeout(80 * 1000)
+
+      parallel([
+        (cb) => {
+          df.spawn({
+            exec: path.resolve(`${__dirname}/../../src/cli/bin.js`),
+            config,
+            initOptions: { bits: 512 }
+          }, (err, node) => {
+            expect(err).to.not.exist()
+            ipfsA = ipfsExec(node.repoPath)
+            nodes.push(node)
+            cb()
+          })
+        },
+        (cb) => {
+          df.spawn({
+            exec: path.resolve(`${__dirname}/../../src/cli/bin.js`),
+            config,
+            initOptions: { bits: 512 }
+          }, (err, node) => {
+            expect(err).to.not.exist()
+            node.api.id((err, id) => {
+              expect(err).to.not.exist()
+              bMultiaddr = id.addresses[0]
+              nodes.push(node)
+              cb()
+            })
+          })
+        }
+      ], done)
+    })
+
+    after((done) => parallel(nodes.map((node) => (cb) => node.stop(cb)), done))
 
     it('connect', () => {
       return ipfsA('swarm', 'connect', bMultiaddr).then((out) => {
@@ -105,6 +114,54 @@ describe('swarm', () => {
     it('`peers` should not throw after `disconnect`', () => {
       return ipfsA('swarm peers').then((out) => {
         expect(out).to.be.empty()
+      })
+    })
+  })
+
+  describe('handlers', () => {
+    let peerInfo
+    const ipfs = {
+      swarm: { addrs: () => {} }
+    }
+    const argv = {
+      resolve: () => {},
+      getIpfs: () => ipfs
+    }
+
+    describe('addrs', () => {
+      before((done) => {
+        PeerId.create({ bits: 512 }, (err, peerId) => {
+          if (err) return done(err)
+          peerInfo = new PeerInfo(peerId)
+          done()
+        })
+      })
+
+      it('should return addresses for all peers', (done) => {
+        const printSpy = sinon.stub(process.stdout, 'write')
+        sinon.stub(argv, 'resolve').callsFake(promise => {
+          promise.then(() => {
+            const output = printSpy.getCalls().map(call => call.args[0])
+            printSpy.restore()
+            expect(output).to.eql([
+              `${peerInfo.id.toB58String()} (2)\n`,
+              `\t/ip4/127.0.0.1/tcp/4001\n`,
+              `\t/ip4/127.0.0.1/tcp/4001/ws\n`
+            ])
+            done()
+          })
+        })
+
+        sinon.stub(peerInfo.multiaddrs, '_multiaddrs').value([
+          multiaddr('/ip4/127.0.0.1/tcp/4001'),
+          multiaddr(`/ip4/127.0.0.1/tcp/4001/ws/ipfs/${peerInfo.id.toB58String()}`)
+        ])
+
+        sinon.stub(ipfs.swarm, 'addrs').returns(
+          Promise.resolve([peerInfo])
+        )
+
+        addrsCommand.handler(argv)
       })
     })
   })


### PR DESCRIPTION
Dont fail if decapsulation of ipfs fails. Go node addresses typically wont contain their peerid


Fixes https://github.com/ipfs/js-ipfs/issues/1575