### PR TITLE
refactor: pass print to commands in argv

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -25,8 +25,7 @@ if (!semver.satisfies(process.versions.node, pkg.engines.node)) {
 
 const YargsPromise = require('yargs-promise')
 const updateNotifier = require('update-notifier')
-const utils = require('./utils')
-const print = utils.print
+const { print } = require('./utils')
 const mfs = require('ipfs-mfs/cli')
 const debug = require('debug')('ipfs:cli')
 const parser = require('./parser')

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -7,7 +7,7 @@ const byteman = require('byteman')
 const mh = require('multihashes')
 const multibase = require('multibase')
 const toPull = require('stream-to-pull-stream')
-const { print, isDaemonOn, createProgressBar } = require('../utils')
+const { createProgressBar } = require('../utils')
 const { cidToString } = require('../../utils/cid')
 const globSource = require('../../utils/files/glob-source')
 
@@ -33,7 +33,7 @@ function addPipeline (source, addStream, options) {
         if (options.silent) return resolve()
 
         if (options.quieter) {
-          print(added.pop().hash)
+          options.print(added.pop().hash)
           return resolve()
         }
 
@@ -54,7 +54,7 @@ function addPipeline (source, addStream, options) {
             if (!options.quiet && file.path.length > 0) log.push(file.path)
             return log.join(' ')
           })
-          .forEach((msg) => print(msg))
+          .forEach((msg) => options.print(msg))
 
         resolve()
       })
@@ -168,7 +168,7 @@ module.exports = {
         chunker: argv.chunker
       }
 
