### PR TITLE
fix: allow setting Addresses.Delegates

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -53,6 +53,7 @@ const configSchema = s({
   config: optional(s({
     API: 'object?',
     Addresses: optional(s({
+      Delegates: optional(s(['multiaddr'])),
       Swarm: optional(s(['multiaddr'])),
       API: 'multiaddr?',
       Gateway: 'multiaddr'

--- a/test/core/config.spec.js
+++ b/test/core/config.spec.js
@@ -144,6 +144,10 @@ describe('config', () => {
       { config: { Bootstrap: ['/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'] } },
       { config: { Bootstrap: [] } },
 
+      { config: { Addresses: { Delegates: ['/dns4/node0.preload.ipfs.io/tcp/443/https'] } } },
+      { config: { Addresses: { Delegates: [] } } },
+      { config: { Addresses: { Delegates: undefined } } },
+
       { config: undefined }
     ]
 


### PR DESCRIPTION
This PR adds `Addresses.Delegates` (added in  https://github.com/ipfs/js-ipfs/pull/2195) as an optional array to the schema used for config validation. 

It fixes the error below:

![2019-07-12--21-00-53](https://user-images.githubusercontent.com/157609/61152758-92e00180-a4e9-11e9-8ef1-c6c1200575ee.png)

ps. I tested it in Brave (embedded js-ipfs + preload nodes) and delegated DHT queries produce expected responses :ok_hand: 

> ![2019-07-12--21-27-35](https://user-images.githubusercontent.com/157609/61153580-eeab8a00-a4eb-11e9-9152-0dcb51e2a67d.png)
> ![2019-07-12--21-27-52](https://user-images.githubusercontent.com/157609/61153579-eeab8a00-a4eb-11e9-8478-71f68d3330d4.png)