### PR TITLE
fix: clean repo func on windows

### DIFF
--- a/test/http-api/routes.js
+++ b/test/http-api/routes.js
@@ -58,7 +58,7 @@ describe('HTTP API', () => {
       this.timeout(50 * 1000)
 
       await http.api.stop()
-      clean(repoTests)
+      await clean(repoTests)
     })
 
     describe('## http-api spec tests for custom config', () => {
@@ -81,7 +81,7 @@ describe('HTTP API', () => {
       this.timeout(50 * 1000)
 
       await http.api.stop()
-      clean(repoTests)
+      await clean(repoTests)
     })
 
     describe('## http-api spec tests for default config', () => {

--- a/test/utils/clean.js
+++ b/test/utils/clean.js
@@ -1,15 +1,16 @@
 'use strict'
 
 const rimraf = require('rimraf')
-const fs = require('fs')
+const fs = require('fs').promises
+const { promisify } = require('util')
 
-module.exports = (dir) => {
+module.exports = async dir => {
   try {
-    fs.accessSync(dir)
+    await fs.access(dir)
   } catch (err) {
     // Does not exist so all good
     return
   }
 
-  rimraf.sync(dir)
+  return promisify(rimraf)(dir)
 }

--- a/test/utils/create-repo-nodejs.js
+++ b/test/utils/create-repo-nodejs.js
@@ -16,10 +16,7 @@ function createTempRepo (repoPath) {
     series([
       // ignore err, might have been closed already
       (cb) => repo.close(() => cb()),
-      (cb) => {
-        clean(repoPath)
-        cb()
-      }
+      (cb) => clean(repoPath).then(cb, cb)
     ], done)
   }
 

--- a/test/utils/on-and-off.js
+++ b/test/utils/on-and-off.js
@@ -30,10 +30,9 @@ function off (tests) {
       return thing.ipfs('init')
     })
 
-    after(function (done) {
+    after(function () {
       this.timeout(20 * 1000)
-      clean(repoPath)
-      setImmediate(done)
+      return clean(repoPath)
     })
 
     tests(thing)


### PR DESCRIPTION
`rimraf.sync` does not retry when it encounters errors on windows. The async version retries a number of times before failing.

See https://github.com/isaacs/rimraf/issues/72 for context on why rimraf on windows might error.

Attempting to fix this error seeing quite often in CI now:

<img width="838" alt="windows-error" src="https://user-images.githubusercontent.com/152863/61126661-fd228300-a4a4-11e9-8ec2-bc327589f2ae.png">
