### PR TITLE
fix: failing test on config

### DIFF
--- a/test/core/name.spec.js
+++ b/test/core/name.spec.js
@@ -485,8 +485,10 @@ describe('name', function () {
         },
         _options: {
           libp2p: {
-            dht: {
-              enabled: true
+            config: {
+              dht: {
+                enabled: true
+              }
             }
           }
         }


### PR DESCRIPTION
A previous commit broke a test, as the `dht` was not properly enabled and the test is failing in master branch