### PR TITLE
fix: browser-mfs example

### DIFF
--- a/examples/browser-mfs/package.json
+++ b/examples/browser-mfs/package.json
@@ -13,8 +13,8 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "http-server": "~0.11.1",
-    "uglifyjs-webpack-plugin": "^2.1.2",
-    "webpack": "^4.15.1",
+    "terser-webpack-plugin": "^1.2.1",
+    "webpack": "^4.28.4",
     "webpack-cli": "^3.0.8"
   },
   "dependencies": {

--- a/examples/browser-mfs/webpack.config.js
+++ b/examples/browser-mfs/webpack.config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = {
@@ -11,18 +11,44 @@ module.exports = {
     './index.js'
   ],
   plugins: [
-    new UglifyJsPlugin({
-      sourceMap: true,
-      uglifyOptions: {
-        mangle: false,
-        compress: false
-      }
-    }),
     new HtmlWebpackPlugin({
       title: 'IPFS MFS example',
       template: 'index.html'
     })
   ],
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          parse: {
+            // we want terser to parse ecma 8 code. However, we don't want it
+            // to apply any minfication steps that turns valid ecma 5 code
+            // into invalid ecma 5 code. This is why the 'compress' and 'output'
+            // sections only apply transformations that are ecma 5 safe
+            // https://github.com/facebook/create-react-app/pull/4234
+            ecma: 8
+          },
+          compress: {
+            ecma: 5,
+            warnings: false
+          },
+          mangle: {
+            safari10: true
+          },
+          output: {
+            ecma: 5,
+            comments: false
+          }
+        },
+        // Use multi-process parallel running to improve the build speed
+        // Default number of concurrent runs: os.cpus().length - 1
+        parallel: true,
+        // Enable file caching
+        cache: true,
+        sourceMap: true
+      })
+    ]
+  },
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'bundle.js'


### PR DESCRIPTION
Switch to a different plugin which correctly compiles modern JS