### PR TITLE
fix: fix error when preloding is disabled in the browser

### DIFF
--- a/src/core/mfs-preload.js
+++ b/src/core/mfs-preload.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const debug = require('debug')
-
+const setImmediate = require('async/setImmediate')
 const log = debug('ipfs:mfs-preload')
 log.error = debug('ipfs:mfs-preload:error')
 


### PR DESCRIPTION
Sometimes you don't want to preload everything, if your code is an example or a demo.  In that case you'd turn off preloading but `setImmediate` is [not a thing in browsers-other-than-IE](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate) so pull in `async/set-immediate` instead