### PR TITLE
fix: value when latency unknown

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "execa": "^2.0.3",
     "form-data": "^2.5.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "~0.107.3",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#test/swarm-peers-latency-assert",
     "ipfsd-ctl": "^0.43.0",
     "libp2p-websocket-star": "~0.10.2",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "execa": "^2.0.3",
     "form-data": "^2.5.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#test/swarm-peers-latency-assert",
+    "interface-ipfs-core": "^0.109.1",
     "ipfsd-ctl": "^0.43.0",
     "libp2p-websocket-star": "~0.10.2",
     "ncp": "^2.0.0",

--- a/src/core/components/swarm.js
+++ b/src/core/components/swarm.js
@@ -34,7 +34,7 @@ module.exports = function swarm (self) {
           peer: peer.id
         }
         if (verbose) {
-          tupple.latency = 'unknown'
+          tupple.latency = 'n/a'
         }
 
         peers.push(tupple)

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -5,7 +5,7 @@ const tests = require('interface-ipfs-core')
 const CommonFactory = require('../utils/interface-common-factory')
 const isNode = require('detect-node')
 
-describe('interface-ipfs-core tests', function () {
+describe.only('interface-ipfs-core tests', function () {
   this.timeout(20 * 1000)
 
   const defaultCommonFactory = CommonFactory.create()
@@ -17,10 +17,20 @@ describe('interface-ipfs-core tests', function () {
   tests.bootstrap(defaultCommonFactory)
 
   tests.config(defaultCommonFactory, {
-    skip: [{
-      name: 'should set a number',
-      reason: 'Failing - needs to be fixed'
-    }]
+    skip: [
+      {
+        name: 'should set a number',
+        reason: 'Failing - needs to be fixed'
+      },
+      {
+        name: 'should output changes but not save them for dry run',
+        reason: 'TODO unskip when https://github.com/ipfs/js-ipfs/pull/2165 is merged'
+      },
+      {
+        name: 'should set a config profile',
+        reason: 'TODO unskip when https://github.com/ipfs/js-ipfs/pull/2165 is merged'
+      }
+    ]
   })
 
   tests.dag(defaultCommonFactory)
@@ -119,7 +129,14 @@ describe('interface-ipfs-core tests', function () {
     }
   }))
 
-  tests.object(defaultCommonFactory)
+  tests.object(defaultCommonFactory, {
+    skip: [
+      {
+        name: 'should respect timeout option',
+        reason: 'js-ipfs doesn\'t support timeout yet'
+      }
+    ]
+  })
 
   tests.pin(defaultCommonFactory)
 

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -5,7 +5,7 @@ const tests = require('interface-ipfs-core')
 const CommonFactory = require('../utils/interface-common-factory')
 const isNode = require('detect-node')
 
-describe.only('interface-ipfs-core tests', function () {
+describe('interface-ipfs-core tests', function () {
   this.timeout(20 * 1000)
 
   const defaultCommonFactory = CommonFactory.create()

--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -17,10 +17,20 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
   tests.bootstrap(defaultCommonFactory)
 
   tests.config(defaultCommonFactory, {
-    skip: [{
-      name: 'should set a number',
-      reason: 'Failing - needs to be fixed'
-    }]
+    skip: [
+      {
+        name: 'should set a number',
+        reason: 'Failing - needs to be fixed'
+      },
+      {
+        name: 'should output changes but not save them for dry run',
+        reason: 'TODO unskip when https://github.com/ipfs/js-ipfs/pull/2165 is merged'
+      },
+      {
+        name: 'should set a config profile',
+        reason: 'TODO unskip when https://github.com/ipfs/js-ipfs/pull/2165 is merged'
+      }
+    ]
   })
 
   tests.dag(defaultCommonFactory, {
@@ -122,7 +132,14 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
     }
   }))
 
-  tests.object(defaultCommonFactory)
+  tests.object(defaultCommonFactory, {
+    skip: [
+      {
+        name: 'should respect timeout option',
+        reason: 'js-ipfs doesn\'t support timeout yet'
+      }
+    ]
+  })
 
   tests.pin(defaultCommonFactory)
 


### PR DESCRIPTION
go-ipfs returns "n/a" when latency is unknown. This change restores compatibility.

Depends on:

* [x] https://github.com/ipfs/interface-js-ipfs-core/pull/511