### PR TITLE
feat: reprovider

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "multihashes": "~0.4.14",
     "multihashing-async": "~0.6.0",
     "node-fetch": "^2.3.0",
+    "p-queue": "^6.0.2",
     "peer-book": "~0.9.0",
     "peer-id": "~0.12.0",
     "peer-info": "~0.15.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "hashlru": "^2.3.0",
     "human-to-milliseconds": "^2.0.0",
     "interface-datastore": "~0.6.0",
-    "ipfs-bitswap": "~0.24.1",
+    "ipfs-bitswap": "ipfs/js-ipfs-bitswap#feat/use-ipfs-provider",
     "ipfs-block": "~0.8.1",
     "ipfs-block-service": "~0.15.1",
     "ipfs-http-client": "^32.0.1",

--- a/src/core/components/files-regular/refs-local-pull-stream.js
+++ b/src/core/components/files-regular/refs-local-pull-stream.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const CID = require('cids')
-const base32 = require('base32.js')
 const pull = require('pull-stream')
 const pullDefer = require('pull-defer')
+const { blockKeyToCid } = require('../../utils')
 
 module.exports = function (self) {
   return () => {
@@ -14,21 +13,12 @@ module.exports = function (self) {
         return deferred.resolve(pull.error(err))
       }
 
-      const refs = blocks.map(b => dsKeyToRef(b.key))
+      const refs = blocks.map(b => ({
+        ref: blockKeyToCid(b.key).toString()
+      }))
       deferred.resolve(pull.values(refs))
     })
 
     return deferred
-  }
-}
-
-function dsKeyToRef (key) {
-  try {
-    // Block key is of the form /<base32 encoded string>
-    const decoder = new base32.Decoder()
-    const buff = Buffer.from(decoder.write(key.toString().slice(1)).finalize())
-    return { ref: new CID(buff).toString() }
-  } catch (err) {
-    return { err: `Could not convert block with key '${key}' to CID: ${err.message}` }
   }
 }

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -67,6 +67,7 @@ const configSchema = s({
       }))
     })),
     Reprovider: optional(s({
+      Delay: 'string?',
       Interval: 'string?',
       Strategy: 'string?'
     })),

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -66,6 +66,10 @@ const configSchema = s({
         Enabled: 'boolean?'
       }))
     })),
+    Reprovider: optional(s({
+      Interval: 'string?',
+      Strategy: 'string?'
+    })),
     Bootstrap: optional(s(['multiaddr-ipfs']))
   })),
   ipld: 'object?',

--- a/src/core/provider/index.js
+++ b/src/core/provider/index.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const errCode = require('err-code')
+const human = require('human-to-milliseconds')
+const promisify = require('promisify-es6')
+
+const CID = require('cids')
+
+const Reprovider = require('./reprovider')
+
+class Provider {
+  /**
+   * Provider goal is to announce blocks to the network.
+   * It keeps track of which blocks are provided, and allow them to be reprovided
+   * @param {Libp2p} libp2p
+   * @param {Blockstore} blockstore
+   * @param {object} options
+   * @memberof Provider
+   */
+  constructor (libp2p, blockstore, options) {
+    this._running = false
+
+    this._contentRouting = libp2p.contentRouting
+    this._blockstore = blockstore
+    this._options = options
+    this.reprovider = undefined
+  }
+
+  /**
+   * Begin processing the provider work
+   * @returns {void}
+   */
+  async start () {
+    // do not run twice
+    if (this._running) {
+      return
+    }
+
+    this._running = true
+
+    // handle options
+    const strategy = this._options.strategy || 'all'
+    const humanInterval = this._options.Interval || '12h'
+    const interval = await promisify((callback) => human(humanInterval, callback))()
+    const options = {
+      interval,
+      strategy
+    }
+
+    this.reprovider = new Reprovider(this._contentRouting, this._blockstore, options)
+
+    // Start reprovider
+    this.reprovider.start()
+  }
+
+  /**
+   * Stop the provider
+   * @returns {void}
+   */
+  stop () {
+    this._running = true
+
+    // stop the reprovider
+    this.reprovider.stop()
+  }
+
+  /**
+   * Announce block to the network and add and entry to the tracker
+   * Takes a cid and makes an attempt to announce it to the network
+   * @param {CID} cid
+   */
+  async provide (cid) {
+    if (!CID.isCID(cid)) {
+      throw errCode('invalid CID to provide', 'ERR_INVALID_CID')
+    }
+
+    await promisify((callback) => {
+      this._contentRouting.provide(cid, callback)
+    })()
+  }
+
+  async findProviders (cid, options) { // eslint-disable-line require-await
+    if (!CID.isCID(cid)) {
+      throw errCode('invalid CID to find', 'ERR_INVALID_CID')
+    }
+
+    return promisify((callback) => {
+      this._contentRouting.findProviders(cid, options, callback)
+    })()
+  }
+}
+
+exports = module.exports = Provider

