### PR TITLE
chore: unskip dns tests

### DIFF
--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -102,18 +102,6 @@ describe('interface-ipfs-core tests', function () {
       {
         name: 'should resolve IPNS link recursively',
         reason: 'TODO: IPNS resolve not yet implemented https://github.com/ipfs/js-ipfs/issues/1918'
-      },
-      {
-        name: 'should non-recursively resolve ipfs.io',
-        reasone: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should recursively resolve ipfs.io',
-        reasone: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should resolve subdomain docs.ipfs.io',
-        reasone: 'TODO: gateway issue on dns. To be enabled on a new PR'
       }
     ]
   })
@@ -122,42 +110,7 @@ describe('interface-ipfs-core tests', function () {
     spawnOptions: {
       args: ['--pass ipfs-is-awesome-software', '--offline']
     }
-  }), {
-    skip: [
-      {
-        name: 'should resolve /ipns/ipfs.io',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should resolve /ipns/ipfs.io recursive === false',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should resolve /ipns/ipfs.io recursive === true',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should resolve /ipns/ipfs.io with remainder',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should resolve /ipns/ipfs.io with remainder recursive === false',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should resolve /ipns/ipfs.io with remainder  recursive === true',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should fail to resolve /ipns/ipfs.a',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      },
-      {
-        name: 'should resolve ipns path with hamt-shard recursive === true',
-        reasones: 'TODO: gateway issue on dns. To be enabled on a new PR'
-      }
-    ]
-  })
+  }))
 
   tests.namePubsub(CommonFactory.create({
     spawnOptions: {


### PR DESCRIPTION
Due to an issue with the gateways, dns tests were failing and were skipped on [ipfs/js-ipfs#2298](https://github.com/ipfs/js-ipfs/pull/2298).

This PR intends to unskip them once the gateways are working as expected

closes #2416