### PR TITLE
chore: update comment about skipping the DHT test

### DIFF
--- a/test/cli/dht.js
+++ b/test/cli/dht.js
@@ -31,7 +31,7 @@ const daemonOpts = {
   initOptions: { bits: 512 }
 }
 
-// TODO: unskip when DHT is enabled in 0.36
+// TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
 describe.skip('dht', () => {
   const nodes = []
   let ipfsA

--- a/test/core/dht.spec.js
+++ b/test/core/dht.spec.js
@@ -12,7 +12,7 @@ const isNode = require('detect-node')
 const IPFSFactory = require('ipfsd-ctl')
 const IPFS = require('../../src/core')
 
-// TODO: unskip when DHT is enabled in 0.36
+// TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
 describe.skip('dht', () => {
   describe('enabled', () => {
     let ipfsd, ipfs

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -52,7 +52,7 @@ describe('interface-ipfs-core tests', function () {
     }
   }), {
     skip: {
-      reason: 'TODO: unskip when DHT is enabled in 0.36'
+      reason: 'TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994'
     }
   })
 

--- a/test/core/name.spec.js
+++ b/test/core/name.spec.js
@@ -88,7 +88,7 @@ describe('name', function () {
     })
   })
 
-  // TODO: unskip when DHT is enabled in 0.36
+  // TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
   describe.skip('work with dht', () => {
     let nodes
     let nodeA

--- a/test/core/ping.spec.js
+++ b/test/core/ping.spec.js
@@ -195,7 +195,7 @@ describe('ping', function () {
     })
   })
 
-  // TODO: unskip when DHT enabled in 0.36
+  // TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
   describe.skip('DHT enabled', function () {
     // Our bootstrap process will run 3 IPFS daemons where
     // A ----> B ----> C

--- a/test/http-api/inject/dht.js
+++ b/test/http-api/inject/dht.js
@@ -8,7 +8,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 module.exports = (http) => {
-  // TODO: unskip when DHT is enabled in 0.36
+  // TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
   describe.skip('/dht', () => {
     let api
 

--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -61,7 +61,7 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
     }
   }), {
     skip: {
-      reason: 'TODO: unskip when DHT is enabled in 0.36'
+      reason: 'TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994'
     }
   })
 


### PR DESCRIPTION
To find all of those comments run:

```console
$ grep DHT test -R |grep TODO
test/cli/dht.js:// TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
test/core/ping.spec.js:  // TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
test/core/interface.spec.js:      reason: 'TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994'
test/core/dht.spec.js:// TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
test/core/name.spec.js:  // TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
test/http-api/inject/dht.js:  // TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
test/http-api/interface.js:      reason: 'TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994'
```