### PR TITLE
fix: preload addreses with trailing slash (new multiaddr-to-uri)

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "mime-types": "^2.1.21",
     "mkdirp": "~0.5.1",
     "multiaddr": "^6.1.0",
-    "multiaddr-to-uri": "^4.0.1",
+    "multiaddr-to-uri": "^5.0.0",
     "multibase": "~0.6.0",
     "multicodec": "~0.5.1",
     "multihashes": "~0.4.14",

--- a/src/core/preload.js
+++ b/src/core/preload.js
@@ -32,7 +32,7 @@ module.exports = self => {
 
   let stopped = true
   let requests = []
-  const apiUris = options.addresses.map(apiAddrToUri)
+  const apiUris = options.addresses.map(toUri)
 
   const api = (cid, callback) => {
     callback = callback || noop
@@ -83,11 +83,4 @@ module.exports = self => {
   }
 
   return api
-}
-
-function apiAddrToUri (addr) {
-  if (!(addr.endsWith('http') || addr.endsWith('https'))) {
-    addr = addr + '/http'
-  }
-  return toUri(addr)
 }


### PR DESCRIPTION
This PR switches to latest `multiaddr-to-uri` and removes code that is no longer needed.

Closes #2333 as a side-effect :ok_hand: 

Note: `multiaddr-to-uri` assumes http by default now, which should make it easier and more robust to configure: https://github.com/multiformats/js-multiaddr-to-uri/pull/7
