### PR TITLE
test: merge util factory spawn options

### DIFF
--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -5,12 +5,13 @@ const each = require('async/each')
 const IPFSFactory = require('ipfsd-ctl')
 const ipfsClient = require('ipfs-http-client')
 const IPFS = require('../../src')
+const mergeOptions = require('merge-options')
 
 function createFactory (options) {
   options = options || {}
 
   options.factoryOptions = options.factoryOptions || { type: 'proc', exec: IPFS }
-  options.spawnOptions = options.spawnOptions || {
+  options.spawnOptions = mergeOptions({
     initOptions: { bits: 512 },
     config: {
       Bootstrap: [],
@@ -24,7 +25,7 @@ function createFactory (options) {
       }
     },
     preload: { enabled: false }
-  }
+  }, options.spawnOptions)
 
   if (options.factoryOptions.type !== 'proc') {
     options.factoryOptions.IpfsClient = options.factoryOptions.IpfsClient || ipfsClient


### PR DESCRIPTION
Previously the spawnOptions defaults were not being included
if a test specified them. This would result in some tests dialing
out to the Bootstrap nodes, or using mdns when not desired. This
resolves that by using 'merge-options' to include defaults.