--- a/src/core/provider/index.js
+++ b/src/core/provider/index.js
@@ -3,6 +3,7 @@
 const errCode = require('err-code')
 const human = require('human-to-milliseconds')
 const promisify = require('promisify-es6')
+const assert = require('assert')
 
 const CID = require('cids')
 
@@ -26,6 +27,8 @@ class Provider {
     this._blockstore = blockstore
     this._options = options
     this.reprovider = undefined
+
+    this._validateOptions()
   }
 
   /**
@@ -63,7 +66,7 @@ class Provider {
    * @returns {void}
    */
   stop () {
-    this._running = true
+    this._running = false
 
     // stop the reprovider
     this.reprovider.stop()
@@ -100,6 +103,19 @@ class Provider {
     return promisify((callback) => {
       this._contentRouting.findProviders(cid, options, callback)
     })()
+  }
+
+  // Validate Provider options
+  _validateOptions () {
+    const delay = (this._options.Delay || this._options.delay)
+    assert(delay && parseInt(delay) !== 0, '0 delay is not a valid value for reprovider')
+
+    const interval = (this._options.Interval || this._options.interval)
+    assert(interval && parseInt(interval) !== 0, '0 interval is not a valid value for reprovider')
+
+    const strategy = (this._options.Strategy || this._options.strategy)
+    assert(strategy && (strategy === 'all' || strategy === 'pinned' || strategy === 'roots'),
+      'Reprovider must have one of the following strategies: `all`, `pinned` or `roots`')
   }
 }
 

--- a/src/core/provider/queue.js
+++ b/src/core/provider/queue.js
@@ -1,0 +1,110 @@
+'use strict'
+
+const queue = require('async/queue')
+
+const debug = require('debug')
+const log = debug('ipfs:provider')
+log.error = debug('ipfs:provider:error')
+
+class WorkerQueue {
+  /**
+   * Creates an instance of a WorkerQueue.
+   * @param {function} executeWork
+   * @param {number} [concurrency=3]
+   */
+  constructor (executeWork, concurrency = 3) {
+    this.executeWork = executeWork
+    this._concurrency = concurrency
+
+    this.running = false
+    this.queue = this._setupQueue()
+  }
+
+  /**
+   * Create the underlying async queue.
+   * @returns {queue}
+   */
+  _setupQueue () {
+    const q = queue(async (block) => {
+      await this._processNext(block)
+    }, this._concurrency)
+
+    // If there is an error, stop the worker
+    q.error = (err) => {
+      log.error(err)
+      this.stop(err)
+    }
+
+    q.buffer = 0
+
+    return q
+  }
+
+  /**
+   * Use the queue from async to keep `concurrency` amount items running
+   * @param {Block[]} blocks
+   * @returns {Promise}
+   */
+  async execute (blocks) {
+    this.running = true
+
+    // store the promise resolution functions to be resolved at end of queue
+    this.execution = {}
+    const execPromise = new Promise((resolve, reject) => Object.assign(this.execution, { resolve, reject }))
+
+    // When all blocks have been processed, stop the worker
+    this.queue.drain = () => {
+      log('queue:drain')
+      this.stop()
+    }
+
+    // Fill queue with blocks
+    this.queue.push(blocks)
+
+    await execPromise
+  }
+
+  /**
+   * Stop the worker, optionally an error is thrown if received
+   *
+   * @param {object} error
+   */
+  stop (error) {
+    if (!this.running) {
+      return
+    }
+
+    this.running = false
+    this.queue.kill()
+
+    if (error) {
+      this.execution && this.execution.reject(error)
+    } else {
+      this.execution && this.execution.resolve()
+    }
+  }
+
+  /**
+   * Process the next block in the queue.
+   * @param {Block} block
+   */
+  async _processNext (block) {
+    if (!this.running) {
+      return
+    }
+
+    // Execute work
+    log('queue:work')
+
+    let execErr
+    try {
+      await this.executeWork(block)
+    } catch (err) {
+      execErr = err
+    }
+
+    log('queue:work:done', execErr)
+  }
+}
+
+exports = module.exports = WorkerQueue