-      if (options.enableShardingExperiment && isDaemonOn()) {
+      if (options.enableShardingExperiment && argv.isDaemonOn()) {
         throw new Error('Error: Enabling the sharding experiment should be done on the daemon')
       }
 

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -17,7 +16,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, cidBase, resolve }) {
+  handler ({ getIpfs, print, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const stats = await ipfs.bitswap.stat()

--- a/src/cli/commands/bitswap/unwant.js
+++ b/src/cli/commands/bitswap/unwant.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -21,7 +20,7 @@ module.exports = {
       choices: multibase.names
     }
   },
-  handler ({ getIpfs, key, cidBase, resolve }) {
+  handler ({ getIpfs, print, key, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       await ipfs.bitswap.unwant(key)

--- a/src/cli/commands/bitswap/wantlist.js
+++ b/src/cli/commands/bitswap/wantlist.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -22,7 +21,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, peer, cidBase, resolve }) {
+  handler ({ getIpfs, print, peer, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const list = await ipfs.bitswap.wantlist(peer)

--- a/src/cli/commands/block/get.js
+++ b/src/cli/commands/block/get.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'get <key>',
 
@@ -9,7 +7,7 @@ module.exports = {
 
   builder: {},
 
-  handler ({ getIpfs, key, resolve }) {
+  handler ({ getIpfs, print, key, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const block = await ipfs.block.get(key)

--- a/src/cli/commands/block/put.js
+++ b/src/cli/commands/block/put.js
@@ -4,7 +4,6 @@ const bl = require('bl')
 const fs = require('fs')
 const multibase = require('multibase')
 const promisify = require('promisify-es6')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -54,7 +53,7 @@ module.exports = {
 
       const ipfs = await argv.getIpfs()
       const { cid } = await ipfs.block.put(data, argv)
-      print(cidToString(cid, { base: argv.cidBase }))
+      argv.print(cidToString(cid, { base: argv.cidBase }))
     })())
   }
 }

--- a/src/cli/commands/block/rm.js
+++ b/src/cli/commands/block/rm.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { print, isDaemonOn } = require('../../utils')
-
 module.exports = {
   command: 'rm <key>',
 
@@ -9,7 +7,7 @@ module.exports = {
 
   builder: {},
 
-  handler ({ getIpfs, key, resolve }) {
+  handler ({ getIpfs, print, isDaemonOn, key, resolve }) {
     resolve((async () => {
       if (isDaemonOn()) {
         // TODO implement this once `js-ipfs-http-client` supports it

--- a/src/cli/commands/block/stat.js
+++ b/src/cli/commands/block/stat.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -17,7 +16,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, key, cidBase, resolve }) {
+  handler ({ getIpfs, print, key, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const stats = await ipfs.block.stat(key)

--- a/src/cli/commands/bootstrap/add.js
+++ b/src/cli/commands/bootstrap/add.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'add [<peer>]',
 
@@ -19,7 +17,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const list = await ipfs.bootstrap.add(argv.peer, { default: argv.default })
-      list.Peers.forEach((peer) => print(peer))
+      list.Peers.forEach((peer) => argv.print(peer))
     })())
   }
 }

--- a/src/cli/commands/bootstrap/list.js
+++ b/src/cli/commands/bootstrap/list.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'list',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const list = await ipfs.bootstrap.list()
-      list.Peers.forEach((node) => print(node))
+      list.Peers.forEach((node) => argv.print(node))
     })())
   }
 }

--- a/src/cli/commands/bootstrap/rm.js
+++ b/src/cli/commands/bootstrap/rm.js
@@ -3,7 +3,6 @@
 const debug = require('debug')
 const log = debug('cli:bootstrap')
 log.error = debug('cli:bootstrap:error')
-const print = require('../../utils').print
 
 module.exports = {
   command: 'rm [<peer>]',
@@ -22,7 +21,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const list = await ipfs.bootstrap.rm(argv.peer, { all: argv.all })
-      list.Peers.forEach((peer) => print(peer))
+      list.Peers.forEach((peer) => argv.print(peer))
     })())
   }
 }

--- a/src/cli/commands/commands.js
+++ b/src/cli/commands/commands.js
@@ -1,5 +1,5 @@
 'use strict'
-const print = require('../utils').print
+
 const path = require('path')
 const glob = require('glob').sync
 
@@ -8,7 +8,7 @@ module.exports = {
 
   describe: 'List all available commands',
 
-  handler () {
+  handler ({ print }) {
     const basePath = path.resolve(__dirname, '..')
 
     // modeled after https://github.com/vdemedes/ronin/blob/master/lib/program.js#L78

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -1,5 +1,4 @@
 'use strict'
-const print = require('../utils').print
 
 module.exports = {
   command: 'config <key> [value]',
@@ -39,9 +38,9 @@ module.exports = {
         value = await ipfs.config.get(key)
 
         if (typeof value === 'object') {
-          print(JSON.stringify(value, null, 2))
+          argv.print(JSON.stringify(value, null, 2))
         } else {
-          print(value)
+          argv.print(value)
         }
       } else {
         // Set the new value of a given key

--- a/src/cli/commands/config/show.js
+++ b/src/cli/commands/config/show.js
@@ -3,7 +3,6 @@
 const debug = require('debug')
 const log = debug('cli:config')
 log.error = debug('cli:config:error')
-const print = require('../../utils').print
 
 module.exports = {
   command: 'show',
@@ -19,7 +18,7 @@ module.exports = {
 
       const ipfs = await argv.getIpfs()
       const config = await ipfs.config.get()
-      print(JSON.stringify(config, null, 4))
+      argv.print(JSON.stringify(config, null, 4))
     })())
   }
 }

--- a/src/cli/commands/daemon.js
+++ b/src/cli/commands/daemon.js
@@ -2,7 +2,7 @@
 
 const os = require('os')
 const toUri = require('multiaddr-to-uri')
-const { getRepoPath, print, ipfsPathHelp } = require('../utils')
+const { ipfsPathHelp } = require('../utils')
 
 module.exports = {
   command: 'daemon',
@@ -37,12 +37,13 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
+      const { print } = argv
       print('Initializing IPFS daemon...')
       print(`js-ipfs version: ${require('../../../package.json').version}`)
       print(`System version: ${os.arch()}/${os.platform()}`)
       print(`Node.js version: ${process.versions.node}`)
 
-      const repoPath = getRepoPath()
+      const repoPath = argv.getRepoPath()
 
       // Required inline to reduce startup time
       const Daemon = require('../../cli/daemon')

--- a/src/cli/commands/dag/get.js
+++ b/src/cli/commands/dag/get.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const CID = require('cids')
-const print = require('../../utils').print
 
 module.exports = {
   command: 'get <cid path>',
@@ -21,6 +20,7 @@ module.exports = {
       const cidString = refParts[0]
       const path = refParts.slice(1).join('/')
       const cid = new CID(cidString)
+      const { print } = argv
 
       const options = {
         localResolve: argv.localResolve
@@ -32,7 +32,7 @@ module.exports = {
       try {
         result = await ipfs.dag.get(cid, path, options)
       } catch (err) {
-        return print(`dag get failed: ${err}`)
+        return argv.print(`dag get failed: ${err}`)
       }
 
       if (options.localResolve) {

--- a/src/cli/commands/dht/find-peer.js
+++ b/src/cli/commands/dht/find-peer.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'findpeer <peerID>',
 
@@ -9,15 +7,12 @@ module.exports = {
 
   builder: {},
 
-  handler ({ getIpfs, peerID, resolve }) {
+  handler ({ getIpfs, print, peerID, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const peers = await ipfs.dht.findPeer(peerID)
       const addresses = peers.multiaddrs.toArray().map((ma) => ma.toString())
-
-      addresses.forEach((addr) => {
-        print(addr)
-      })
+      addresses.forEach((addr) => print(addr))
     })())
   }
 }

--- a/src/cli/commands/dht/find-providers.js
+++ b/src/cli/commands/dht/find-providers.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'findprovs <key>',
 
@@ -26,7 +24,7 @@ module.exports = {
       const provs = await ipfs.dht.findProvs(key, opts)
 
       provs.forEach((element) => {
-        print(element.id.toB58String())
+        argv.print(element.id.toB58String())
       })
     })())
   }

--- a/src/cli/commands/dht/get.js
+++ b/src/cli/commands/dht/get.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'get <key>',
 
@@ -9,11 +7,10 @@ module.exports = {
 
   builder: {},
 
-  handler ({ getIpfs, key, resolve }) {
+  handler ({ getIpfs, print, key, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const value = await ipfs.dht.get(key)
-
       print(value)
     })())
   }

--- a/src/cli/commands/dht/query.js
+++ b/src/cli/commands/dht/query.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'query <peerID>',
 
@@ -9,7 +7,7 @@ module.exports = {
 
   builder: {},
 
-  handler ({ getIpfs, peerID, resolve }) {
+  handler ({ getIpfs, print, peerID, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const result = await ipfs.dht.query(peerID)

--- a/src/cli/commands/dns.js
+++ b/src/cli/commands/dns.js
@@ -1,5 +1,4 @@
 'use strict'
-const print = require('../utils').print
 
 module.exports = {
   command: 'dns <domain>',
@@ -18,7 +17,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, domain, resolve, recursive, format }) {
+  handler ({ getIpfs, print, domain, resolve, recursive, format }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const path = await ipfs.dns(domain, { recursive, format })

--- a/src/cli/commands/file/ls.js
+++ b/src/cli/commands/file/ls.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'ls <key>',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const path = argv.key
       // `ipfs file ls` is deprecated. See https://ipfs.io/docs/commands/#ipfs-file-ls
-      print(`This functionality is deprecated, and will be removed in future versions. If possible, please use 'ipfs ls' instead.`)
+      argv.print(`This functionality is deprecated, and will be removed in future versions. If possible, please use 'ipfs ls' instead.`)
 
       const ipfs = await argv.getIpfs()
       let links = await ipfs.ls(path)
@@ -23,7 +21,7 @@ module.exports = {
         links = [{ hash: path }]
       }
 
-      links.forEach((file) => print(file.hash))
+      links.forEach((file) => argv.print(file.hash))
     })())
   }
 }

--- a/src/cli/commands/get.js
+++ b/src/cli/commands/get.js
@@ -5,7 +5,6 @@ const path = require('path')
 const mkdirp = require('mkdirp')
 const pull = require('pull-stream')
 const toPull = require('stream-to-pull-stream')
-const print = require('../utils').print
 
 function checkArgs (hash, outPath) {
   // format the output directory
@@ -58,7 +57,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, ipfsPath, output, resolve }) {
+  handler ({ getIpfs, print, ipfsPath, output, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
 

--- a/src/cli/commands/id.js
+++ b/src/cli/commands/id.js
@@ -1,5 +1,4 @@
 'use strict'
-const print = require('../utils').print
 
 module.exports = {
   command: 'id',
@@ -17,7 +16,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const id = await ipfs.id()
-      print(JSON.stringify(id, '', 2))
+      argv.print(JSON.stringify(id, '', 2))
     })())
   }
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -1,14 +1,13 @@
 'use strict'
 
-const utils = require('../utils')
-const print = utils.print
+const { ipfsPathHelp } = require('../utils')
 
 module.exports = {
   command: 'init [config] [options]',
   describe: 'Initialize a local IPFS node',
   builder (yargs) {
     return yargs
-      .epilog(utils.ipfsPathHelp)
+      .epilog(ipfsPathHelp)
       .positional('config', {
         describe: 'Node config, this should JSON and will be merged with the default config. Check https://github.com/ipfs/js-ipfs#optionsconfig',
         type: 'string'
@@ -33,9 +32,9 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
-      const path = utils.getRepoPath()
+      const path = argv.getRepoPath()
 
-      print(`initializing ipfs node at ${path}`)
+      argv.print(`initializing ipfs node at ${path}`)
 
       // Required inline to reduce startup time
       const IPFS = require('../../core')
@@ -54,7 +53,7 @@ module.exports = {
           privateKey: argv.privateKey,
           emptyRepo: argv.emptyRepo,
           pass: argv.pass,
-          log: print
+          log: argv.print
         })
       } catch (err) {
         if (err.code === 'EACCES') {

--- a/src/cli/commands/key/gen.js
+++ b/src/cli/commands/key/gen.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'gen <name>',
 
@@ -29,7 +27,7 @@ module.exports = {
       }
       const ipfs = await argv.getIpfs()
       const key = await ipfs.key.gen(argv.name, opts)
-      print(`generated ${key.id} ${key.name}`)
+      argv.print(`generated ${key.id} ${key.name}`)
     })())
   }
 }

--- a/src/cli/commands/key/import.js
+++ b/src/cli/commands/key/import.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fs = require('fs')
-const print = require('../../utils').print
 
 module.exports = {
   command: 'import <name>',
@@ -27,7 +26,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const key = await ipfs.key.import(argv.name, argv.input, argv.passin)
-      print(`imported ${key.id} ${key.name}`)
+      argv.print(`imported ${key.id} ${key.name}`)
     })())
   }
 }

