### PR TITLE
feat: resolution of .eth names via .eth.link

### DIFF
--- a/src/core/components/dns.js
+++ b/src/core/components/dns.js
@@ -4,6 +4,15 @@
 const dns = require('../runtime/dns-nodejs')
 const promisify = require('promisify-es6')
 
+function fqdnFixups (domain) {
+  // Allow resolution of .eth names via .eth.link
+  // More context at the go-ipfs counterpart: https://github.com/ipfs/go-ipfs/pull/6448
+  if (domain.endsWith('.eth')) {
+    domain = domain.replace(/.eth$/, '.eth.link')
+  }
+  return domain
+}
+
 module.exports = () => {
   return promisify((domain, opts, callback) => {
     if (typeof domain !== 'string') {
@@ -16,6 +25,7 @@ module.exports = () => {
     }
 
     opts = opts || {}
+    domain = fqdnFixups(domain)
 
     dns(domain, opts, callback)
   })

--- a/test/http-api/inject/dns.js
+++ b/test/http-api/inject/dns.js
@@ -11,10 +11,19 @@ module.exports = (http) => {
       api = http.api._httpApi._apiServers[0]
     })
 
-    it('resolve ipfs.io dns', async () => {
+    it('resolve ipfs.io DNS', async () => {
       const res = await api.inject({
         method: 'GET',
         url: '/api/v0/dns?arg=ipfs.io'
+      })
+
+      expect(res.result).to.have.property('Path')
+    })
+
+    it('resolve ipfs.enstest.eth ENS', async () => {
+      const res = await api.inject({
+        method: 'GET',
+        url: '/api/v0/dns?arg=ipfs.enstest.eth'
       })
 
       expect(res.result).to.have.property('Path')


### PR DESCRIPTION
> This is js-ipfs version of a change that already landed in go-ipfs: https://github.com/ipfs/go-ipfs/pull/6448


The `.eth` TLD is not recognised by mainstream DNS,
however ENS provides DNS compatibility service at `.eth.link`

This change enables resolution of ENS names ending with `.eth`
on systems that  have regular DNS set up:

```console
$ jsipfs dns ipfs.enstest.eth
/ipfs/QmRAQB6YaCyidP37UdDnjFY5vQuiBrcqdyoW1CuDgwxkD4

$ jsipfs name resolve /ipns/ipfs.enstest.eth.link
/ipfs/QmRAQB6YaCyidP37UdDnjFY5vQuiBrcqdyoW1CuDgwxkD4
```

cc @mcdee, @parkan