--- a/src/core/provider/reprovider.js
+++ b/src/core/provider/reprovider.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const promisify = require('promisify-es6')
+const WorkerQueue = require('./queue')
+
+const { blockKeyToCid } = require('../utils')
+
+// const initialDelay = 15000
+const initialDelay = 3000
+
+class Reprovider {
+  /**
+   * Reprovider goal is to reannounce blocks to the network.
+   * @param {object} contentRouting
+   * @param {Blockstore} blockstore
+   * @param {object} options
+   * @memberof Reprovider
+   */
+  constructor (contentRouting, blockstore, options) {
+    this._contentRouting = contentRouting
+    this._blockstore = blockstore
+    this._options = options
+
+    this._timeoutId = undefined
+    this._worker = new WorkerQueue(this._provideBlock)
+  }
+
+  /**
+   * Begin processing the reprovider work and waiting for reprovide triggers
+   * @returns {void}
+   */
+  start () {
+    // Start doing reprovides after the initial delay
+    this._timeoutId = setTimeout(() => {
+      this._runPeriodically()
+    }, initialDelay)
+  }
+
+  /**
+   * Stops the reprovider. Any active reprovide actions should be aborted
+   * @returns {void}
+   */
+  stop () {
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId)
+      this._timeoutId = undefined
+    }
+    this._worker.stop()
+  }
+
+  /**
+   * Run reprovide on every `options.interval` ms
+   * @returns {void}
+   */
+  async _runPeriodically () {
+    while (this._timeoutId) {
+      const blocks = await promisify((callback) => this._blockstore.query({}, callback))()
+
+      // TODO strategy logic here
+      if (this._options.strategy === 'pinned') {
+
+      } else if (this._options.strategy === 'pinned') {
+
+      }
+
+      await this._worker.execute(blocks)
+
+      // Each subsequent walk should run on a `this._options.interval` interval
+      await new Promise(resolve => {
+        this._timeoutId = setTimeout(resolve, this._options.interval)
+      })
+    }
+  }
+
+  /**
+   * Do the reprovide work to libp2p content routing
+   * @param {Block} block
+   * @returns {void}
+   */
+  async _provideBlock (block) {
+    const cid = blockKeyToCid(block.key.toBuffer())
+
+    await promisify((callback) => {
+      this._contentRouting.provide(cid, callback)
+    })()
+  }
+}
+
+exports = module.exports = Reprovider

