### PR TITLE
Add CORS headers to gateway responses

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -125,7 +125,13 @@ class HttpApi {
   }
 
   async _createGatewayServer (host, port, ipfs) {
-    const server = Hapi.server({ host, port })
+    const server = Hapi.server({ 
+      host, 
+      port,
+      routes: {
+        cors: true
+      }
+    })
     server.app.ipfs = ipfs
 
     await server.register({

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -125,8 +125,8 @@ class HttpApi {
   }
 
   async _createGatewayServer (host, port, ipfs) {
-    const server = Hapi.server({ 
-      host, 
+    const server = Hapi.server({
+      host,
       port,
       routes: {
         cors: true

--- a/test/gateway/index.js
+++ b/test/gateway/index.js
@@ -137,6 +137,22 @@ describe('HTTP Gateway', function () {
     expect(res.headers.suborigin).to.equal('ipfs000bafybeicg2rebjoofv4kbyovkw7af3rpiitvnl6i7ckcywaq6xjcxnc2mby')
   })
 
+  it('returns CORS headers', async () => {
+    const res = await gateway.inject({
+      method: 'OPTIONS',
+      url: '/ipfs/QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o',
+      headers: {
+        origin: "http://example.com",
+        "access-control-request-method": "GET",
+        "access-control-request-headers": ""
+      }
+    })
+
+    expect(res.statusCode).to.equal(200)
+    expect(res.headers['access-control-allow-origin']).to.equal('http://example.com')
+    expect(res.headers['access-control-allow-methods']).to.equal('GET')
+  })
+
   /* TODO when support for CIDv1 lands
   it('valid CIDv1', (done) => {
     gateway.inject({

--- a/test/gateway/index.js
+++ b/test/gateway/index.js
@@ -142,9 +142,9 @@ describe('HTTP Gateway', function () {
       method: 'OPTIONS',
       url: '/ipfs/QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o',
       headers: {
-        origin: "http://example.com",
-        "access-control-request-method": "GET",
-        "access-control-request-headers": ""
+        origin: 'http://example.com',
+        'access-control-request-method': 'GET',
+        'access-control-request-headers': ''
       }
     })
 


### PR DESCRIPTION
This allows JSON content served from the gateway to be consumed without a CORS error.

I just tried upgrading from 0.34 to 0.36 and found this issue... adding this extra config seemed to fix it.