### PR TITLE
docs: update examples

### DIFF
--- a/examples/browser-browserify/src/index.js
+++ b/examples/browser-browserify/src/index.js
@@ -2,17 +2,15 @@
 
 const IPFS = require('ipfs')
 
-const node = new IPFS({ repo: String(Math.random() + Date.now()) })
+document.addEventListener('DOMContentLoaded', async () => {
+  const node = await IPFS.create({ repo: String(Math.random() + Date.now()) })
 
-node.once('ready', () => console.log('IPFS node is ready'))
+  console.log('IPFS node is ready')
 
-function store () {
-  const toStore = document.getElementById('source').value
+  async function store () {
+    const toStore = document.getElementById('source').value
 
-  node.add(Buffer.from(toStore), (err, res) => {
-    if (err || !res) {
-      return console.error('ipfs add error', err, res)
-    }
+    const res = await node.add(Buffer.from(toStore))
 
     res.forEach((file) => {
       if (file && file.hash) {
@@ -20,19 +18,14 @@ function store () {
         display(file.hash)
       }
     })
-  })
-}
+  }
 
-function display (hash) {
-  // buffer: true results in the returned result being a buffer rather than a stream
-  node.cat(hash, (err, data) => {
-    if (err) { return console.error('ipfs cat error', err) }
-
+  async function display (hash) {
+    // buffer: true results in the returned result being a buffer rather than a stream
+    const data = await node.cat(hash)
     document.getElementById('hash').innerText = hash
     document.getElementById('content').innerText = data
-  })
-}
+  }
 
-document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('store').onclick = store
 })

--- a/examples/browser-create-react-app/package.json
+++ b/examples/browser-create-react-app/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "dot-prop": "^5.0.0",
     "ipfs": "file:../../",
-    "ipfs-css": "^0.12.0",
+    "ipfs-css": "^0.13.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-scripts": "3.0.1",

--- a/examples/browser-create-react-app/src/hooks/use-ipfs-factory.js
+++ b/examples/browser-create-react-app/src/hooks/use-ipfs-factory.js
@@ -40,7 +40,7 @@ export default function useIpfsFactory ({ commands }) {
     } else {
       try {
         console.time('IPFS Started')
-        ipfs = await promiseMeJsIpfs(Ipfs, {})
+        ipfs = await Ipfs.create()
         console.timeEnd('IPFS Started')
       } catch (error) {
         console.error('IPFS init error:', error)
@@ -53,12 +53,4 @@ export default function useIpfsFactory ({ commands }) {
   }
 
   return { ipfs, isIpfsReady, ipfsInitError }
-}
-
-function promiseMeJsIpfs (Ipfs, opts) {
-  return new Promise((resolve, reject) => {
-    const ipfs = new Ipfs(opts)
-    ipfs.once('ready', () => resolve(ipfs))
-    ipfs.once('error', err => reject(err))
-  })
 }

--- a/examples/browser-mfs/index.js
+++ b/examples/browser-mfs/index.js
@@ -3,9 +3,6 @@
 /* eslint-env browser */
 
 const IPFS = require('ipfs')
-const ipfs = new IPFS({
-  repo: `ipfs-${Math.random()}`
-})
 const {
   dragDrop,
   log,
@@ -25,11 +22,15 @@ const {
 } = require('./forms')
 const mime = require('mime-sniffer')
 
-hideForms()
+document.addEventListener('DOMContentLoaded', async () => {
+  const ipfs = await IPFS.create({
+    repo: `ipfs-${Math.random()}`
+  })
 
-log('IPFS: Initialising')
+  hideForms()
 
-ipfs.on('ready', () => {
+  log('IPFS: Initialising')
+
   // Allow adding files to IPFS via drag and drop
   dragDrop(async (files) => {
     /* eslint-disable-next-line no-alert */

--- a/examples/browser-parceljs/package.json
+++ b/examples/browser-parceljs/package.json
@@ -26,6 +26,6 @@
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "parcel-bundler": "^1.10.3",
-    "standard": "^12.0.1"
+    "standard": "^13.1.0"
   }
 }

--- a/examples/browser-parceljs/public/index.js
+++ b/examples/browser-parceljs/public/index.js
@@ -1,21 +1,21 @@
 import 'babel-polyfill'
 import IPFS from 'ipfs'
 
-// IPFS node setup
-const node = new IPFS({ repo: String(Math.random() + Date.now()) })
+document.addEventListener('DOMContentLoaded', async () => {
+  // IPFS node setup
+  const node = await IPFS.create({ repo: String(Math.random() + Date.now()) })
 
-// UI elements
-const status = document.getElementById('status')
-const output = document.getElementById('output')
+  // UI elements
+  const status = document.getElementById('status')
+  const output = document.getElementById('output')
 
-output.textContent = ''
+  output.textContent = ''
 
-function log (txt) {
-  console.info(txt)
-  output.textContent += `${txt.trim()}\n`
-}
+  function log (txt) {
+    console.info(txt)
+    output.textContent += `${txt.trim()}\n`
+  }
 
-node.on('ready', async () => {
   status.innerText = 'Connected to IPFS :)'
 
   const version = await node.version()

--- a/examples/browser-readablestream/index.js
+++ b/examples/browser-readablestream/index.js
@@ -3,8 +3,7 @@
 /* eslint-env browser */
 
 const Ipfs = require('../../')
-const videoStream = require('videostream')
-const ipfs = new Ipfs({ repo: 'ipfs-' + Math.random() })
+const VideoStream = require('videostream')
 const {
   dragDrop,
   statusMessages,
@@ -12,9 +11,11 @@ const {
   log
 } = require('./utils')
 
-log('IPFS: Initialising')
+document.addEventListener('DOMContentLoaded', async () => {
+  const ipfs = await Ipfs.create({ repo: 'ipfs-' + Math.random() })
 
-ipfs.on('ready', () => {
+  log('IPFS: Initialising')
+
   // Set up event listeners on the <video> element from index.html
   const videoElement = createVideoElement()
   const hashInput = document.getElementById('hash')
@@ -27,7 +28,7 @@ ipfs.on('ready', () => {
     log(`IPFS: Playing ${hashInput.value.trim()}`)
 
     // Set up the video stream an attach it to our <video> element
-    videoStream({
+    const videoStream = new VideoStream({
       createReadStream: function createReadStream (opts) {
         const start = opts.start
 
@@ -61,6 +62,8 @@ ipfs.on('ready', () => {
         return stream
       }
     }, videoElement)
+
+    videoElement.addEventListener('error', () => log(videoStream.detailedError))
   }
 
   // Allow adding files to IPFS via drag and drop

--- a/examples/browser-script-tag/README.md
+++ b/examples/browser-script-tag/README.md
@@ -2,7 +2,7 @@
 
 You can use IPFS in your in-browser JavaScript code with just a `<script>` tag.
 
-```
+```html
 <script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
 ```
 

--- a/examples/browser-script-tag/index.html
+++ b/examples/browser-script-tag/index.html
@@ -4,12 +4,14 @@
   <title>IPFS in the Browser</title>
   <script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
   <script type="text/javascript">
-    const node = new Ipfs({ repo: 'ipfs-' + Math.random() })
+    document.addEventListener('DOMContentLoaded', async () => {
+      const node = await Ipfs.create({ repo: 'ipfs-' + Math.random() })
+      window.node = node
 
-    node.once('ready', () => {
-      console.log('Online status: ', node.isOnline() ? 'online' : 'offline')
+      const status = node.isOnline() ? 'online' : 'offline'
 
-      document.getElementById("status").innerHTML= 'Node status: ' + (node.isOnline() ? 'online' : 'offline')
+      console.log(`Node status: ${status}`)
+      document.getElementById('status').innerHTML = `Node status: ${status}`
 
       // You can write more code here to use it. Use methods like
       // node.add, node.get. See the API docs here:
@@ -29,25 +31,24 @@
 
   <code style="display:block; white-space:pre-wrap; background-color:#d7d6d6">
     const { Buffer } = Ipfs
-    node.add(new Buffer('Hello world!'), (err, filesAdded) => {
-      if (err) {
-        return console.error('Error - ipfs add', err, res)
-      }
 
+    async function addFile () {
+      const filesAdded = await node.add(Buffer.from('Hello world!'))
       filesAdded.forEach((file) => console.log('successfully stored', file.hash))
-    })
+    }
+
+    addFile()
   </code>
 
   <p>You can cat that same file. If you used the exact same string as above ('Hello world!') you should have an hash like this: 'QmQzCQn4puG4qu8PVysxZmscmQ5vT1ZXpqo7f58Uh9QfyY'</p>
 
   <code style="display:block; white-space:pre-wrap; background-color:#d7d6d6">
-    node.cat('QmQzCQn4puG4qu8PVysxZmscmQ5vT1ZXpqo7f58Uh9QfyY', function (err, data) {
-      if (err) {
-        return console.error('Error - ipfs files cat', err, res)
-      }
-
+    async function catFile () {
+      const data = await node.cat('QmQzCQn4puG4qu8PVysxZmscmQ5vT1ZXpqo7f58Uh9QfyY')
       console.log(data.toString())
-    })
+    }
+
+    catFile()
   </code>
 </body>
 </html>

--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -1,8 +1,7 @@
 <html>
   <body>
     <video id="video" controls></video>
-    <!-- <script src="https://unpkg.com/ipfs/dist/index.js"></script> -->
-    <script src="../../dist/index.js"></script>
+    <script src="https://unpkg.com/ipfs/dist/index.js"></script>
     <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.4/dist/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>

--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -1,7 +1,8 @@
 <html>
   <body>
     <video id="video" controls></video>
-    <script src="https://unpkg.com/ipfs/dist/index.js"></script>
+    <!-- <script src="https://unpkg.com/ipfs/dist/index.js"></script> -->
+    <script src="../../dist/index.js"></script>
     <script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.4/dist/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>

--- a/examples/browser-video-streaming/streaming.js
+++ b/examples/browser-video-streaming/streaming.js
@@ -3,18 +3,18 @@
 /* global Hls Ipfs HlsjsIpfsLoader */
 /* eslint-env browser */
 
-const testhash = 'QmdpAidwAsBGptFB3b6A9Pyi5coEbgjHrL3K2Qrsutmj9K'
-const repoPath = 'ipfs-' + Math.random()
-const node = new Ipfs({ repo: repoPath })
+document.addEventListener('DOMContentLoaded', async () => {
+  const testHash = 'QmdpAidwAsBGptFB3b6A9Pyi5coEbgjHrL3K2Qrsutmj9K'
+  const repoPath = 'ipfs-' + Math.random()
+  const node = await Ipfs.create({ repo: repoPath })
 
-node.on('ready', () => {
   Hls.DefaultConfig.loader = HlsjsIpfsLoader
   Hls.DefaultConfig.debug = false
   if (Hls.isSupported()) {
     const video = document.getElementById('video')
     const hls = new Hls()
     hls.config.ipfs = node
-    hls.config.ipfsHash = testhash
+    hls.config.ipfsHash = testHash
     hls.loadSource('master.m3u8')
     hls.attachMedia(video)
     hls.on(Hls.Events.MANIFEST_PARSED, () => video.play())

--- a/examples/browser-webpack/src/components/app.js
+++ b/examples/browser-webpack/src/components/app.js
@@ -10,71 +10,50 @@ class App extends React.Component {
     super(props)
     this.state = {
       id: null,
-      version: null,
-      protocol_version: null,
-      added_file_hash: null,
-      added_file_contents: null
+      agentVersion: null,
+      protocolVersion: null,
+      addedFileHash: null,
+      addedFileContents: null
     }
   }
+
   componentDidMount () {
-    const self = this
-    let node
-
-    create()
-
-    function create () {
-      // Create the IPFS node instance
-
-      node = new IPFS({ repo: String(Math.random() + Date.now()) })
-
-      node.once('ready', () => {
-        console.log('IPFS node is ready')
-        ops()
-      })
-    }
-
-    function ops () {
-      node.id((err, res) => {
-        if (err) {
-          throw err
-        }
-        self.setState({
-          id: res.id,
-          version: res.agentVersion,
-          protocol_version: res.protocolVersion
-        })
-      })
-
-      node.add([Buffer.from(stringToUse)], (err, filesAdded) => {
-        if (err) { throw err }
-
-        const hash = filesAdded[0].hash
-        self.setState({ added_file_hash: hash })
-
-        node.cat(hash, (err, data) => {
-          if (err) { throw err }
-          self.setState({ added_file_contents: data.toString() })
-        })
-      })
-    }
+    this.ops()
   }
+
+  async ops () {
+    const node = await IPFS.create({ repo: String(Math.random() + Date.now()) })
+
+    console.log('IPFS node is ready')
+
+    const { id, agentVersion, protocolVersion } = await node.id()
+
+    this.setState({ id, agentVersion, protocolVersion })
+
+    const [{ hash }] = await node.add(Buffer.from(stringToUse))
+    this.setState({ addedFileHash: hash })
+
+    const data = await node.cat(hash)
+    this.setState({ addedFileContents: data.toString() })
+  }
+
   render () {
     return (
       <div style={{ textAlign: 'center' }}>
         <h1>Everything is working!</h1>
         <p>Your ID is <strong>{this.state.id}</strong></p>
-        <p>Your IPFS version is <strong>{this.state.version}</strong></p>
-        <p>Your IPFS protocol version is <strong>{this.state.protocol_version}</strong></p>
+        <p>Your IPFS version is <strong>{this.state.agentVersion}</strong></p>
+        <p>Your IPFS protocol version is <strong>{this.state.protocolVersion}</strong></p>
         <hr />
         <div>
           Added a file! <br />
-          {this.state.added_file_hash}
+          {this.state.addedFileHash}
         </div>
         <br />
         <br />
         <p>
           Contents of this file: <br />
-          {this.state.added_file_contents}
+          {this.state.addedFileContents}
         </p>
       </div>
     )

--- a/examples/circuit-relaying/index.html
+++ b/examples/circuit-relaying/index.html
@@ -23,7 +23,7 @@
           <ul id="msgs"></ul>
         </div>
         <div>
-          <label>message:</label>
+          <label>Message:</label>
           <input type="text" id="message"></input>
           <button id="send">Send</button>
         </div>

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -18,8 +18,8 @@
     "ipfs-pubsub-room": "^1.4.0"
   },
   "devDependencies": {
-    "aegir": "^19.0.3",
-    "ipfs-css": "~0.12.0",
+    "aegir": "^20.0.0",
+    "ipfs-css": "^0.13.1",
     "parcel-bundler": "^1.6.2",
     "tachyons": "^4.9.1"
   },

--- a/examples/circuit-relaying/src/app.js
+++ b/examples/circuit-relaying/src/app.js
@@ -4,54 +4,54 @@
 const IPFS = require('ipfs')
 const Helpers = require('./helpers')
 
-const $peerId = document.querySelector('#peer-id')
-const $message = document.querySelector('#message')
-const $msgs = document.querySelector('#msgs')
-const $send = document.querySelector('#send')
-const $peer = document.querySelector('#peer')
-const $connect = document.querySelector('#connect')
-const $pAddrs = document.querySelector('#peers-addrs')
-const $room = document.querySelector('#room')
-const $roomId = document.querySelector('#room-id')
+document.addEventListener('DOMContentLoaded', async () => {
+  const $peerId = document.querySelector('#peer-id')
+  const $message = document.querySelector('#message')
+  const $msgs = document.querySelector('#msgs')
+  const $send = document.querySelector('#send')
+  const $peer = document.querySelector('#peer')
+  const $connect = document.querySelector('#connect')
+  const $pAddrs = document.querySelector('#peers-addrs')
+  const $room = document.querySelector('#room')
+  const $roomId = document.querySelector('#room-id')
 
-let roomName = `default`
-const fragment = window.location.hash.substr(1)
-if (fragment) {
-  roomName = fragment
-}
-
-$pAddrs.value = ''
-$room.innerText = roomName
-
-const repo = () => {
-  return 'ipfs/pubsub-demo/' + Math.random()
-}
-
-const ipfs = new IPFS({
-  repo: repo(),
-  relay: {
-    enabled: true, // enable relay dialer/listener (STOP)
-    hop: {
-      enabled: true // make this node a relay (HOP)
-    }
-  },
-  EXPERIMENTAL: {
-    pubsub: true // enable pubsub
-  },
-  config: {
-    Bootstrap: []
+  let roomName = `default`
+  const fragment = window.location.hash.substr(1)
+  if (fragment) {
+    roomName = fragment
   }
-})
 
-const peersSet = new Set()
-const helpers = Helpers(ipfs, peersSet)
-const createRoom = helpers.createRoom
-const sendMsg = helpers.sendMsg
-const updatePeers = helpers.updatePeers
-const updateAddrs = helpers.updateAddrs
+  $pAddrs.value = ''
+  $room.innerText = roomName
 
-ipfs.once('ready', () => ipfs.id((err, info) => {
-  if (err) { throw err }
+  const repo = () => {
+    return 'ipfs/pubsub-demo/' + Math.random()
+  }
+
+  const ipfs = await IPFS.create({
+    repo: repo(),
+    relay: {
+      enabled: true, // enable relay dialer/listener (STOP)
+      hop: {
+        enabled: true // make this node a relay (HOP)
+      }
+    },
+    EXPERIMENTAL: {
+      pubsub: true // enable pubsub
+    },
+    config: {
+      Bootstrap: []
+    }
+  })
+
+  const peersSet = new Set()
+  const helpers = Helpers(ipfs, peersSet)
+  const createRoom = helpers.createRoom
+  const sendMsg = helpers.sendMsg
+  const updatePeers = helpers.updatePeers
+  const updateAddrs = helpers.updateAddrs
+
+  const info = await ipfs.id()
   console.log('IPFS node ready with id ' + info.id)
 
   let room = createRoom(roomName)
@@ -97,14 +97,14 @@ ipfs.once('ready', () => ipfs.id((err, info) => {
     }
   })
 
-  $connect.addEventListener('click', () => {
+  $connect.addEventListener('click', async () => {
     const peer = $peer.value
     $peer.value = ''
-    ipfs.swarm.connect(peer, (err) => {
-      if (err) {
-        return console.error(err)
-      }
-      $pAddrs.innerHTML += `<li>${peer.trim()}</li>`
-    })
+    try {
+      await ipfs.swarm.connect(peer)
+    } catch (err) {
+      return console.error(err)
+    }
+    $pAddrs.innerHTML += `<li>${peer.trim()}</li>`
   })
-}))
+})

--- a/examples/custom-ipfs-repo/index.js
+++ b/examples/custom-ipfs-repo/index.js
@@ -61,47 +61,38 @@ const customRepositoryOptions = {
   lock: fsLock
 }
 
-// Initialize our IPFS node with the custom repo options
-const node = new IPFS({
-  repo: new Repo('/tmp/custom-repo/.ipfs', customRepositoryOptions)
-})
+async function main () {
+  // Initialize our IPFS node with the custom repo options
+  const node = await IPFS.create({
+    repo: new Repo('/tmp/custom-repo/.ipfs', customRepositoryOptions)
+  })
 
-// Test the new repo by adding and fetching some data
-node.on('ready', () => {
+  // Test the new repo by adding and fetching some data
   console.log('Ready')
-  node.version()
-    .then((version) => {
-      console.log('Version:', version.version)
-    })
-    // Once we have the version, let's add a file to IPFS
-    .then(() => {
-      return node.add({
-        path: 'test-data.txt',
-        content: Buffer.from('We are using a customized repo!')
-      })
-    })
-    // Log out the added files metadata and cat the file from IPFS
-    .then((filesAdded) => {
-      console.log('\nAdded file:', filesAdded[0].path, filesAdded[0].hash)
-      return node.cat(filesAdded[0].hash)
-    })
-    // Print out the files contents to console
-    .then((data) => {
-      console.log('\nFetched file content:')
-      process.stdout.write(data)
-    })
-    // Log out the error, if there is one
-    .catch((err) => {
-      console.log('File Processing Error:', err)
-    })
-    // After everything is done, shut the node down
-    // We don't need to worry about catching errors here
-    .then(() => {
-      console.log('\n\nStopping the node')
-      return node.stop()
-    })
-    // Let users know where they can inspect the repo
-    .then(() => {
-      console.log('Check "/tmp/custom-repo/.ipfs" to see what your customized repository looks like on disk.')
-    })
-})
+  const { version } = await node.version()
+  console.log('Version:', version)
+
+  // Once we have the version, let's add a file to IPFS
+  const filesAdded = await node.add({
+    path: 'test-data.txt',
+    content: Buffer.from('We are using a customized repo!')
+  })
+
+  // Log out the added files metadata and cat the file from IPFS
+  console.log('\nAdded file:', filesAdded[0].path, filesAdded[0].hash)
+
+  const data = await node.cat(filesAdded[0].hash)
+
+  // Print out the files contents to console
+  console.log('\nFetched file content:')
+  process.stdout.write(data)
+
+  // After everything is done, shut the node down
+  console.log('\n\nStopping the node')
+  await node.stop()
+
+  // Let users know where they can inspect the repo
+  console.log('Check "/tmp/custom-repo/.ipfs" to see what your customized repository looks like on disk.')
+}
+
+main()

--- a/examples/custom-libp2p/index.js
+++ b/examples/custom-libp2p/index.js
@@ -110,24 +110,23 @@ async function main () {
   })
 
   // Lets log out the number of peers we have every 2 seconds
-  setInterval(() => {
-    node.swarm.peers((err, peers) => {
-      if (err) {
-        console.log('An error occurred trying to check our peers:', err)
-        process.exit(1)
-      }
+  setInterval(async () => {
+    try {
+      const peers = await node.swarm.peers()
       console.log(`The node now has ${peers.length} peers.`)
-    })
+    } catch (err) {
+      console.log('An error occurred trying to check our peers:', err)
+    }
   }, 2000)
 
   // Log out the bandwidth stats every 4 seconds so we can see how our configuration is doing
-  setInterval(() => {
-    node.stats.bw((err, stats) => {
-      if (err) {
-        console.log('An error occurred trying to check our stats:', err)
-      }
+  setInterval(async () => {
+    try {
+      const stats = await node.stats.bw()
       console.log(`\nBandwidth Stats: ${JSON.stringify(stats, null, 2)}\n`)
-    })
+    } catch (err) {
+      console.log('An error occurred trying to check our stats:', err)
+    }
   }, 4000)
 }
 

--- a/examples/custom-libp2p/index.js
+++ b/examples/custom-libp2p/index.js
@@ -10,7 +10,6 @@ const SPDY = require('libp2p-spdy')
 const KadDHT = require('libp2p-kad-dht')
 const MPLEX = require('pull-mplex')
 const SECIO = require('libp2p-secio')
-const assert = require('assert')
 
 /**
  * Options for the libp2p bundle
@@ -104,14 +103,11 @@ const libp2pBundle = (opts) => {
   })
 }
 
-// Now that we have our custom libp2p bundle, let's start up the ipfs node!
-const node = new IPFS({
-  libp2p: libp2pBundle
-})
-
-// Listen for the node to start, so we can log out some metrics
-node.once('start', (err) => {
-  assert.ifError(err, 'Should startup without issue')
+async function main () {
+  // Now that we have our custom libp2p bundle, let's start up the ipfs node!
+  const node = await IPFS.create({
+    libp2p: libp2pBundle
+  })
 
   // Lets log out the number of peers we have every 2 seconds
   setInterval(() => {
@@ -133,4 +129,6 @@ node.once('start', (err) => {
       console.log(`\nBandwidth Stats: ${JSON.stringify(stats, null, 2)}\n`)
     })
   }, 4000)
-})
+}
+
+main()

--- a/examples/exchange-files-in-browser/package.json
+++ b/examples/exchange-files-in-browser/package.json
@@ -12,7 +12,6 @@
     "http-server": "~0.11.1"
   },
   "dependencies": {
-    "ipfs": "file:../../",
-    "stream-buffers": "^3.0.1"
+    "ipfs": "file:../../"
   }
 }

--- a/examples/exchange-files-in-browser/public/app.js
+++ b/examples/exchange-files-in-browser/public/app.js
@@ -202,13 +202,13 @@ async function getFile () {
 
   const files = await node.get(hash)
 
-  return files.map(async (file) => {
+  return Promise.all(files.map(async (file) => {
     if (file.content) {
       await appendFile(file.name, hash, file.size, file.content)
       onSuccess(`The ${file.name} file was added.`)
       $emptyRow.style.display = 'none'
     }
-  })
+  }))
 }
 
 /* Drag & Drop
@@ -224,12 +224,12 @@ async function onDrop (event) {
 
   const files = Array.from(event.dataTransfer.files)
 
-  for (let i = 0; i < files.length; i++) {
-    fileSize = files[i].size
+  for (const file of files) {
+    fileSize = file.size // Note: fileSize is used by updateProgress
 
     const filesAdded = await node.add({
-      path: files[i].name,
-      content: files[i]
+      path: file.name,
+      content: file
     }, { wrapWithDirectory: true, progress: updateProgress })
 
     // As we are wrapping the content we use that hash to keep

--- a/examples/exchange-files-in-browser/public/app.js
+++ b/examples/exchange-files-in-browser/public/app.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const IPFS = require('ipfs')
+const { Buffer } = IPFS
 
 // Node
 const $nodeId = document.querySelector('.node-id')
@@ -13,7 +14,7 @@ const $peersList = $peers.querySelector('tbody')
 const $multiaddrInput = document.querySelector('#multiaddr-input')
 const $connectButton = document.querySelector('#peer-btn')
 // Files
-const $multihashInput = document.querySelector('#multihash-input')
+const $cidInput = document.querySelector('#cid-input')
 const $fetchButton = document.querySelector('#fetch-btn')
 const $dragContainer = document.querySelector('#drag-container')
 const $progressBar = document.querySelector('#progress-bar')
@@ -35,13 +36,12 @@ let fileSize = 0
 
 let node
 let info
-let Buffer = IPFS.Buffer
 
 /* ===========================================================================
    Start the IPFS node
    =========================================================================== */
 
-function start () {
+async function start () {
   if (!node) {
     const options = {
       EXPERIMENTAL: {
@@ -55,22 +55,49 @@ function start () {
       }
     }
 
-    node = new IPFS(options)
+    node = await IPFS.create(options)
 
-    node.once('start', () => {
-      node.id()
-        .then((id) => {
-          info = id
-          updateView('ready', node)
-          onSuccess('Node is ready.')
-          setInterval(refreshPeerList, 1000)
-          setInterval(sendFileList, 10000)
-        })
-        .catch((error) => onError(error))
+    try {
+      info = await node.id()
+      updateView('ready', node)
+    } catch (err) {
+      return onError(err)
+    }
 
-      subscribeToWorkpsace()
+    onSuccess('Node is ready.')
 
-      window.addEventListener('hashchange', workspaceUpdated)
+    setInterval(async () => {
+      try {
+        await refreshPeerList()
+      } catch (err) {
+        err.message = `Failed to refresh the peer list: ${err.message}`
+        onError(err)
+      }
+    }, 1000)
+
+    setInterval(async () => {
+      try {
+        await sendFileList()
+      } catch (err) {
+        err.message = `Failed to publish the file list: ${err.message}`
+        onError(err)
+      }
+    }, 10000)
+
+    try {
+      await subscribeToWorkpsace()
+    } catch (err) {
+      err.message = `Failed to subscribe to the workspace: ${err.message}`
+      return onError(err)
+    }
+
+    window.addEventListener('hashchange', async () => {
+      try {
+        await workspaceUpdated()
+      } catch (err) {
+        err.message = `Failed to subscribe to the updated workspace: ${err.message}`
+        onError(err)
+      }
     })
   }
 }
@@ -85,47 +112,39 @@ const messageHandler = (message) => {
   const messageSender = message.from
 
   // append new files when someone uploads them
-  if (myNode !== messageSender && !isFileInList(hash)) {
-    $multihashInput.value = hash
+  if (myNode !== messageSender && !FILES.includes(hash)) {
+    $cidInput.value = hash
     getFile()
   }
 }
 
-const subscribeToWorkpsace = () => {
-  node.pubsub.subscribe(workspace, messageHandler)
-    .then(() => {
-      const msg = `Subscribed to workspace ${workspace}`
-      $logs.innerHTML = msg
-    })
-    .catch(() => onError('An error occurred when subscribing to the workspace.'))
+const subscribeToWorkpsace = async () => {
+  await node.pubsub.subscribe(workspace, messageHandler)
+  const msg = `Subscribed to workspace ${workspace}`
+  $logs.innerHTML = msg
 }
 
 // unsubscribe from old workspace and re-subscribe to new one
-const workspaceUpdated = () => {
-  node.pubsub.unsubscribe(workspace).then(() => {
-    // clear files from old workspace
-    FILES = []
-    $fileHistory.innerHTML = ''
+const workspaceUpdated = async () => {
+  await node.pubsub.unsubscribe(workspace)
+  // clear files from old workspace
+  FILES = []
+  $fileHistory.innerHTML = ''
 
-    workspace = location.hash
-    subscribeToWorkpsace()
-  })
+  workspace = location.hash
+  await subscribeToWorkpsace()
 }
 
 const publishHash = (hash) => {
   const data = Buffer.from(hash)
-
-  node.pubsub.publish(workspace, data)
-    .catch(() => onError('An error occurred when publishing the message.'))
+  return node.pubsub.publish(workspace, data)
 }
 
 /* ===========================================================================
    Files handling
    =========================================================================== */
 
-const isFileInList = (hash) => FILES.indexOf(hash) !== -1
-
-const sendFileList = () => FILES.forEach((hash) => publishHash(hash))
+const sendFileList = () => Promise.all(FILES.map(publishHash))
 
 const updateProgress = (bytesLoaded) => {
   let percent = 100 - ((bytesLoaded / fileSize) * 100)
@@ -165,33 +184,31 @@ function appendFile (name, hash, size, data) {
 
   $fileHistory.insertBefore(row, $fileHistory.firstChild)
 
-  publishHash(hash)
+  return publishHash(hash)
 }
 
-function getFile () {
-  const hash = $multihashInput.value
+async function getFile () {
+  const hash = $cidInput.value
 
-  $multihashInput.value = ''
+  $cidInput.value = ''
 
   if (!hash) {
-    return onError('No multihash was inserted.')
-  } else if (isFileInList(hash)) {
+    return onError('No CID was inserted.')
+  } else if (FILES.includes(hash)) {
     return onSuccess('The file is already in the current workspace.')
   }
 
   FILES.push(hash)
 
-  node.get(hash)
-    .then((files) => {
-      files.forEach((file) => {
-        if (file.content) {
-          appendFile(file.name, hash, file.size, file.content)
-          onSuccess(`The ${file.name} file was added.`)
-          $emptyRow.style.display = 'none'
-        }
-      })
-    })
-    .catch(() => onError('An error occurred when fetching the files.'))
+  const files = await node.get(hash)
+
+  return files.map(async (file) => {
+    if (file.content) {
+      await appendFile(file.name, hash, file.size, file.content)
+      onSuccess(`The ${file.name} file was added.`)
+      $emptyRow.style.display = 'none'
+    }
+  })
 }
 
 /* Drag & Drop
@@ -201,91 +218,65 @@ const onDragEnter = () => $dragContainer.classList.add('dragging')
 
 const onDragLeave = () => $dragContainer.classList.remove('dragging')
 
-function onDrop (event) {
+async function onDrop (event) {
   onDragLeave()
   event.preventDefault()
 
-  const dt = event.dataTransfer
-  const filesDropped = dt.files
+  const files = Array.from(event.dataTransfer.files)
 
-  function readFileContents (file) {
-    return new Promise((resolve) => {
-      const reader = new window.FileReader()
-      reader.onload = (event) => resolve(event.target.result)
-      reader.readAsArrayBuffer(file)
-    })
+  for (let i = 0; i < files.length; i++) {
+    fileSize = files[i].size
+
+    const filesAdded = await node.add({
+      path: files[i].name,
+      content: files[i]
+    }, { wrapWithDirectory: true, progress: updateProgress })
+
+    // As we are wrapping the content we use that hash to keep
+    // the original file name when adding it to the table
+    $cidInput.value = filesAdded[1].hash
+
+    resetProgress()
+    await getFile()
   }
-
-  const files = []
-  for (let i = 0; i < filesDropped.length; i++) {
-    files.push(filesDropped[i])
-  }
-
-  files.forEach((file) => {
-    readFileContents(file)
-      .then((buffer) => {
-        fileSize = file.size
-
-        node.add({
-          path: file.name,
-          content: Buffer.from(buffer)
-        }, { wrapWithDirectory: true, progress: updateProgress }, (err, filesAdded) => {
-          if (err) {
-            return onError(err)
-          }
-
-          // As we are wrapping the content we use that hash to keep
-          // the original file name when adding it to the table
-          $multihashInput.value = filesAdded[1].hash
-
-          resetProgress()
-          getFile()
-        })
-      })
-      .catch(onError)
-  })
 }
 
 /* ===========================================================================
    Peers handling
    =========================================================================== */
 
-function connectToPeer (event) {
+async function connectToPeer (event) {
   const multiaddr = $multiaddrInput.value
 
   if (!multiaddr) {
-    return onError('No multiaddr was inserted.')
+    throw new Error('No multiaddr was inserted.')
   }
 
-  node.swarm.connect(multiaddr)
-    .then(() => {
-      onSuccess(`Successfully connected to peer.`)
-      $multiaddrInput.value = ''
-    })
-    .catch(() => onError('An error occurred when connecting to the peer.'))
+  await node.swarm.connect(multiaddr)
+
+  onSuccess(`Successfully connected to peer.`)
+  $multiaddrInput.value = ''
 }
 
-function refreshPeerList () {
-  node.swarm.peers()
-    .then((peers) => {
-      const peersAsHtml = peers.reverse()
-        .map((peer) => {
-          if (peer.addr) {
-            const addr = peer.addr.toString()
-            if (addr.indexOf('ipfs') >= 0) {
-              return addr
-            } else {
-              return addr + peer.peer.id.toB58String()
-            }
-          }
-        })
-        .map((addr) => {
-          return `<tr><td>${addr}</td></tr>`
-        }).join('')
+async function refreshPeerList () {
+  const peers = await node.swarm.peers()
 
-      $peersList.innerHTML = peersAsHtml
+  const peersAsHtml = peers.reverse()
+    .map((peer) => {
+      if (peer.addr) {
+        const addr = peer.addr.toString()
+        if (addr.indexOf('ipfs') >= 0) {
+          return addr
+        } else {
+          return addr + peer.peer.id.toB58String()
+        }
+      }
     })
-    .catch((error) => onError(error))
+    .map((addr) => {
+      return `<tr><td>${addr}</td></tr>`
+    }).join('')
+
+  $peersList.innerHTML = peersAsHtml
 }
 
 /* ===========================================================================
@@ -298,6 +289,7 @@ function onSuccess (msg) {
 }
 
 function onError (err) {
+  console.log(err)
   let msg = 'An error occured, check the dev console'
 
   if (err.stack !== undefined) {
@@ -345,10 +337,31 @@ const startApplication = () => {
   // Setup event listeners
   $dragContainer.addEventListener('dragenter', onDragEnter)
   $dragContainer.addEventListener('dragover', onDragEnter)
-  $dragContainer.addEventListener('drop', onDrop)
+  $dragContainer.addEventListener('drop', async e => {
+    try {
+      await onDrop(e)
+    } catch (err) {
+      err.message = `Failed to add files: ${err.message}`
+      onError(err)
+    }
+  })
   $dragContainer.addEventListener('dragleave', onDragLeave)
-  $fetchButton.addEventListener('click', getFile)
-  $connectButton.addEventListener('click', connectToPeer)
+  $fetchButton.addEventListener('click', async () => {
+    try {
+      await getFile()
+    } catch (err) {
+      err.message = `Failed to fetch CID: ${err.message}`
+      onError(err)
+    }
+  })
+  $connectButton.addEventListener('click', async () => {
+    try {
+      await connectToPeer()
+    } catch (err) {
+      err.message = `Failed to connect to peer: ${err.message}`
+      onError(err)
+    }
+  })
   $workspaceBtn.addEventListener('click', () => {
     window.location.hash = $workspaceInput.value
   })

--- a/examples/exchange-files-in-browser/public/index.html
+++ b/examples/exchange-files-in-browser/public/index.html
@@ -65,7 +65,7 @@
           <h2>Files</h2>
 
           <div class="input-button">
-            <input id="multihash-input" type="text" placeholder="Multihash" disabled />
+            <input id="cid-input" type="text" placeholder="CID" disabled />
             <button id="fetch-btn" type="button" disabled>Fetch</button>
           </div>
 

--- a/examples/ipfs-101/1.js
+++ b/examples/ipfs-101/1.js
@@ -2,9 +2,8 @@
 
 const IPFS = require('ipfs')
 
-const node = new IPFS()
-
-node.on('ready', async () => {
+async function main () {
+  const node = await IPFS.create()
   const version = await node.version()
 
   console.log('Version:', version.version)
@@ -19,4 +18,6 @@ node.on('ready', async () => {
   const fileBuffer = await node.cat(filesAdded[0].hash)
 
   console.log('Added file contents:', fileBuffer.toString())
-})
+}
+
+main()

--- a/examples/ipfs-101/README.md
+++ b/examples/ipfs-101/README.md
@@ -9,27 +9,31 @@ Creating an IPFS instance can be done in one line, after requiring the module, y
 ```js
 const IPFS = require('ipfs')
 
-const node = new IPFS()
-```
+async function main () {
+  const node = await IPFS.create()
+  // ...
+}
 
-We can listen for the `ready` event to learn when the node is ready to be used. Within the ready event, we'll use `async`/`await` to help us manage the async flow.
+main()
+```
 
 As a test, we are going to check the version of the node.
 
 ```js
 const IPFS = require('ipfs')
 
-const node = new IPFS()
-
-node.on('ready', async () => {
+async function main () {
+  const node = await IPFS.create()
   const version = await node.version()
 
   console.log('Version:', version.version)
-})
+  // ...
+}
+
+main()
 ```
 
-(If you prefer not to use `async`/`await`, you can instead use `.then()` as you would with any promise,
-or pass an [error-first callback](https://nodejs.org/api/errors.html#errors_error_first_callbacks), e.g. `node.version((err, version) => { ... })`)
+(If you prefer not to use `async`/`await`, you can instead use `.then()` as you would with any promise, or pass an [error-first callback](https://nodejs.org/api/errors.html#errors_error_first_callbacks), e.g. `node.version((err, version) => { ... })`)
 
 Running the code above gets you:
 
@@ -40,10 +44,13 @@ Version: 0.31.2
 
 Now let's make it more interesting and add a file to IPFS using `node.add`. A file consists of a path and content.
 
-You can learn about the IPFS File API at [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md).
+You can learn about the IPFS File API at [interface-ipfs-core](https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md).
 
 ```js
-node.on('ready', async () => {
+const IPFS = require('ipfs')
+
+async function main () {
+  const node = await IPFS.create()
   const version = await node.version()
 
   console.log('Version:', version.version)
@@ -54,7 +61,10 @@ node.on('ready', async () => {
   })
 
   console.log('Added file:', filesAdded[0].path, filesAdded[0].hash)
-})
+  // ...
+}
+
+main()
 ```
 
 You can now go to an IPFS Gateway and load the printed hash from a gateway. Go ahead and try it!
@@ -71,7 +81,10 @@ Added file: hello.txt QmXgZAUWd8yo4tvjBETqzUy3wLx5YRzuDwUQnBwRGrAmAo
 The last step of this tutorial is retrieving the file back using the `cat` 😺 call.
 
 ```js
-node.on('ready', async () => {
+const IPFS = require('ipfs')
+
+async function main () {
+  const node = await IPFS.create()
   const version = await node.version()
 
   console.log('Version:', version.version)
@@ -86,7 +99,9 @@ node.on('ready', async () => {
   const fileBuffer = await node.cat(filesAdded[0].hash)
 
   console.log('Added file contents:', fileBuffer.toString())
-})
+}
+
+main()
 ```
 
 That's it! You just added and retrieved a file from the Distributed Web!

--- a/examples/run-in-electron/main.js
+++ b/examples/run-in-electron/main.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { app, BrowserWindow } = require('electron')
+const IPFS = require('ipfs')
 
 let mainWindow
 
@@ -23,22 +24,16 @@ function createWindow () {
   })
 }
 
-app.on('ready', () => {
+app.on('ready', async () => {
   createWindow()
 
-  const IPFS = require('ipfs')
-  const node = new IPFS()
-  node.on('ready', () => {
-    node.id((err, id) => {
-      if (err) {
-        return console.log(err)
-      }
-      console.log(id)
-    })
-  })
-  node.on('error', (err) => {
-    return console.log(err)
-  })
+  try {
+    const node = await IPFS.create()
+    const id = await node.id()
+    console.log(id)
+  } catch (err) {
+    console.error(err)
+  }
 })
 
 // Quit when all windows are closed.

--- a/examples/run-in-electron/package.json
+++ b/examples/run-in-electron/package.json
@@ -14,7 +14,7 @@
   "author": "David Dias <daviddias@ipfs.io>",
   "license": "MIT",
   "devDependencies": {
-    "electron": "^5.0.2",
+    "electron": "^6.0.0",
     "electron-rebuild": "^1.8.4",
     "ipfs": "file:../../"
   },

--- a/examples/run-in-electron/package.json
+++ b/examples/run-in-electron/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "electron": "^5.0.2",
     "electron-rebuild": "^1.8.4",
-    "ipfs": "ipfs/js-ipfs"
+    "ipfs": "file:../../"
   },
   "greenkeeper": {
     "ignore": [

--- a/examples/traverse-ipld-graphs/create-node.js
+++ b/examples/traverse-ipld-graphs/create-node.js
@@ -4,19 +4,10 @@ const IPFS = require('../../src/core')
 // In your project, replace by the following line and install IPFS as a dep
 // const IPFS = require('ipfs')
 
-function createNode (options, callback) {
-  if (typeof options === 'function') {
-    callback = options
-    options = {}
-  }
-
+function createNode (options) {
+  options = options || {}
   options.path = options.path || '/tmp/ipfs' + Math.random()
-
-  const node = new IPFS({
-    repo: options.path
-  })
-
-  node.on('start', () => callback(null, node))
+  return IPFS.create({ repo: options.path })
 }
 
 module.exports = createNode

--- a/examples/traverse-ipld-graphs/create-node.js
+++ b/examples/traverse-ipld-graphs/create-node.js
@@ -4,8 +4,7 @@ const IPFS = require('../../src/core')
 // In your project, replace by the following line and install IPFS as a dep
 // const IPFS = require('ipfs')
 
-function createNode (options) {
-  options = options || {}
+function createNode (options = {}) {
   options.path = options.path || '/tmp/ipfs' + Math.random()
   return IPFS.create({ repo: options.path })
 }

--- a/examples/traverse-ipld-graphs/eth.js
+++ b/examples/traverse-ipld-graphs/eth.js
@@ -18,8 +18,8 @@ async function main () {
     path.join(__dirname, '/eth-blocks/block_302517')
   ]
 
-  for (let i = 0; i < ethBlocks.length; i++) {
-    const data = await fs.readFile(ethBlocks[i])
+  for (const ethBlockPath of ethBlocks) {
+    const data = await fs.readFile(ethBlockPath)
     const multihash = await promisify(multihashing)(data, 'keccak-256')
 
     const cid = new CID(1, 'eth-block', multihash)

--- a/examples/traverse-ipld-graphs/eth.js
+++ b/examples/traverse-ipld-graphs/eth.js
@@ -1,17 +1,15 @@
 'use strict'
 
-const createNode = require('./create-node.js')
-const asyncEach = require('async/each')
+const createNode = require('./create-node')
 const path = require('path')
 const multihashing = require('multihashing-async')
 const Block = require('ipfs-block')
 const CID = require('cids')
-const fs = require('fs')
+const fs = require('fs').promises
+const { promisify } = require('util')
 
-createNode((err, ipfs) => {
-  if (err) {
-    throw err
-  }
+async function main () {
+  const ipfs = await createNode()
 
   console.log('\nStart of the example:')
 
@@ -20,34 +18,25 @@ createNode((err, ipfs) => {
     path.join(__dirname, '/eth-blocks/block_302517')
   ]
 
-  asyncEach(ethBlocks, (ethBlockPath, cb) => {
-    const data = fs.readFileSync(ethBlockPath)
+  for (let i = 0; i < ethBlocks.length; i++) {
+    const data = await fs.readFile(ethBlocks[i])
+    const multihash = await promisify(multihashing)(data, 'keccak-256')
 
-    multihashing(data, 'keccak-256', (err, multihash) => {
-      if (err) {
-        cb(err)
-      }
-      const cid = new CID(1, 'eth-block', multihash)
-      // console.log(cid.toBaseEncodedString())
+    const cid = new CID(1, 'eth-block', multihash)
+    // console.log(cid.toBaseEncodedString())
 
-      ipfs.block.put(new Block(data, cid), cb)
-    })
-  }, (err) => {
-    if (err) {
-      throw err
-    }
+    await ipfs.block.put(new Block(data, cid))
+  }
 
-    const block302516 = 'z43AaGEywSDX5PUJcrn5GfZmb6FjisJyR7uahhWPk456f7k7LDA'
-    const block302517 = 'z43AaGF42R2DXsU65bNnHRCypLPr9sg6D7CUws5raiqATVaB1jj'
+  const block302516 = 'z43AaGEywSDX5PUJcrn5GfZmb6FjisJyR7uahhWPk456f7k7LDA'
+  const block302517 = 'z43AaGF42R2DXsU65bNnHRCypLPr9sg6D7CUws5raiqATVaB1jj'
+  let res
 
-    function errOrLog (err, result) {
-      if (err) {
-        throw err
-      }
-      console.log(result.value.toString('hex'))
-    }
+  res = await ipfs.dag.get(block302516 + '/number')
+  console.log(res.value.toString('hex'))
 
-    ipfs.dag.get(block302516 + '/number', errOrLog)
-    ipfs.dag.get(block302517 + '/parent/number', errOrLog)
-  })
-})
+  res = await ipfs.dag.get(block302517 + '/parent/number')
+  console.log(res.value.toString('hex'))
+}
+
+main()

--- a/examples/traverse-ipld-graphs/get-path-accross-formats.js
+++ b/examples/traverse-ipld-graphs/get-path-accross-formats.js
@@ -1,62 +1,35 @@
 'use strict'
 
-const createNode = require('./create-node.js')
-const series = require('async/series')
+const createNode = require('./create-node')
 const dagPB = require('ipld-dag-pb')
 
-createNode((err, ipfs) => {
-  if (err) {
-    throw err
-  }
+async function main () {
+  const ipfs = await createNode()
 
   console.log('\nStart of the example:')
 
-  let cidPBNode
-  let cidCBORNode
+  const someData = Buffer.from('capoeira')
+  const pbNode = dagPB.DAGNode.create(someData)
 
-  series([
-    (cb) => {
-      const someData = Buffer.from('capoeira')
-      let node
+  const pbNodeCid = await ipfs.dag.put(pbNode, {
+    format: 'dag-pb',
+    hashAlg: 'sha2-256'
+  })
 
-      try {
-        node = dagPB.DAGNode.create(someData)
-      } catch (err) {
-        return cb(err)
-      }
+  const myData = {
+    name: 'David',
+    likes: ['js-ipfs', 'icecream', 'steak'],
+    hobbies: [pbNodeCid]
+  }
 
-      ipfs.dag.put(node, { format: 'dag-pb', hashAlg: 'sha2-256' }, (err, cid) => {
-        if (err) {
-          cb(err)
-        }
-        cidPBNode = cid
-        cb()
-      })
-    },
-    (cb) => {
-      const myData = {
-        name: 'David',
-        likes: ['js-ipfs', 'icecream', 'steak'],
-        hobbies: [cidPBNode]
-      }
+  const cborNodeCid = await ipfs.dag.put(myData, {
+    format: 'dag-cbor',
+    hashAlg: 'sha3-512'
+  })
 
-      ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha3-512' }, (err, cid) => {
-        if (err) {
-          throw err
-        }
+  const result = await ipfs.dag.get(cborNodeCid, 'hobbies/0/Data')
 
-        cidCBORNode = cid
-        cb()
-      })
-    },
-    (cb) => {
-      ipfs.dag.get(cidCBORNode, 'hobbies/0/Data', (err, result) => {
-        if (err) {
-          throw err
-        }
+  console.log(result.value.toString())
+}
 
-        console.log(result.value.toString())
-      })
-    }
-  ])
-})
+main()

--- a/examples/traverse-ipld-graphs/get-path.js
+++ b/examples/traverse-ipld-graphs/get-path.js
@@ -1,11 +1,9 @@
 'use strict'
 
-const createNode = require('./create-node.js')
+const createNode = require('./create-node')
 
-createNode((err, ipfs) => {
-  if (err) {
-    throw err
-  }
+async function main () {
+  const ipfs = await createNode()
 
   console.log('\nStart of the example:')
 
@@ -14,35 +12,17 @@ createNode((err, ipfs) => {
     likes: ['js-ipfs', 'icecream', 'steak']
   }
 
-  ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha2-256' }, (err, cid) => {
-    if (err) {
-      throw err
-    }
+  const cid = await ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha2-256' })
+  let result
 
-    ipfs.dag.get(cid, 'name', (err, result) => {
-      if (err) {
-        throw err
-      }
+  result = await ipfs.dag.get(cid, 'name')
+  console.log(result.value)
 
-      console.log(result.value, result.remainderPath)
-    })
+  result = await ipfs.dag.get(cid, 'likes')
+  console.log(result.value)
 
-    ipfs.dag.get(cid, 'likes', (err, result) => {
-      if (err) {
-        throw err
-      }
+  result = await ipfs.dag.get(cid + '/likes/0')
+  console.log(result.value)
+}
 
-      console.log(result.value)
-    })
-
-    const cidStr = cid.toBaseEncodedString()
-
-    ipfs.dag.get(cidStr + '/likes/0', (err, result) => {
-      if (err) {
-        throw err
-      }
-
-      console.log(result.value)
-    })
-  })
-})
+main()

--- a/examples/traverse-ipld-graphs/get.js
+++ b/examples/traverse-ipld-graphs/get.js
@@ -1,11 +1,9 @@
 'use strict'
 
-const createNode = require('./create-node.js')
+const createNode = require('./create-node')
 
-createNode((err, ipfs) => {
-  if (err) {
-    throw err
-  }
+async function main () {
+  const ipfs = await createNode()
 
   console.log('\nStart of the example:')
 
@@ -14,17 +12,10 @@ createNode((err, ipfs) => {
     likes: ['js-ipfs', 'icecream', 'steak']
   }
 
-  ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha2-256' }, (err, cid) => {
-    if (err) {
-      throw err
-    }
+  const cid = await ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha2-256' })
+  const result = await ipfs.dag.get(cid)
 
-    ipfs.dag.get(cid, (err, result) => {
-      if (err) {
-        throw err
-      }
+  console.log(JSON.stringify(result.value))
+}
 
-      console.log(JSON.stringify(result.value))
-    })
-  })
-})
+main()

--- a/examples/traverse-ipld-graphs/put.js
+++ b/examples/traverse-ipld-graphs/put.js
@@ -1,11 +1,9 @@
 'use strict'
 
-const createNode = require('./create-node.js')
+const createNode = require('./create-node')
 
-createNode((err, ipfs) => {
-  if (err) {
-    throw err
-  }
+async function main () {
+  const ipfs = await createNode()
 
   console.log('\nStart of the example:')
 
@@ -14,12 +12,10 @@ createNode((err, ipfs) => {
     likes: ['js-ipfs', 'icecream', 'steak']
   }
 
-  ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha2-256' }, (err, cid) => {
-    if (err) {
-      throw err
-    }
-    console.log(cid.toBaseEncodedString())
-    // should print:
-    //   bafyreigsccjrxlioppkkzv27se4gxh2aygbxfnsobkaxxqiuni544uk66a
-  })
-})
+  const cid = await ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha2-256' })
+  console.log(cid.toString())
+  // should print:
+  //   bafyreigsccjrxlioppkkzv27se4gxh2aygbxfnsobkaxxqiuni544uk66a
+}
+
+main()

--- a/examples/traverse-ipld-graphs/tree.js
+++ b/examples/traverse-ipld-graphs/tree.js
@@ -1,64 +1,35 @@
 'use strict'
 
-const createNode = require('./create-node.js')
-const series = require('async/series')
+const createNode = require('./create-node')
 const dagPB = require('ipld-dag-pb')
 
-createNode((err, ipfs) => {
-  if (err) {
-    throw err
-  }
+async function main () {
+  const ipfs = await createNode()
 
   console.log('\nStart of the example:')
 
-  let cidPBNode
-  let cidCBORNode
+  const someData = Buffer.from('capoeira')
+  const pbNode = dagPB.DAGNode.create(someData)
 
-  series([
-    (cb) => {
-      const someData = Buffer.from('capoeira')
-      let node
-
-      try {
-        node = dagPB.DAGNode.create(someData)
-      } catch (err) {
-        return cb(err)
-      }
-
-      ipfs.dag.put(node, { format: 'dag-pb', hashAlg: 'sha2-256' }, (err, cid) => {
-        if (err) {
-          return cb(err)
-        }
-        cidPBNode = cid
-        cb()
-      })
-    },
-    (cb) => {
-      const myData = {
-        name: 'David',
-        likes: ['js-ipfs', 'icecream', 'steak'],
-        hobbies: [{ '/': cidPBNode.toBaseEncodedString() }]
-      }
-
-      ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha3-512' }, (err, cid) => {
-        if (err) {
-          throw err
-        }
-
-        cidCBORNode = cid
-        cb()
-      })
-    },
-    (cb) => {
-      ipfs.dag.tree(cidCBORNode, { recursive: true }, (err, paths) => {
-        if (err) {
-          throw err
-        }
-
-        console.log(paths)
-      })
-    }
-  ], (err) => {
-    console.error('Error:', err)
+  const pbNodeCid = await ipfs.dag.put(pbNode, {
+    format: 'dag-pb',
+    hashAlg: 'sha2-256'
   })
-})
+
+  const myData = {
+    name: 'David',
+    likes: ['js-ipfs', 'icecream', 'steak'],
+    hobbies: [pbNodeCid]
+  }
+
+  const cborNodeCid = await ipfs.dag.put(myData, {
+    format: 'dag-cbor',
+    hashAlg: 'sha3-512'
+  })
+
+  const paths = await ipfs.dag.tree(cborNodeCid, { recursive: true })
+
+  console.log(paths)
+}
+
+main()


### PR DESCRIPTION
Since I was going through these anyway to ensure they work with [0.37](https://github.com/ipfs/js-ipfs/issues/2192) I've updated the examples to use the new [`IPFS.create` constructor](https://github.com/ipfs/js-ipfs#ipfs-constructor) and switched to using the promised API so that we onboard new users to using promises and minimise the disruption caused when https://github.com/ipfs/js-ipfs/issues/1670 bubbles up to here.