### PR TITLE
fix: fix ipns routing test

### DIFF
--- a/src/core/ipns/routing/config.js
+++ b/src/core/ipns/routing/config.js
@@ -22,7 +22,7 @@ module.exports = (ipfs) => {
   }
 
   // DHT should not be added as routing if we are offline or it is disabled
-  if (get(ipfs._options, 'offline') || !get(ipfs._options, 'libp2p.config.dht.enabled', false)) {
+  if (get(ipfs._options, 'offline') || !get(ipfs._options, 'libp2p.dht.enabled', false)) {
     const offlineDatastore = new OfflineDatastore(ipfs._repo)
     ipnsStores.push(offlineDatastore)
   } else {


### PR DESCRIPTION
This test 'should use the dht if enabled' was failing because the ipns routing was trying to get the wrong option.