--- a/src/cli/commands/key/list.js
+++ b/src/cli/commands/key/list.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'list',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const keys = await ipfs.key.list()
-      keys.forEach((ki) => print(`${ki.id} ${ki.name}`))
+      keys.forEach((ki) => argv.print(`${ki.id} ${ki.name}`))
     })())
   }
 }

--- a/src/cli/commands/key/rename.js
+++ b/src/cli/commands/key/rename.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'rename <name> <newName>',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const res = await ipfs.key.rename(argv.name, argv.newName)
-      print(`renamed to ${res.id} ${res.now}`)
+      argv.print(`renamed to ${res.id} ${res.now}`)
     })())
   }
 }

--- a/src/cli/commands/key/rm.js
+++ b/src/cli/commands/key/rm.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'rm <name>',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const key = await ipfs.key.rm(argv.name)
-      print(`${key.id} ${key.name}`)
+      argv.print(`${key.id} ${key.name}`)
     })())
   }
 }

--- a/src/cli/commands/ls.js
+++ b/src/cli/commands/ls.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print, rightpad } = require('../utils')
+const { rightpad } = require('../utils')
 const { cidToString } = require('../../utils/cid')
 
 module.exports = {
@@ -34,7 +34,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, key, recursive, headers, cidBase, resolve }) {
+  handler ({ getIpfs, print, key, recursive, headers, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       let links = await ipfs.ls(key, { recursive })

--- a/src/cli/commands/name/publish.js
+++ b/src/cli/commands/name/publish.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { print } = require('../../utils')
-
 module.exports = {
   command: 'publish <ipfsPath>',
 
@@ -46,7 +44,7 @@ module.exports = {
 
       const ipfs = await argv.getIpfs()
       const result = await ipfs.name.publish(argv.ipfsPath, opts)
-      print(`Published to ${result.name}: ${result.value}`)
+      argv.print(`Published to ${result.name}: ${result.value}`)
     })())
   }
 }

