### PR TITLE
fix: use trickle builder in daemon mode too

### DIFF
--- a/src/http/api/resources/files-regular.js
+++ b/src/http/api/resources/files-regular.js
@@ -161,7 +161,8 @@ exports.add = {
         'only-hash': Joi.boolean(),
         pin: Joi.boolean().default(true),
         'wrap-with-directory': Joi.boolean(),
-        chunker: Joi.string()
+        chunker: Joi.string(),
+        trickle: Joi.boolean()
       })
       // TODO: Necessary until validate "recursive", "stream-channels" etc.
       .options({ allowUnknown: true })
@@ -218,7 +219,8 @@ exports.add = {
       hashAlg: request.query.hash,
       wrapWithDirectory: request.query['wrap-with-directory'],
       pin: request.query.pin,
-      chunker: request.query.chunker
+      chunker: request.query.chunker,
+      strategy: request.query.trickle ? 'trickle' : 'balanced'
     }
 
     const aborter = abortable()

--- a/test/http-api/inject/files.js
+++ b/test/http-api/inject/files.js
@@ -76,6 +76,40 @@ module.exports = (http) => {
         expect(res.statusCode).to.equal(200)
         expect(multibase.isEncoded(JSON.parse(res.result).Hash)).to.deep.equal('base64')
       })
+
+      it('should add data using the trickle importer', async () => {
+        const form = new FormData()
+        form.append('data', Buffer.from('TEST\n'))
+        const headers = form.getHeaders()
+
+        const payload = await streamToPromise(form)
+        const res = await api.inject({
+          method: 'POST',
+          url: '/api/v0/add?trickle=true&pin=false',
+          headers,
+          payload
+        })
+
+        expect(res.statusCode).to.equal(200)
+        expect(JSON.parse(res.result).Hash).to.equal('QmRJTAvvv1UNgCXxK9grf6u2pCT2ZQ2wCwsojpC1sTjkp9')
+      })
+
+      it('should add data using the balanced importer', async () => {
+        const form = new FormData()
+        form.append('data', Buffer.from('TEST\n'))
+        const headers = form.getHeaders()
+
+        const payload = await streamToPromise(form)
+        const res = await api.inject({
+          method: 'POST',
+          url: '/api/v0/add?pin=false',
+          headers,
+          payload
+        })
+
+        expect(res.statusCode).to.equal(200)
+        expect(JSON.parse(res.result).Hash).to.equal('Qmdudp5XvJr7KrqK6fQ7m2ACStoRxuwfovNHnY6dAAeUis')
+      })
     })
 
     describe('/cat', () => {


### PR DESCRIPTION
At the moment this doesn't work in daemon mode..

Depends on ipfs/js-ipfs-http-client#1015