### PR TITLE
fix: browser video streaming example

### DIFF
--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -2,7 +2,7 @@
   <body>
     <video id="video" controls></video>
     <script src="https://unpkg.com/ipfs/dist/index.js"></script>
-    <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.3/dist/index.js"></script>
+    <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.4/dist/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>
   </body>


### PR DESCRIPTION
This was waiting on an upstream PR https://github.com/moshisushi/hlsjs-ipfs-loader/pull/9

resolves https://github.com/ipfs/js-ipfs/issues/2255