--- a/src/cli/commands/name/pubsub/cancel.js
+++ b/src/cli/commands/name/pubsub/cancel.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../../utils').print
-
 module.exports = {
   command: 'cancel <name>',
 
@@ -11,7 +9,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const result = await ipfs.name.pubsub.cancel(argv.name)
-      print(result.canceled ? 'canceled' : 'no subscription')
+      argv.print(result.canceled ? 'canceled' : 'no subscription')
     })())
   }
 }

--- a/src/cli/commands/name/pubsub/state.js
+++ b/src/cli/commands/name/pubsub/state.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../../utils').print
-
 module.exports = {
   command: 'state',
 
@@ -11,7 +9,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const result = await ipfs.name.pubsub.state()
-      print(result.enabled ? 'enabled' : 'disabled')
+      argv.print(result.enabled ? 'enabled' : 'disabled')
     })())
   }
 }

--- a/src/cli/commands/name/pubsub/subs.js
+++ b/src/cli/commands/name/pubsub/subs.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../../utils').print
-
 module.exports = {
   command: 'subs',
 
@@ -11,7 +9,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const result = await ipfs.name.pubsub.subs()
-      result.forEach(s => print(s))
+      result.forEach(s => argv.print(s))
     })())
   }
 }

--- a/src/cli/commands/name/resolve.js
+++ b/src/cli/commands/name/resolve.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'resolve [<name>]',
 
