### PR TITLE
chore: show stack traces on uncaught errors

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -5,7 +5,7 @@
 
 // Handle any uncaught errors
 process.once('uncaughtException', (err, origin) => {
-  if (origin === 'uncaughtException') {
+  if (!origin || origin === 'uncaughtException') {
     console.error(err)
     process.exit(1)
   }


### PR DESCRIPTION
`origin` can be `undefined` as well as [`uncaughtException` or `unhandledRejection`](https://nodejs.org/api/process.html#process_event_uncaughtexception)

It'd be nice to see the stack traces when that's the case.

This can happen when you've done silly stuff like tried to `require` something that doesn't exist, etc.