### PR TITLE
fix(tests): remove Math.random from  tests

### DIFF
--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -335,7 +335,7 @@ describe('files', () => runOnAndOff((thing) => {
   it('add --only-hash does not add a file to the datastore', function () {
     this.timeout(30 * 1000)
     this.slow(10 * 1000)
-    const content = String(Math.random())
+    const content = hat()
     const filepath = path.join(os.tmpdir(), `${content}.txt`)
     fs.writeFileSync(filepath, content)
 
@@ -356,7 +356,7 @@ describe('files', () => runOnAndOff((thing) => {
   it('add pins by default', function () {
     this.timeout(10 * 1000)
     const filePath = path.join(os.tmpdir(), hat())
-    const content = String(Math.random())
+    const content = hat()
     fs.writeFileSync(filePath, content)
 
     return ipfs(`add -Q ${filePath}`)
@@ -371,7 +371,7 @@ describe('files', () => runOnAndOff((thing) => {
   it('add does not pin with --pin=false', function () {
     this.timeout(20 * 1000)
     const filePath = path.join(os.tmpdir(), hat())
-    const content = String(Math.random())
+    const content = hat()
     fs.writeFileSync(filePath, content)
 
     return ipfs(`add -Q --pin=false ${filePath}`)

--- a/test/cli/object.js
+++ b/test/cli/object.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const hat = require('hat')
 const expect = require('chai').expect
 const runOnAndOff = require('../utils/on-and-off')
 const UnixFs = require('ipfs-unixfs')
@@ -139,7 +140,7 @@ describe('object', () => runOnAndOff((thing) => {
 
     // has to be big enough to span several DAGNodes
     const data = crypto.randomBytes(1024 * 300)
-    const file = path.join(os.tmpdir(), `file-${Math.random()}.txt`)
+    const file = path.join(os.tmpdir(), `file-${hat()}.txt`)
 
     fs.writeFileSync(file, data)
 

--- a/test/core/bitswap.spec.js
+++ b/test/core/bitswap.spec.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const hat = require('hat')
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
@@ -22,7 +23,7 @@ const callbackify = require('callbackify')
 const IPFS = require('../../src/core')
 
 function makeBlock (callback) {
-  const d = Buffer.from(`IPFS is awesome ${Math.random()}`)
+  const d = Buffer.from(`IPFS is awesome ${hat()}`)
 
   multihashing(d, 'sha2-256', (err, multihash) => {
     if (err) {
@@ -214,7 +215,7 @@ describe('bitswap', function () {
     it('2 peers', (done) => {
       // TODO make this test more interesting (10Mb file)
       // TODO remove randomness from the test
-      const file = Buffer.from(`I love IPFS <3 ${Math.random()}`)
+      const file = Buffer.from(`I love IPFS <3 ${hat()}`)
 
       waterfall([
         // 0. Start node

--- a/test/core/bitswap.spec.js
+++ b/test/core/bitswap.spec.js
@@ -139,7 +139,7 @@ describe('bitswap', function () {
 
   describe('transfer a block between', () => {
     it('2 peers', function (done) {
-      this.timeout(80 * 1000)
+      this.timeout(160 * 1000)
 
       let remoteNode
       let block
@@ -163,7 +163,7 @@ describe('bitswap', function () {
     })
 
     it('3 peers', function (done) {
-      this.timeout(80 * 1000)
+      this.timeout(160 * 1000)
 
       let blocks
       const remoteNodes = []

--- a/test/http-api/files.js
+++ b/test/http-api/files.js
@@ -2,6 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
+const hat = require('hat')
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const DaemonFactory = require('ipfsd-ctl')
@@ -34,7 +35,7 @@ describe('.files', () => {
 
   describe('.add', function () {
     it('performs a speculative add, --only-hash', () => {
-      const content = String(Math.random())
+      const content = hat()
 
       return ipfs.add(Buffer.from(content), { onlyHash: true })
         .then(files => {
@@ -60,7 +61,7 @@ describe('.files', () => {
     })
 
     it('lists files', () => {
-      const fileName = `single-file-${Math.random()}.txt`
+      const fileName = `single-file-${hat()}.txt`
 
       return ipfs.files.write(`/${fileName}`, Buffer.from('Hello world'), {
         create: true
@@ -73,8 +74,8 @@ describe('.files', () => {
     })
 
     it('lists files in directories', () => {
-      const dirName = `dir-${Math.random()}`
-      const fileName = `file-in-dir-${Math.random()}.txt`
+      const dirName = `dir-${hat()}`
+      const fileName = `file-in-dir-${hat()}.txt`
 
       return ipfs.files.write(`/${dirName}/${fileName}`, Buffer.from('Hello world'), {
         create: true,
@@ -90,8 +91,8 @@ describe('.files', () => {
 
   describe('.cp', function () {
     it('copies a file', () => {
-      const source = `source-file-${Math.random()}.txt`
-      const destination = `destination-file-${Math.random()}.txt`
+      const source = `source-file-${hat()}.txt`
+      const destination = `destination-file-${hat()}.txt`
 
       return ipfs.files.write(`/${source}`, Buffer.from('Hello world'), {
         create: true
@@ -116,8 +117,8 @@ describe('.files', () => {
     })
 
     it('copies a directory', () => {
-      const source = `source-dir-${Math.random()}`
-      const destination = `destination-dir-${Math.random()}`
+      const source = `source-dir-${hat()}`
+      const destination = `destination-dir-${hat()}`
 
       return ipfs.files.mkdir(`/${source}`)
         .then(() => ipfs.files.cp(`/${source}`, `/${destination}`))
@@ -140,8 +141,8 @@ describe('.files', () => {
     })
 
     it('copies a file with array args', () => {
-      const source = `source-file-${Math.random()}.txt`
-      const destination = `destination-file-${Math.random()}.txt`
+      const source = `source-file-${hat()}.txt`
+      const destination = `destination-file-${hat()}.txt`
 
       return ipfs.files.write(`/${source}`, Buffer.from('Hello world'), {
         create: true
@@ -166,8 +167,8 @@ describe('.files', () => {
     })
 
     it('copies a directory with array args', () => {
-      const source = `source-dir-${Math.random()}`
-      const destination = `destination-dir-${Math.random()}`
+      const source = `source-dir-${hat()}`
+      const destination = `destination-dir-${hat()}`
 
       return ipfs.files.mkdir(`/${source}`)
         .then(() => ipfs.files.cp([`/${source}`, `/${destination}`]))
@@ -192,7 +193,7 @@ describe('.files', () => {
 
   describe('.mkdir', function () {
     it('makes a directory', () => {
-      const directory = `directory-${Math.random()}`
+      const directory = `directory-${hat()}`
 
       return ipfs.files.mkdir(`/${directory}`)
         .then(() => ipfs.files.ls(`/`, {
@@ -210,8 +211,8 @@ describe('.files', () => {
 
   describe('.mv', function () {
     it('moves a file', () => {
-      const source = `source-file-${Math.random()}.txt`
-      const destination = `destination-file-${Math.random()}.txt`
+      const source = `source-file-${hat()}.txt`
+      const destination = `destination-file-${hat()}.txt`
 
       return ipfs.files.write(`/${source}`, Buffer.from('Hello world'), {
         create: true
@@ -234,8 +235,8 @@ describe('.files', () => {
     })
 
     it('moves a directory', () => {
-      const source = `source-dir-${Math.random()}`
-      const destination = `destination-dir-${Math.random()}`
+      const source = `source-dir-${hat()}`
+      const destination = `destination-dir-${hat()}`
 
       return ipfs.files.mkdir(`/${source}`)
         .then(() => ipfs.files.mv(`/${source}`, `/${destination}`))
@@ -258,8 +259,8 @@ describe('.files', () => {
     })
 
     it('moves a file with array args', () => {
-      const source = `source-file-${Math.random()}.txt`
-      const destination = `destination-file-${Math.random()}.txt`
+      const source = `source-file-${hat()}.txt`
+      const destination = `destination-file-${hat()}.txt`
 
       return ipfs.files.write(`/${source}`, Buffer.from('Hello world'), {
         create: true
@@ -282,8 +283,8 @@ describe('.files', () => {
     })
 
     it('moves a directory with array args', () => {
-      const source = `source-dir-${Math.random()}`
-      const destination = `destination-dir-${Math.random()}`
+      const source = `source-dir-${hat()}`
+      const destination = `destination-dir-${hat()}`
 
       return ipfs.files.mkdir(`/${source}`)
         .then(() => ipfs.files.mv([`/${source}`, `/${destination}`]))
@@ -308,7 +309,7 @@ describe('.files', () => {
 
   describe('.read', function () {
     it('reads a file', () => {
-      const fileName = `single-file-${Math.random()}.txt`
+      const fileName = `single-file-${hat()}.txt`
       const content = Buffer.from('Hello world')
 
       return ipfs.files.write(`/${fileName}`, content, {
@@ -323,7 +324,7 @@ describe('.files', () => {
 
   describe('.rm', function () {
     it('removes a file', () => {
-      const fileName = `single-file-${Math.random()}.txt`
+      const fileName = `single-file-${hat()}.txt`
 
       return ipfs.files.write(`/${fileName}`, Buffer.from('Hello world'), {
         create: true
@@ -340,8 +341,8 @@ describe('.files', () => {
     })
 
     it('removes a directory', () => {
-      const dirName = `dir-${Math.random()}`
-      const fileName = `file-in-dir-${Math.random()}.txt`
+      const dirName = `dir-${hat()}`
+      const fileName = `file-in-dir-${hat()}.txt`
 
       return ipfs.files.write(`/${dirName}/${fileName}`, Buffer.from('Hello world'), {
         create: true,
@@ -363,7 +364,7 @@ describe('.files', () => {
 
   describe('.stat', function () {
     it('stats a file', () => {
-      const fileName = `single-file-${Math.random()}.txt`
+      const fileName = `single-file-${hat()}.txt`
 
       return ipfs.files.write(`/${fileName}`, Buffer.from('Hello world'), {
         create: true
@@ -384,7 +385,7 @@ describe('.files', () => {
     })
 
     it('stats a directory', () => {
-      const dirName = `dir-${Math.random()}`
+      const dirName = `dir-${hat()}`
 
       return ipfs.files.mkdir(`/${dirName}`)
         .then(() => ipfs.files.stat(`/${dirName}`))

--- a/test/http-api/inject/dag.js
+++ b/test/http-api/inject/dag.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const hat = require('hat')
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
@@ -260,7 +261,7 @@ module.exports = (http) => {
       it('pins a node after adding', async () => {
         const node = {
           foo: 'bar',
-          disambiguator: Math.random()
+          disambiguator: hat()
         }
 
         const res = await api.inject({
@@ -280,7 +281,7 @@ module.exports = (http) => {
       it('does not pin a node after adding', async () => {
         const node = {
           foo: 'bar',
-          disambiguator: Math.random()
+          disambiguator: hat()
         }
 
         const res = await api.inject({


### PR DESCRIPTION
This PR:

- replaces Math.random() with [hat()](https://www.npmjs.com/package/hat)
- increases timeout of bitswap tests that fail often

### Motivation

CI often fails in tests that use Math.random.
I suspect Math.random is not random enough on some platforms.
Let's see if this PR pass without a problem