### PR TITLE
chore: skip ENS test if failing

### DIFF
--- a/test/http-api/inject/dns.js
+++ b/test/http-api/inject/dns.js
@@ -20,11 +20,17 @@ module.exports = (http) => {
       expect(res.result).to.have.property('Path')
     })
 
-    it('resolve ipfs.enstest.eth ENS', async () => {
+    it('resolve ipfs.enstest.eth ENS', async function () {
       const res = await api.inject({
         method: 'GET',
         url: '/api/v0/dns?arg=ipfs.enstest.eth'
       })
+
+      // TODO: eth.link domains have no SLA yet and are liable to be down...
+      // Remove skip when reliable!
+      if (res.statusCode === 500) {
+        return this.skip()
+      }
 
       expect(res.result).to.have.property('Path')
     })


### PR DESCRIPTION
From IRC:
> lidel: Moving it to permanent infrastructure, thats why its down atm.

Lets skip this (on failure) until service level improves.