### PR TITLE
fix: disable socket timeout for pubsub subscriptions

### DIFF
--- a/src/http/api/routes/pubsub.js
+++ b/src/http/api/routes/pubsub.js
@@ -6,7 +6,12 @@ module.exports = [
   {
     method: '*',
     path: '/api/v0/pubsub/sub',
-    handler: resources.pubsub.subscribe.handler
+    handler: resources.pubsub.subscribe.handler,
+    options: {
+      timeout: {
+        socket: false
+      }
+    }
   },
   {
     method: '*',


### PR DESCRIPTION
By default, node sockets automatically timeout after 2 minutes. This instructs Hapi to disable the timeout.