--- a/src/core/provider/reprovider.js
+++ b/src/core/provider/reprovider.js
@@ -11,8 +11,8 @@ class Reprovider {
    * @param {object} contentRouting
    * @param {Blockstore} blockstore
    * @param {object} options
-   * @param {string} options.delay reprovider initial delay in human friendly time
-   * @param {string} options.interval reprovider interval in human friendly time
+   * @param {string} options.delay reprovider initial delay in milliseconds
+   * @param {string} options.interval reprovider interval in milliseconds
    * @param {string} options.strategy reprovider strategy
    */
   constructor (contentRouting, blockstore, options) {
@@ -60,7 +60,7 @@ class Reprovider {
 
     if (this._options.strategy === 'pinned') {
 
-    } else if (this._options.strategy === 'pinned') {
+    } else if (this._options.strategy === 'roots') {
 
     }
 

--- a/src/core/runtime/config-browser.js
+++ b/src/core/runtime/config-browser.js
@@ -27,6 +27,10 @@ module.exports = () => ({
     '/dns4/node0.preload.ipfs.io/tcp/443/wss/ipfs/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
     '/dns4/node1.preload.ipfs.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6'
   ],
+  Reprovider: {
+    Interval: '12h',
+    Strategy: 'all'
+  },
   Swarm: {
     ConnMgr: {
       LowWater: 200,

--- a/src/core/runtime/config-browser.js
+++ b/src/core/runtime/config-browser.js
@@ -28,6 +28,7 @@ module.exports = () => ({
     '/dns4/node1.preload.ipfs.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6'
   ],
   Reprovider: {
+    Delay: '15s',
     Interval: '12h',
     Strategy: 'all'
   },

--- a/src/core/runtime/config-nodejs.js
+++ b/src/core/runtime/config-nodejs.js
@@ -40,6 +40,10 @@ module.exports = () => ({
     '/dns4/node0.preload.ipfs.io/tcp/443/wss/ipfs/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
     '/dns4/node1.preload.ipfs.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6'
   ],
+  Reprovider: {
+    Interval: '12h',
+    Strategy: 'all'
+  },
   Swarm: {
     ConnMgr: {
       LowWater: 200,

--- a/src/core/runtime/config-nodejs.js
+++ b/src/core/runtime/config-nodejs.js
@@ -41,6 +41,7 @@ module.exports = () => ({
     '/dns4/node1.preload.ipfs.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6'
   ],
   Reprovider: {
+    Delay: '15s',
     Interval: '12h',
     Strategy: 'all'
   },

--- a/test/core/provider.spec.js
+++ b/test/core/provider.spec.js
@@ -13,12 +13,14 @@ const IPFS = require('../../src')
 const DaemonFactory = require('ipfsd-ctl')
 const df = DaemonFactory.create({ type: 'proc' })
 
+const DELAY = '3s'
 const INTERVAL = '10s'
 const STRATEGY = 'all'
 
 const config = {
   Bootstrap: [],
   Reprovider: {
+    Delay: DELAY,
     Interval: INTERVAL,
     Strategy: STRATEGY
   }
@@ -74,6 +76,7 @@ describe('record provider', () => {
         expect(err).to.not.exist()
         ipfsd = _ipfsd
         node = _ipfsd.api
+
         done()
       })
     })

--- a/test/core/provider.spec.js
+++ b/test/core/provider.spec.js
@@ -1,0 +1,205 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const sinon = require('sinon')
+
+const CID = require('cids')
+
+const IPFS = require('../../src')
+const DaemonFactory = require('ipfsd-ctl')
+const df = DaemonFactory.create({ type: 'proc' })
+
+const INTERVAL = '10s'
+const STRATEGY = 'all'
+
+const config = {
+  Bootstrap: [],
+  Reprovider: {
+    Interval: INTERVAL,
+    Strategy: STRATEGY
+  }
+}
+
+describe('record provider', () => {
+  // if no dht nor delegated routing enabled
+  describe('disabled', () => {
+    let node
+    let ipfsd
+
+    before(function (done) {
+      this.timeout(50 * 1000)
+
+      df.spawn({
+        exec: IPFS
+      }, (err, _ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsd = _ipfsd
+        node = _ipfsd.api
+
+        done()
+      })
+    })
+
+    after((done) => {
+      ipfsd.stop(done)
+    })
+
+    it('should not be running', () => {
+      expect(node._provider._running).to.equal(false)
+      expect(node._provider.reprovider).to.not.exist()
+    })
+  })
+
+  describe('enabled with default configuration', () => {
+    let node
+    let ipfsd
+
+    before(function (done) {
+      this.timeout(50 * 1000)
+
+      df.spawn({
+        exec: IPFS,
+        libp2p: {
+          config: {
+            dht: {
+              enabled: true
+            }
+          }
+        }
+      }, (err, _ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsd = _ipfsd
+        node = _ipfsd.api
+        done()
+      })
+    })
+
+    after((done) => {
+      ipfsd.stop(done)
+    })
+
+    it('should be running', () => {
+      expect(node._provider._running).to.equal(true)
+      expect(node._provider.reprovider).to.exist()
+      expect(node._provider.reprovider._timeoutId).to.exist()
+    })
+
+    it('should use the defaults', () => {
+      expect(node._provider._options.Interval).to.equal('12h')
+      expect(node._provider._options.Strategy).to.equal('all')
+    })
+
+    it('should be able to provide a valid CIDs', async () => {
+      const cid = new CID('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ')
+
+      try {
+        await node._provider.provide(cid)
+      } catch (err) {
+        expect(err).to.not.exist()
+        throw err
+      }
+    })
+
+    it('should thrown providing an invalid CIDs', async () => {
+      const cid = 'Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ'
+
+      try {
+        await node._provider.provide(cid)
+      } catch (err) {
+        expect(err).to.exist()
+        expect(err.code).to.equal('ERR_INVALID_CID')
+      }
+    })
+
+    it('should be able to find providers of a valid CID', async () => {
+      const cid = new CID('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ')
+
+      let providers
+      try {
+        providers = await node._provider.findProviders(cid)
+      } catch (err) {
+        expect(err).to.not.exist()
+        throw err
+      }
+
+      expect(providers).to.exist()
+    })
+
+    it('should thrown finding providers of an invalid CID', async () => {
+      const cid = 'Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ'
+
+      try {
+        await node._provider.findProviders(cid)
+      } catch (err) {
+        expect(err).to.exist()
+        expect(err.code).to.equal('ERR_INVALID_CID')
+      }
+    })
+  })
+
+  describe('enabled with custom config', () => {
+    let node
+    let ipfsd
+
+    before(function (done) {
+      this.timeout(50 * 1000)
+
+      df.spawn({
+        exec: IPFS,
+        config,
+        libp2p: {
+          config: {
+            dht: {
+              enabled: true
+            }
+          }
+        }
+      }, (err, _ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsd = _ipfsd
+        node = _ipfsd.api
+
+        done()
+      })
+    })
+
+    after((done) => {
+      ipfsd.stop(done)
+    })
+
+    it('should be running', () => {
+      expect(node._provider._running).to.equal(true)
+      expect(node._provider.reprovider).to.exist()
+      expect(node._provider.reprovider._timeoutId).to.exist()
+    })
+
+    it('should use the provided configuration', () => {
+      expect(node._provider._options.Interval).to.equal(INTERVAL)
+      expect(node._provider._options.Strategy).to.equal(STRATEGY)
+    })
+
+    it('should reprovide after tens seconds', function (done) {
+      this.timeout(20 * 1000)
+
+      const reprovider = node._provider.reprovider
+      sinon.spy(reprovider, '_runPeriodically')
+      sinon.spy(reprovider._worker, '_processNext')
+
+      setTimeout(() => {
+        expect(reprovider._runPeriodically.called).to.equal(true)
+        expect(reprovider._worker._processNext.called).to.equal(true)
+
+        sinon.restore()
+        done()
+      }, 10000)
+    })
+  })
+
+  describe.skip('reprovide strategies', () => {
+
+  })
+})

--- a/test/core/provider.spec.js
+++ b/test/core/provider.spec.js
@@ -8,6 +8,7 @@ chai.use(dirtyChai)
 const sinon = require('sinon')
 
 const CID = require('cids')
+const human = require('human-to-milliseconds')
 
 const IPFS = require('../../src')
 const DaemonFactory = require('ipfsd-ctl')
@@ -52,7 +53,7 @@ describe('record provider', () => {
 
     it('should not be running', () => {
       expect(node._provider._running).to.equal(false)
-      expect(node._provider.reprovider).to.not.exist()
+      expect(node._provider.reprovider._timeoutId).to.not.exist()
     })
   })
 
@@ -92,8 +93,8 @@ describe('record provider', () => {
     })
 
     it('should use the defaults', () => {
-      expect(node._provider._options.Interval).to.equal('12h')
-      expect(node._provider._options.Strategy).to.equal('all')
+      expect(node._provider._options.interval).to.equal(human('12h'))
+      expect(node._provider._options.strategy).to.equal('all')
     })
 
     it('should be able to provide a valid CIDs', async () => {
@@ -181,8 +182,8 @@ describe('record provider', () => {
     })
 
     it('should use the provided configuration', () => {
-      expect(node._provider._options.Interval).to.equal(INTERVAL)
-      expect(node._provider._options.Strategy).to.equal(STRATEGY)
+      expect(node._provider._options.interval).to.equal(human(INTERVAL))
+      expect(node._provider._options.strategy).to.equal(STRATEGY)
     })
 
     it('should reprovide after tens seconds', function (done) {


### PR DESCRIPTION
In the context of `js-ipfs` reannouncing blocks to the network [ipfs/js-ipfs#2160](https://github.com/ipfs/js-ipfs/issues/2160), this PR aims to add a Provider layer controlled by `js-ipfs`. This provider will be used by bitswap.

Needs:

- [ ] Different strategies
- [ ] [ipfs/js-ipfs-bitswap#199](https://github.com/ipfs/js-ipfs-bitswap/pull/199)
- [ ] documentation - should be a part of [ipfs/js-ipfs#2204](https://github.com/ipfs/js-ipfs/issues/2204)