### PR TITLE
feat: act as HTTP PROXY for http://<cidv1b32>.ipfs.localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@hapi/ammo": "^3.1.0",
     "@hapi/boom": "^7.4.2",
+    "@hapi/h2o2": "^8.3.0",
     "@hapi/hapi": "^18.3.1",
     "@hapi/joi": "^15.0.1",
     "array-shuffle": "^1.0.1",

--- a/src/http/gateway/routes/gateway.js
+++ b/src/http/gateway/routes/gateway.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const Joi = require('@hapi/joi')
+const Boom = require('@hapi/boom')
 const resources = require('../resources')
+const isIpfs = require('is-ipfs')
 
 module.exports = [
   {
@@ -37,6 +39,29 @@ module.exports = [
       },
       ext: {
         onPostHandler: { method: resources.gateway.afterHandler }
+      }
+    }
+  },
+  {
+    method: '*',
+    path: '/{path*}',
+    handler: {
+      proxy: {
+        mapUri: request => {
+          if (!isIpfs.ipfsSubdomain(request.url.toString())) {
+            throw Boom.notFound()
+          }
+
+          const cid = request.url.hostname.split('.')[0]
+          let uri = `${request.server.info.uri}/ipfs/${cid}`
+
+          if (request.url.pathname !== '/') {
+            uri += request.url.pathname
+          }
+
+          console.log(`${request.url} -> ${uri}`)
+          return { uri }
+        }
       }
     }
   }

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -2,6 +2,7 @@
 
 const Hapi = require('@hapi/hapi')
 const Pino = require('hapi-pino')
+const H2o2 = require('@hapi/h2o2')
 const debug = require('debug')
 const multiaddr = require('multiaddr')
 const toMultiaddr = require('uri-to-multiaddr')
@@ -132,6 +133,8 @@ class HttpApi {
         level: debug.enabled(LOG) ? 'debug' : (debug.enabled(LOG_ERROR) ? 'error' : 'fatal')
       }
     })
+
+    await server.register(H2o2)
 
     server.route(require('./gateway/routes'))
 


### PR DESCRIPTION
PoC right now, but you get the idea.

```
⨎ curl -v --proxy 'http://127.0.0.1:8180' 'http://bafybeih4mncb4apdnrvbnqkicldf74sfstykoryzi7noaf4njxkiuflnay.ipfs.localhost/658.png' > 658.png
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8180 (#0)
> GET http://bafybeih4mncb4apdnrvbnqkicldf74sfstykoryzi7noaf4njxkiuflnay.ipfs.localhost/658.png HTTP/1.1
> Host: bafybeih4mncb4apdnrvbnqkicldf74sfstykoryzi7noaf4njxkiuflnay.ipfs.localhost
> User-Agent: curl/7.54.0
> Accept: */*
> Proxy-Connection: Keep-Alive
>
< HTTP/1.1 200 OK
< content-type: application/octet-stream
< cache-control: no-cache
< Date: Fri, 12 Jul 2019 14:20:44 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
<
{ [16211 bytes data]
100  853k    0  853k    0     0  30.0M      0 --:--:-- --:--:-- --:--:-- 30.8M
* Connection #0 to host 127.0.0.1 left intact
```

refs https://github.com/ipfs/go-ipfs/issues/5982

License: MIT
Signed-off-by: Alan Shaw <alan.shaw@protocol.ai>