### PR TITLE
feat: ready promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ We've come a long way, but this project is still in Alpha, lots of development i
   - [API Docs](#api)
     - [Constructor](#ipfs-constructor)
     - [Events](#events)
+    - [ready](#nodeready)
     - [start](#nodestart)
     - [stop](#nodestop)
     - [Core API](#core-api)
@@ -540,6 +541,16 @@ node.on('error', errorObject => console.error(errorObject))
 - `start` is emitted when a node has started listening for connections. It will not be emitted if you set the `start: false` option on the constructor.
 
 - `stop` is emitted when a node has closed all connections and released access to its repo. This is usually the result of calling [`node.stop()`](#nodestop).
+
+#### `node.ready`
+
+A promise that resolves when the node is ready to use. Should be used when constructing an IPFS node using `new`. You don't need to use this if you're using [`await IPFS.create`](#ipfs-constructor). e.g.
+
+```js
+const node = new IPFS()
+await node.ready
+// Ready to use!
+```
 
 #### `node.start()`
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,10 @@ To create an IPFS node programmatically:
 
 ```js
 const IPFS = require('ipfs')
-const node = new IPFS()
+const node = await IPFS.create()
 
-node.on('ready', () => {
-  // Ready to use!
-  // See https://github.com/ipfs/js-ipfs#core-api
-})
+// Ready to use!
+// See https://github.com/ipfs/js-ipfs#core-api
 ```
 
 ### Through command line tool
@@ -124,8 +122,7 @@ The CLI is available by using the command `jsipfs` in your terminal. This is ali
 
 Learn how to bundle with browserify and webpack in the [`examples`](https://github.com/ipfs/js-ipfs/tree/master/examples) folder.
 
-
-You can also load it using a `<script>` using the [unpkg](https://unpkg.com) CDN **or** the [jsDelivr](https://www.jsdelivr.com/package/npm/ipfs) CDN. Inserting one of the following lines will make a `Ipfs` object available in the global namespace.
+You can also load it using a `<script>` using the [unpkg](https://unpkg.com) CDN **or** the [jsDelivr](https://www.jsdelivr.com/package/npm/ipfs) CDN. Inserting one of the following lines will make an `Ipfs` object available in the global namespace.
 
 ```html
 <!-- loading the minified version using unpkg -->
@@ -148,12 +145,12 @@ Inserting one of the above lines will make an `Ipfs` object available in the glo
 
 ```html
 <script>
-const node = new window.Ipfs()
-
-node.on('ready', () => {
+async function main () {
+  const node = await window.Ipfs.create()
   // Ready to use!
   // See https://github.com/ipfs/js-ipfs#core-api
-})
+}
+main()
 </script>
 ```
 
@@ -161,7 +158,7 @@ node.on('ready', () => {
 
 ### IPFS CLI
 
-The `jsipfs` CLI, available when `js-ipfs` is installed globally, follows(should, it is a WIP) the same interface defined by `go-ipfs`, you can always use the `help` command for help menus.
+The `jsipfs` CLI, available when `js-ipfs` is installed globally, follows (should, it is a WIP) the same interface defined by `go-ipfs`, you can always use the `help` command for help menus.
 
 ```sh
 # Install js-ipfs globally
@@ -191,20 +188,14 @@ If you want a programmatic way to spawn a IPFS Daemon using JavaScript, check ou
 
 ### IPFS Module
 
-Use the IPFS Module as a dependency of a project to __spawn in process instances of IPFS__. Create an instance by calling `new IPFS()` and waiting for its `ready` event:
+Use the IPFS Module as a dependency of a project to __spawn in process instances of IPFS__. Create an instance by calling `await IPFS.create()`:
 
 ```js
 // Create the IPFS node instance
-const node = new IPFS()
-
-node.on('ready', () => {
-  // Your node is now ready to use \o/
-
-  // stopping a node
-  node.stop(() => {
-    // node is now 'offline'
-  })
-})
+const node = await IPFS.create()
+// Your node is now ready to use \o/
+await node.stop()
+// node is now 'offline'
 ```
 
 ### [Tutorials and Examples](/examples)
@@ -216,11 +207,10 @@ You can find some examples and tutorials in the [examples](/examples) folder, th
 #### IPFS Constructor
 
 ```js
-const node = new IPFS([options])
+const node = await IPFS.create([options])
 ```
 
 Creates and returns an instance of an IPFS node. Use the `options` argument to specify advanced configuration. It is an object with any of these properties:
-
 
 ##### `options.repo`
 
@@ -234,7 +224,7 @@ Example:
 
 ```js
 // Store data outside your user directory
-const node = new IPFS({ repo: '/var/ipfs/data' })
+const node = await IPFS.create({ repo: '/var/ipfs/data' })
 ```
 
 ##### `options.init`

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:node:cli": "aegir test -t node -f test/cli/index.js",
     "test:node:interface": "aegir test -t node -f test/core/interface.spec.js",
     "test:bootstrapers": "IPFS_TEST=bootstrapers aegir test -t browser -f test/bootstrapers.js",
+    "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
     "benchmark": "echo \"Error: no benchmarks yet\" && exit 1",
     "benchmark:node": "echo \"Error: no benchmarks yet\" && exit 1",
     "benchmark:node:core": "echo \"Error: no benchmarks yet\" && exit 1",

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -142,6 +142,14 @@ class IPFS extends EventEmitter {
     this.state = require('./state')(this)
 
     boot(this)
+    this.once('ready', () => this.__ready = true)
+  }
+  get ready () {
+    return new Promise((resolve, reject) => {
+      if (this.__ready) return resolve(this)
+      this.on('ready', () => resolve(this))
+      this.on('error', reject)
+    })
   }
 }
 
@@ -153,4 +161,9 @@ Object.assign(module.exports, { crypto, isIPFS, Buffer: BufferImpl, CID, multiad
 
 module.exports.createNode = (options) => {
   return new IPFS(options)
+}
+
+exports.create = (options) => {
+  let node = new IPFS(options)
+  return node.ready
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -142,13 +142,14 @@ class IPFS extends EventEmitter {
     this.state = require('./state')(this)
 
     boot(this)
-    this.once('ready', () => { this.__ready = true })
+    this.once('ready', () => { this._ready = true })
   }
+
   get ready () {
     return new Promise((resolve, reject) => {
-      if (this.__ready) return resolve(this)
-      this.on('ready', () => resolve(this))
-      this.on('error', reject)
+      if (this._ready) return resolve(this)
+      this.once('ready', () => resolve(this))
+      this.once('error', reject)
     })
   }
 }
@@ -163,7 +164,6 @@ module.exports.createNode = (options) => {
   return new IPFS(options)
 }
 
-exports.create = (options) => {
-  let node = new IPFS(options)
-  return node.ready
+module.exports.create = (options) => {
+  return new IPFS(options).ready
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -142,7 +142,7 @@ class IPFS extends EventEmitter {
     this.state = require('./state')(this)
 
     boot(this)
-    this.once('ready', () => this.__ready = true)
+    this.once('ready', () => { this.__ready = true })
   }
   get ready () {
     return new Promise((resolve, reject) => {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -141,13 +141,25 @@ class IPFS extends EventEmitter {
 
     this.state = require('./state')(this)
 
+    const onReady = () => {
+      this.removeListener('error', onError)
+      this._ready = true
+    }
+
+    const onError = err => {
+      this.removeListener('ready', onReady)
+      this._readyError = err
+    }
+
+    this.once('ready', onReady).once('error', onError)
+
     boot(this)
-    this.once('ready', () => { this._ready = true })
   }
 
   get ready () {
     return new Promise((resolve, reject) => {
       if (this._ready) return resolve(this)
+      if (this._readyError) return reject(this._readyError)
       this.once('ready', () => resolve(this))
       this.once('error', reject)
     })

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -20,7 +20,7 @@ const IPFS = require('../../src/core')
 // This gets replaced by `create-repo-browser.js` in the browser
 const createTempRepo = require('../utils/create-repo-nodejs.js')
 
-describe.only('create node', function () {
+describe('create node', function () {
   let tempRepo
 
   beforeEach(() => {

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -20,7 +20,7 @@ const IPFS = require('../../src/core')
 // This gets replaced by `create-repo-browser.js` in the browser
 const createTempRepo = require('../utils/create-repo-nodejs.js')
 
-describe('create node', function () {
+describe.only('create node', function () {
   let tempRepo
 
   beforeEach(() => {
@@ -34,6 +34,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: path.join(os.tmpdir(), 'ipfs-repo-' + hat()),
+      init: { bits: 512 },
       config: {
         Addresses: {
           Swarm: []
@@ -60,6 +61,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: tempRepo,
+      init: { bits: 512 },
       config: {
         Addresses: {
           Swarm: []
@@ -85,6 +87,7 @@ describe('create node', function () {
 
     const node = IPFS.createNode({
       repo: tempRepo,
+      init: { bits: 512 },
       config: {
         Addresses: {
           Swarm: []
@@ -109,7 +112,7 @@ describe('create node', function () {
 
   it('should resolve ready promise when initialized not started', async () => {
     const ipfs = new IPFS({
-      init: true,
+      init: { bits: 512 },
       start: false,
       repo: tempRepo,
       config: { Addresses: { Swarm: [] } }
@@ -135,7 +138,7 @@ describe('create node', function () {
 
   it('should resolve ready promise when initialized and started', async () => {
     const ipfs = new IPFS({
-      init: true,
+      init: { bits: 512 },
       start: true,
       repo: tempRepo,
       config: { Addresses: { Swarm: [] } }
@@ -150,6 +153,7 @@ describe('create node', function () {
   it('should resolve ready promise when already ready', async () => {
     const ipfs = new IPFS({
       repo: tempRepo,
+      init: { bits: 512 },
       config: { Addresses: { Swarm: [] } }
     })
 
@@ -164,7 +168,7 @@ describe('create node', function () {
   it('should reject ready promise on boot error', async () => {
     const ipfs = new IPFS({
       repo: tempRepo,
-      init: { bits: 1 }, // Too few bits will cause error on boot
+      init: { bits: 256 }, // Too few bits will cause error on boot
       config: { Addresses: { Swarm: [] } }
     })
 
@@ -173,7 +177,14 @@ describe('create node', function () {
     try {
       await ipfs.ready
     } catch (err) {
-      return expect(ipfs.isOnline()).to.be.false()
+      expect(ipfs.isOnline()).to.be.false()
+
+      // After the error has occurred, it should still reject
+      try {
+        await ipfs.ready
+      } catch (_) {
+        return
+      }
     }
 
     throw new Error('ready promise did not reject')
@@ -182,6 +193,7 @@ describe('create node', function () {
   it('should create a ready node with IPFS.create', async () => {
     const ipfs = await IPFS.create({
       repo: tempRepo,
+      init: { bits: 512 },
       config: { Addresses: { Swarm: [] } }
     })
 
@@ -195,7 +207,7 @@ describe('create node', function () {
     const node = new IPFS({
       repo: tempRepo,
       init: {
-        bits: 512
+        bits: 1024
       },
       config: {
         Addresses: {
@@ -225,6 +237,7 @@ describe('create node', function () {
     const ipfs = new IPFS({
       silent: true,
       repo: tempRepo,
+      init: { bits: 512 },
       preload: { enabled: false }
     })
 
@@ -306,7 +319,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: tempRepo,
-      init: true,
+      init: { bits: 512 },
       start: false,
       config: {
         Addresses: {
@@ -329,7 +342,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: tempRepo,
-      init: true,
+      init: { bits: 512 },
       start: false,
       config: {
         Addresses: {
@@ -351,6 +364,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: tempRepo,
+      init: { bits: 512 },
       config: {
         Addresses: {
           Swarm: ['/ip4/127.0.0.1/tcp/9977']
@@ -378,6 +392,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: tempRepo,
+      init: { bits: 512 },
       config: {
         Addresses: {
           Swarm: []
@@ -400,6 +415,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: tempRepo,
+      init: { bits: 512 },
       config: {
         Addresses: {
           Swarm: []
@@ -421,6 +437,7 @@ describe('create node', function () {
 
     const options = {
       repo: tempRepo,
+      init: { bits: 512 },
       config: {
         Addresses: {
           Swarm: []
@@ -452,7 +469,7 @@ describe('create node', function () {
       _nodeNumber++
       return new IPFS({
         repo,
-        init: { emptyRepo: true },
+        init: { bits: 512, emptyRepo: true },
         config: {
           Addresses: {
             API: `/ip4/127.0.0.1/tcp/${5010 + _nodeNumber}`,
@@ -512,6 +529,7 @@ describe('create node', function () {
 
     const node = new IPFS({
       repo: tempRepo,
+      init: { bits: 512 },
       ipld: {},
       preload: { enabled: false }
     })

--- a/test/core/create-node.spec.js
+++ b/test/core/create-node.spec.js
@@ -107,6 +107,88 @@ describe('create node', function () {
     })
   })
 
+  it('should resolve ready promise when initialized not started', async () => {
+    const ipfs = new IPFS({
+      init: true,
+      start: false,
+      repo: tempRepo,
+      config: { Addresses: { Swarm: [] } }
+    })
+
+    expect(ipfs.isOnline()).to.be.false()
+    await ipfs.ready
+    expect(ipfs.isOnline()).to.be.false()
+  })
+
+  it('should resolve ready promise when not initialized and not started', async () => {
+    const ipfs = new IPFS({
+      init: false,
+      start: false,
+      repo: tempRepo,
+      config: { Addresses: { Swarm: [] } }
+    })
+
+    expect(ipfs.isOnline()).to.be.false()
+    await ipfs.ready
+    expect(ipfs.isOnline()).to.be.false()
+  })
+
+  it('should resolve ready promise when initialized and started', async () => {
+    const ipfs = new IPFS({
+      init: true,
+      start: true,
+      repo: tempRepo,
+      config: { Addresses: { Swarm: [] } }
+    })
+
+    expect(ipfs.isOnline()).to.be.false()
+    await ipfs.ready
+    expect(ipfs.isOnline()).to.be.true()
+    await ipfs.stop()
+  })
+
+  it('should resolve ready promise when already ready', async () => {
+    const ipfs = new IPFS({
+      repo: tempRepo,
+      config: { Addresses: { Swarm: [] } }
+    })
+
+    expect(ipfs.isOnline()).to.be.false()
+    await ipfs.ready
+    expect(ipfs.isOnline()).to.be.true()
+    await ipfs.ready
+    expect(ipfs.isOnline()).to.be.true()
+    await ipfs.stop()
+  })
+
+  it('should reject ready promise on boot error', async () => {
+    const ipfs = new IPFS({
+      repo: tempRepo,
+      init: { bits: 1 }, // Too few bits will cause error on boot
+      config: { Addresses: { Swarm: [] } }
+    })
+
+    expect(ipfs.isOnline()).to.be.false()
+
+    try {
+      await ipfs.ready
+    } catch (err) {
+      return expect(ipfs.isOnline()).to.be.false()
+    }
+
+    throw new Error('ready promise did not reject')
+  })
+
+  it('should create a ready node with IPFS.create', async () => {
+    const ipfs = await IPFS.create({
+      repo: tempRepo,
+      config: { Addresses: { Swarm: [] } }
+    })
+
+    expect(ipfs.isOnline()).to.be.true()
+    await ipfs.stop()
+  })
+
   it('init: { bits: 1024 }', function (done) {
     this.timeout(80 * 1000)
 


### PR DESCRIPTION
This PR is rebased and extended from https://github.com/ipfs/js-ipfs/pull/1878. I've added tests for `node.ready` and `IPFS.create`, and updated the documentation.

**REVIEWERS**: Please be sure to review the README.md changes (github is not rendering the diff by default).

resolves https://github.com/ipfs/js-ipfs/issues/1762
closes #1878 

---

This change is **completely backwards compatible** with existing methods of creating a ready IPFS node. It does two things:

1. Adds functionalty for promised node creation and ready state
2. Alters documentation to recommend usage of promise based APIs over callback APIs

Now is the right time to add this functionality. This will get _existing_ users thinking about switching to promise based APIs and will onboard _new_ users to using the Promise based APIs.

The idea is that this will **lessen the impact** of the [async await/iterators refactor](https://github.com/ipfs/js-ipfs/issues/1670) to users when it bubbles up to this level - users will have to change their applications to resolve API breakages but _not also_ have to deal with a switch from callbacks to promises.

TODO (not necessarily as dependencies of this PR):

* [ ] Update examples to use promise based APIs
* [ ] Update `interface-ipfs-core` to use promise APIs in examples
* [ ] PR to `ipfs-http-client` to add `IPFS.create` and `node.ready` so they can be used interchangably (?? do you think we really need this?)