@@ -32,7 +30,7 @@ module.exports = {
       const ipfs = await argv.getIpfs()
       const result = await ipfs.name.resolve(argv.name, opts)
 
-      print(result)
+      argv.print(result)
     })())
   }
 }

--- a/src/cli/commands/object/data.js
+++ b/src/cli/commands/object/data.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'data <key>',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const data = await ipfs.object.data(argv.key, { enc: 'base58' })
-      print(data, false)
+      argv.print(data, false)
     })())
   }
 }

--- a/src/cli/commands/object/get.js
+++ b/src/cli/commands/object/get.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -21,7 +20,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, key, dataEncoding, cidBase, resolve }) {
+  handler ({ getIpfs, print, key, dataEncoding, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const node = await ipfs.object.get(key, { enc: 'base58' })

--- a/src/cli/commands/object/links.js
+++ b/src/cli/commands/object/links.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -17,7 +16,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, key, cidBase, resolve }) {
+  handler ({ getIpfs, print, key, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const links = await ipfs.object.links(key, { enc: 'base58' })

--- a/src/cli/commands/object/new.js
+++ b/src/cli/commands/object/new.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -17,7 +16,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, template, cidBase, resolve }) {
+  handler ({ getIpfs, print, template, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const cid = await ipfs.object.new(template)

--- a/src/cli/commands/object/patch/add-link.js
+++ b/src/cli/commands/object/patch/add-link.js
@@ -3,7 +3,6 @@
 const dagPB = require('ipld-dag-pb')
 const DAGLink = dagPB.DAGLink
 const multibase = require('multibase')
-const { print } = require('../../../utils')
 const { cidToString } = require('../../../../utils/cid')
 
 module.exports = {
@@ -24,7 +23,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, root, name, ref, cidBase, cidVersion, resolve }) {
+  handler ({ getIpfs, print, root, name, ref, cidBase, cidVersion, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const nodeA = await ipfs.object.get(ref, { enc: 'base58' })

--- a/src/cli/commands/object/patch/append-data.js
+++ b/src/cli/commands/object/patch/append-data.js
@@ -3,7 +3,6 @@
 const bl = require('bl')
 const fs = require('fs')
 const multibase = require('multibase')
-const { print } = require('../../../utils')
 const { cidToString } = require('../../../../utils/cid')
 
 module.exports = {
@@ -39,7 +38,7 @@ module.exports = {
         enc: 'base58'
       })
 
-      print(cidToString(cid, { base: argv.cidBase, upgrade: false }))
+      argv.print(cidToString(cid, { base: argv.cidBase, upgrade: false }))
     })())
   }
 }

--- a/src/cli/commands/object/patch/rm-link.js
+++ b/src/cli/commands/object/patch/rm-link.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../../utils')
 const { cidToString } = require('../../../../utils/cid')
 
 module.exports = {
@@ -17,7 +16,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, root, link, cidBase, resolve }) {
+  handler ({ getIpfs, print, root, link, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const cid = await ipfs.object.patch.rmLink(root, { name: link }, {

--- a/src/cli/commands/object/patch/set-data.js
+++ b/src/cli/commands/object/patch/set-data.js
@@ -3,7 +3,6 @@
 const fs = require('fs')
 const bl = require('bl')
 const multibase = require('multibase')
-const { print } = require('../../../utils')
 const { cidToString } = require('../../../../utils/cid')
 
 module.exports = {
@@ -39,7 +38,7 @@ module.exports = {
         enc: 'base58'
       })
 
-      print(cidToString(cid, { base: argv.cidBase, upgrade: false }))
+      argv.print(cidToString(cid, { base: argv.cidBase, upgrade: false }))
     })())
   }
 }

--- a/src/cli/commands/object/put.js
+++ b/src/cli/commands/object/put.js
@@ -3,7 +3,6 @@
 const bl = require('bl')
 const fs = require('fs')
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -40,7 +39,7 @@ module.exports = {
 
       const ipfs = await argv.getIpfs()
       const cid = await ipfs.object.put(data, { enc: argv.inputEnc })
-      print(`added ${cidToString(cid, { base: argv.cidBase, upgrade: false })}`)
+      argv.print(`added ${cidToString(cid, { base: argv.cidBase, upgrade: false })}`)
     })())
   }
 }

