### PR TITLE
update ipns reference to libp2p dht config

### DIFF
--- a/src/core/ipns/routing/config.js
+++ b/src/core/ipns/routing/config.js
@@ -22,7 +22,7 @@ module.exports = (ipfs) => {
   }
 
   // DHT should not be added as routing if we are offline or it is disabled
-  if (get(ipfs._options, 'offline') || !get(ipfs._options, 'libp2p.dht.enabled', false)) {
+  if (get(ipfs._options, 'offline') || !get(ipfs._options, 'libp2p.config.dht.enabled', false)) {
     const offlineDatastore = new OfflineDatastore(ipfs._repo)
     ipnsStores.push(offlineDatastore)
   } else {


### PR DESCRIPTION
The ipns initialization is checking the wrong path to the libp2p's dht config flag, and as result it always boots in the offline state.

The following code should print the enabled routers:
```javascript
const config = {EXPERIMENTAL:{dht:true}, libp2p:{config:{dht:{enabled:true}}}}
const ipfs = new Ipfs(config)
ipfs.on('ready', () => console.log(ipfs._ipns.routing.stores))
```

With the patch the `ipfs.libp2p.dht` datastore is used.