### PR TITLE
fix(gateway): remove buffer-peek-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "bl": "^3.0.0",
     "boom": "^7.2.0",
     "bs58": "^4.0.1",
-    "buffer-peek-stream": "^1.0.1",
     "byteman": "^1.3.5",
     "callbackify": "^1.1.0",
     "cid-tool": "~0.3.0",

--- a/src/http/gateway/resources/gateway.js
+++ b/src/http/gateway/resources/gateway.js
@@ -149,7 +149,7 @@ module.exports = {
 
     // Set/Sniff Content-Type
     let contentType
-    if (request.headers.range && catOptions.length) {
+    if (rangeResponse) {
       // Range request always returns opaque byte stream
       contentType = 'application/octet-stream'
     } else {


### PR DESCRIPTION
This PR fixes "random" daemon crashes with `NodeError: Cannot call write after a stream was destroyed` (details in https://github.com/libp2p/js-libp2p/issues/374)

It removes `buffer-peek-stream` which caused uncaught errors inside of Hapijs when HTTP client closed HTTP connection before receiving entire payload from a Gateway port.

After falling into rabit hole of accounting for how Hapijs handles Node streams I decided to take step back, change approach and replace stream peeking with much simpler code that does not introduce intermediate streams.


**Steps to reproduce:** https://github.com/libp2p/js-libp2p/issues/374#issuecomment-508786129

Closes https://github.com/libp2p/js-libp2p/issues/374
Closes https://github.com/libp2p/pull-mplex/issues/13