--- a/src/cli/commands/object/stat.js
+++ b/src/cli/commands/object/stat.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'stat <key>',
 
@@ -9,7 +7,7 @@ module.exports = {
 
   builder: {},
 
-  handler ({ getIpfs, key, cidBase, resolve }) {
+  handler ({ getIpfs, print, key, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const stats = await ipfs.object.stat(key, { enc: 'base58' })

--- a/src/cli/commands/pin/add.js
+++ b/src/cli/commands/pin/add.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -23,7 +22,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, ipfsPath, recursive, cidBase, resolve }) {
+  handler ({ getIpfs, print, ipfsPath, recursive, cidBase, resolve }) {
     resolve((async () => {
       const type = recursive ? 'recursive' : 'direct'
       const ipfs = await getIpfs()

--- a/src/cli/commands/pin/ls.js
+++ b/src/cli/commands/pin/ls.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -31,7 +30,7 @@ module.exports = {
     }
   },
 
-  handler: ({ getIpfs, ipfsPath, type, quiet, cidBase, resolve }) => {
+  handler: ({ getIpfs, print, ipfsPath, type, quiet, cidBase, resolve }) => {
     resolve((async () => {
       const paths = ipfsPath
       const ipfs = await getIpfs()

--- a/src/cli/commands/pin/rm.js
+++ b/src/cli/commands/pin/rm.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const { print } = require('../../utils')
 const { cidToString } = require('../../../utils/cid')
 
 module.exports = {
@@ -23,7 +22,7 @@ module.exports = {
     }
   },
 
-  handler: ({ getIpfs, ipfsPath, recursive, cidBase, resolve }) => {
+  handler: ({ getIpfs, print, ipfsPath, recursive, cidBase, resolve }) => {
     resolve((async () => {
       const ipfs = await getIpfs()
       const results = await ipfs.pin.rm(ipfsPath, { recursive })

--- a/src/cli/commands/ping.js
+++ b/src/cli/commands/ping.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const pull = require('pull-stream')
-const print = require('../utils').print
 
 module.exports = {
   command: 'ping <peerId>',
@@ -28,10 +27,10 @@ module.exports = {
           pull.drain(({ success, time, text }) => {
             // Check if it's a pong
             if (success && !text) {
-              print(`Pong received: time=${time} ms`)
+              argv.print(`Pong received: time=${time} ms`)
             // Status response
             } else {
-              print(text)
+              argv.print(text)
             }
           }, err => {
             if (err) return reject(err)

--- a/src/cli/commands/pubsub/ls.js
+++ b/src/cli/commands/pubsub/ls.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'ls',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const subscriptions = await ipfs.pubsub.ls()
-      subscriptions.forEach(sub => print(sub))
+      subscriptions.forEach(sub => argv.print(sub))
     })())
   }
 }

--- a/src/cli/commands/pubsub/peers.js
+++ b/src/cli/commands/pubsub/peers.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'peers <topic>',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const peers = await ipfs.pubsub.peers(argv.topic)
-      peers.forEach(peer => print(peer))
+      peers.forEach(peer => argv.print(peer))
     })())
   }
 }

--- a/src/cli/commands/pubsub/sub.js
+++ b/src/cli/commands/pubsub/sub.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'sub <topic>',
 
@@ -11,7 +9,7 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
-      const handler = msg => print(msg.data.toString())
+      const handler = msg => argv.print(msg.data.toString())
       const ipfs = await argv.getIpfs()
       await ipfs.pubsub.subscribe(argv.topic, handler)
     })())

--- a/src/cli/commands/refs-local.js
+++ b/src/cli/commands/refs-local.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const { print } = require('../utils')
-
 module.exports = {
   command: 'refs-local',
 
   describe: 'List all local references.',
 
-  handler ({ getIpfs, resolve }) {
+  handler ({ getIpfs, print, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
 

--- a/src/cli/commands/refs.js
+++ b/src/cli/commands/refs.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { print } = require('../utils')
-
 module.exports = {
   command: 'refs <key> [keys..]',
 
@@ -37,7 +35,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, key, keys, recursive, format, edges, unique, maxDepth, resolve }) {
+  handler ({ getIpfs, print, key, keys, recursive, format, edges, unique, maxDepth, resolve }) {
     resolve((async () => {
       if (maxDepth === 0) {
         return

--- a/src/cli/commands/repo/stat.js
+++ b/src/cli/commands/repo/stat.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'stat',
 
@@ -18,7 +16,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const stats = await ipfs.repo.stat({ human: argv.human })
-      print(`repo status
+      argv.print(`repo status
   number of objects: ${stats.numObjects}
   repo size: ${stats.repoSize}
   repo path: ${stats.repoPath}

--- a/src/cli/commands/repo/version.js
+++ b/src/cli/commands/repo/version.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'version',
 
@@ -13,7 +11,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const version = await ipfs.repo.version()
-      print(version)
+      argv.print(version)
     })())
   }
 }

--- a/src/cli/commands/resolve.js
+++ b/src/cli/commands/resolve.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const multibase = require('multibase')
-const print = require('../utils').print
 
 module.exports = {
   command: 'resolve <name>',
@@ -21,7 +20,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, name, recursive, cidBase, resolve }) {
+  handler ({ getIpfs, print, name, recursive, cidBase, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const res = await ipfs.resolve(name, { recursive, cidBase })

--- a/src/cli/commands/stats/bw.js
+++ b/src/cli/commands/stats/bw.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const pull = require('pull-stream')
-const print = require('../../utils').print
 
 module.exports = {
   command: 'bw',
@@ -27,7 +26,7 @@ module.exports = {
     }
   },
 
-  handler ({ getIpfs, peer, proto, poll, interval, resolve }) {
+  handler ({ getIpfs, print, peer, proto, poll, interval, resolve }) {
     resolve((async () => {
       const ipfs = await getIpfs()
 

--- a/src/cli/commands/stats/repo.js
+++ b/src/cli/commands/stats/repo.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const print = require('../../utils').print
-
 module.exports = {
   command: 'repo',
 
@@ -18,7 +16,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const stats = await ipfs.stats.repo({ human: argv.human })
-      print(`repo status
+      argv.print(`repo status
   number of objects: ${stats.numObjects}
   repo size: ${stats.repoSize}
   repo path: ${stats.repoPath}

--- a/src/cli/commands/swarm/addrs/local.js
+++ b/src/cli/commands/swarm/addrs/local.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const utils = require('../../../utils')
 const debug = require('debug')
 const log = debug('cli:object')
 log.error = debug('cli:object:error')
-const print = require('../../../utils').print
 
 module.exports = {
   command: 'local',
@@ -15,12 +13,12 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
-      if (!utils.isDaemonOn()) {
+      if (!argv.isDaemonOn()) {
         throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
       const ipfs = await argv.getIpfs()
       const res = await ipfs.swarm.localAddrs()
-      res.forEach(addr => print(addr.toString()))
+      res.forEach(addr => argv.print(addr.toString()))
     })())
   }
 }

--- a/src/cli/commands/swarm/connect.js
+++ b/src/cli/commands/swarm/connect.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const utils = require('../../utils')
-const print = utils.print
-
 module.exports = {
   command: 'connect <address>',
 
@@ -12,12 +9,12 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
-      if (!utils.isDaemonOn()) {
+      if (!argv.isDaemonOn()) {
         throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
       const ipfs = await argv.getIpfs()
       const res = await ipfs.swarm.connect(argv.address)
-      print(res.Strings[0])
+      argv.print(res.Strings[0])
     })())
   }
 }

--- a/src/cli/commands/swarm/disconnect.js
+++ b/src/cli/commands/swarm/disconnect.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const utils = require('../../utils')
-const print = require('../../utils').print
-
 module.exports = {
   command: 'disconnect <address>',
 
@@ -12,12 +9,12 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
-      if (!utils.isDaemonOn()) {
+      if (!argv.isDaemonOn()) {
         throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
       const ipfs = await argv.getIpfs()
       const res = await ipfs.swarm.disconnect(argv.address)
-      print(res.Strings[0])
+      argv.print(res.Strings[0])
     })())
   }
 }

--- a/src/cli/commands/swarm/peers.js
+++ b/src/cli/commands/swarm/peers.js
@@ -2,8 +2,6 @@
 
 const mafmt = require('mafmt')
 const multiaddr = require('multiaddr')
-const utils = require('../../utils')
-const print = require('../../utils').print
 
 module.exports = {
   command: 'peers',
@@ -14,7 +12,7 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
-      if (!utils.isDaemonOn()) {
+      if (!argv.isDaemonOn()) {
         throw new Error('This command must be run in online mode. Try running \'ipfs daemon\' first.')
       }
 
@@ -27,7 +25,7 @@ module.exports = {
           ma = ma.encapsulate('/ipfs/' + item.peer.toB58String())
         }
         const addr = ma.toString()
-        print(addr)
+        argv.print(addr)
       })
     })())
   }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const os = require('os')
-const print = require('../utils').print
 
 module.exports = {
   command: 'version',
@@ -34,6 +33,7 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
+      const { print } = argv
       const ipfs = await argv.getIpfs()
       const data = await ipfs.version()
 

--- a/src/cli/parser.js
+++ b/src/cli/parser.js
@@ -2,7 +2,6 @@
 
 const yargs = require('yargs')
 const utils = require('./utils')
-const print = utils.print
 
 const parser = yargs
   .option('silent', {
@@ -25,15 +24,16 @@ const parser = yargs
     if (err) {
       throw err // preserve stack
     }
-    print(msg)
+    utils.print(msg)
     yargs.showHelp()
   })
   .commandDir('commands')
-  .middleware(argv => {
-    // Function to get hold of a singleton ipfs instance
-    argv.getIpfs = utils.singleton(cb => utils.getIPFS(argv, cb))
-    return argv
-  })
+  .middleware(argv => Object.assign(argv, {
+    getIpfs: utils.singleton(cb => utils.getIPFS(argv, cb)),
+    print: utils.print,
+    isDaemonOn: utils.isDaemonOn,
+    getRepoPath: utils.getRepoPath
+  }))
   .help()
   .strict()
   .completion()

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -11,8 +11,6 @@ const Progress = require('progress')
 const byteman = require('byteman')
 const promisify = require('promisify-es6')
 
-exports = module.exports
-
 exports.isDaemonOn = isDaemonOn
 function isDaemonOn () {
   try {


### PR DESCRIPTION
This is a mechanical change to pass `print` to commands via `argv` instead of requiring it. This gives way to significantly easier testing of command handler functions.

See https://github.com/ipfs/js-ipfs/issues/2131 for full context.

This PR also passes `isDaemonOn` and `getRepoPath` in `argv` for the same reasons.

resolves https://github.com/ipfs/js-ipfs/issues/2131