### PR TITLE
fix(gateway): disable compression

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -82,7 +82,11 @@ class HttpApi {
       // TODO: shouldn't, fix this
       routes: {
         cors: true
-      }
+      },
+      // Disable Compression
+      // Why? Streaming compression in Hapi is not stable enough,
+      // it requires bug-prone hacks such as https://github.com/hapijs/hapi/issues/3599
+      compression: false
     })
     server.app.ipfs = ipfs
 


### PR DESCRIPTION
This PR supersedes https://github.com/ipfs/js-ipfs/pull/2227  as a fix for "random" daemon crashes with `NodeError: Cannot call write after a stream was destroyed` (details in https://github.com/libp2p/js-libp2p/issues/374).

**Steps to reproduce:** https://github.com/libp2p/js-libp2p/issues/374#issuecomment-508786129



@alanshaw confirmed the underlying error was not specific to `buffer-peek-stream`, but caused by the way Hapi handles pipelines with multiple PassThrough/Transform/pipe calls. We had two Transforms: one for content-type sniffing, and one for streaming compression.

Turns out go-ipfs does not compress anything by default, so we can remove PassThrough responsible for streaming of compressed payload and fix the issue while keeping optimization introduced by `buffer-peek-stream` (bit better than #2227 because gateway does not hit datastore twice).

Closes https://github.com/libp2p/js-libp2p/issues/374
Closes https://github.com/libp2p/pull-mplex/issues/13
Closes https://github.com/ipfs/js-ipfs/pull/2227