### PR TITLE
feat(bitswap humanize): add humanize flag (--human) support to bitswap stat

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "dlv": "^1.1.3",
     "err-code": "^1.1.2",
     "file-type": "^11.1.0",
+    "filesize": "^4.1.2",
     "fnv1a": "^1.0.1",
     "fsm-event": "^2.1.0",
     "get-folder-size": "^2.0.0",

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -3,6 +3,7 @@
 const multibase = require('multibase')
 const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
+const filesize = require('filesize')
 
 module.exports = {
   command: 'stat',
@@ -14,20 +15,30 @@ module.exports = {
       describe: 'Number base to display CIDs in. Note: specifying a CID base for v0 CIDs will have no effect.',
       type: 'string',
       choices: multibase.names
+    },
+    human: {
+      describe: 'Print sizes in human readable format (e.g., 1K 234M 2G).',
+      type: 'boolean',
+      default: false
     }
   },
 
-  handler ({ getIpfs, cidBase, resolve }) {
+  handler ({ getIpfs, cidBase, resolve, human }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const stats = await ipfs.bitswap.stat()
       stats.wantlist = stats.wantlist.map(k => cidToString(k['/'], { base: cidBase, upgrade: false }))
       stats.peers = stats.peers || []
+      if (human) {
+        stats.dupDataReceived = filesize(stats.dupDataReceived)
+      } else {
+        stats.dupDataReceived += ' B'
+      }
 
       print(`bitswap status
   blocks received: ${stats.blocksReceived}
   dup blocks received: ${stats.dupBlksReceived}
-  dup data received: ${stats.dupDataReceived}B
+  dup data received: ${stats.dupDataReceived}
   wantlist [${stats.wantlist.length} keys]
     ${stats.wantlist.join('\n    ')}
   partners [${stats.peers.length}]

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -77,7 +77,7 @@ describe('bitswap', () => runOn((thing) => {
         'bitswap status',
         '  blocks received: 0',
         '  dup blocks received: 0',
-        '  dup data received: 0B',
+        '  dup data received: 0 B',
         // We sometimes pick up partners while the tests run and the order of
         // wanted keys is not defined so our assertion ends here.
         '  wantlist [2 keys]'
@@ -85,6 +85,13 @@ describe('bitswap', () => runOn((thing) => {
 
       expect(out).to.include(key0)
       expect(out).to.include(key1)
+    })
+  })
+
+  it('stat with --human flag', function () {
+    this.timeout(20 * 1000)
+    return ipfs('bitswap stat --human').then((out) => {
+      expect(out).to.include('dup data received: 0 B')
     })
   })
 


### PR DESCRIPTION
* add humanize option (--human) to bitswap stat cli command
```jsipfs bitswap stat --human```
OR
```jsipfs stats bitswap --human```

* add related test for the same

closes: ipfs#2057

License: MIT
Signed-off-by: Prabhakar-Poudel <yuvrajzohan@gmail.com>