### PR TITLE
fix: passed config validation

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -54,8 +54,8 @@ const configSchema = s({
     API: 'object?',
     Addresses: optional(s({
       Swarm: optional(s(['multiaddr'])),
-      API: 'multiaddr?',
-      Gateway: 'multiaddr'
+      API: optional(union([s('multiaddr'), s(['multiaddr'])])),
+      Gateway: optional(union([s('multiaddr'), s(['multiaddr'])]))
     })),
     Discovery: optional(s({
       MDNS: optional(s({
@@ -66,7 +66,13 @@ const configSchema = s({
         Enabled: 'boolean?'
       }))
     })),
-    Bootstrap: optional(s(['multiaddr-ipfs']))
+    Bootstrap: optional(s(['multiaddr-ipfs'])),
+    Swarm: optional(s({
+      ConnMgr: optional(s({
+        LowWater: 'number?',
+        HighWater: 'number?'
+      }))
+    }))
   })),
   ipld: 'object?',
   libp2p: optional(union(['function', 'object'])) // libp2p validates this

--- a/test/core/config.spec.js
+++ b/test/core/config.spec.js
@@ -123,9 +123,11 @@ describe('config', () => {
       { config: { Addresses: { Swarm: undefined } } },
 
       { config: { Addresses: { API: '/ip4/127.0.0.1/tcp/5002' } } },
+      { config: { Addresses: { API: ['/ip4/127.0.0.1/tcp/5002', '/ip4/127.0.0.1/tcp/5003'] } } },
       { config: { Addresses: { API: undefined } } },
 
       { config: { Addresses: { Gateway: '/ip4/127.0.0.1/tcp/9090' } } },
+      { config: { Addresses: { Gateway: ['/ip4/127.0.0.1/tcp/9090', '/ip4/127.0.0.1/tcp/9091'] } } },
       { config: { Addresses: { Gateway: undefined } } },
 
       { config: { Addresses: undefined } },
@@ -143,6 +145,11 @@ describe('config', () => {
 
       { config: { Bootstrap: ['/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'] } },
       { config: { Bootstrap: [] } },
+
+      { config: { Swarm: { ConnMgr: { LowWater: 200, HighWater: 500 } } } },
+      { config: { Swarm: { ConnMgr: { LowWater: undefined, HighWater: undefined } } } },
+      { config: { Swarm: { ConnMgr: undefined } } },
+      { config: { Swarm: undefined } },
 
       { config: undefined }
     ]
@@ -168,6 +175,11 @@ describe('config', () => {
 
       { config: { Bootstrap: ['/ip4/0.0.0.0/tcp/4002'] } },
       { config: { Bootstrap: 138 } },
+
+      { config: { Swarm: { ConnMgr: { LowWater: 200, HighWater: {} } } } },
+      { config: { Swarm: { ConnMgr: { LowWater: {}, HighWater: 500 } } } },
+      { config: { Swarm: { ConnMgr: 138 } } },
+      { config: { Swarm: 138 } },
 
       { config: 138 }
     ]

--- a/test/core/config.spec.js
+++ b/test/core/config.spec.js
@@ -129,7 +129,7 @@ describe('config', () => {
       { config: { Addresses: { Gateway: '/ip4/127.0.0.1/tcp/9090' } } },
       { config: { Addresses: { Gateway: ['/ip4/127.0.0.1/tcp/9090', '/ip4/127.0.0.1/tcp/9091'] } } },
       { config: { Addresses: { Gateway: undefined } } },
-      
+
       { config: { Addresses: { Delegates: ['/dns4/node0.preload.ipfs.io/tcp/443/https'] } } },
       { config: { Addresses: { Delegates: [] } } },
       { config: { Addresses: { Delegates: undefined } } },


### PR DESCRIPTION
Fixes validation for `config.Addresses.API` and `config.Addresses.Gateway` to allow array of multiaddr and adds missing `config.Swarm.ConnMgr` validation.