### PR TITLE
chore: run interop tests as part of the build

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -10,7 +10,7 @@ const preloadNode = MockPreloadNode.createNode()
 const echoServer = EchoServer.createServer()
 
 module.exports = {
-  bundlesize: { maxSize: '692kB' },
+  bundlesize: { maxSize: '696kB' },
   webpack: {
     resolve: {
       mainFields: ['browser', 'main'],

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache: false
 stages:
   - check
   - test
-  - cov
+  - tag
 
 node_js:
   - '10'
@@ -18,8 +18,14 @@ os:
   - osx
   - windows
 
+env:
+  # This stops Windows builds from hanging
+  # https://travis-ci.community/t/timeout-after-build-finished-and-succeeded/1336
+  - YARN_GPG=no
+
 script: npx nyc -s npx aegir test -t node --timeout 10000 --bail
-after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+after_success:
+  - npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
 jobs:
   include:
@@ -54,6 +60,17 @@ jobs:
       name: electron-renderer
       script:
         - xvfb-run npx aegir test -t electron-renderer -- --bail --timeout 10000
+
+    - stage: test
+      name: interop
+      script:
+        - npm run test:interop
+
+    - stage: tag
+      if: branch = master AND type = push AND fork = false
+      name: update-last-successful-build
+      script:
+        - npx aegir update-last-successful-build
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:node:cli": "aegir test -t node -f test/cli/index.js",
     "test:node:interface": "aegir test -t node -f test/core/interface.spec.js",
     "test:bootstrapers": "IPFS_TEST=bootstrapers aegir test -t browser -f test/bootstrapers.js",
+    "test:interop": "IPFS_JS_EXEC=$PWD/src/cli/bin.js ipfs-interop",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
     "benchmark": "echo \"Error: no benchmarks yet\" && exit 1",
     "benchmark:node": "echo \"Error: no benchmarks yet\" && exit 1",
@@ -141,7 +142,7 @@
     "libp2p-websocket-star-multi": "~0.4.3",
     "libp2p-websockets": "~0.12.3",
     "lodash": "^4.17.15",
-    "mafmt": "^6.0.2",
+    "mafmt": "^6.0.10",
     "merge-options": "^1.0.1",
     "mime-types": "^2.1.21",
     "mkdirp": "~0.5.1",
@@ -186,7 +187,7 @@
     "yargs-promise": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^20.0.0",
+    "aegir": "^20.1.0",
     "base64url": "^3.0.1",
     "chai": "^4.2.0",
     "clear-module": "^4.0.0",
@@ -198,6 +199,7 @@
     "form-data": "^2.5.1",
     "hat": "0.0.3",
     "interface-ipfs-core": "^0.113.0",
+    "ipfs-interop": "~0.1.0",
     "ipfsd-ctl": "~0.46.0",
     "libp2p-websocket-star": "~0.10.2",
     "ncp": "^2.0.0",

--- a/src/core/components/libp2p.js
+++ b/src/core/components/libp2p.js
@@ -61,7 +61,11 @@ function defaultBundle ({ datastore, peerInfo, peerBook, options, config }) {
   }
 
   const getPubsubRouter = () => {
-    const router = get(config, 'Pubsub.Router', 'gossipsub')
+    let router = get(config, 'Pubsub.Router', 'gossipsub')
+
+    if (!router) {
+      router = 'gossipsub'
+    }
 
     if (!PubsubRouters[router]) {
       throw errCode(new Error(`Router unavailable. Configure libp2p.modules.pubsub to use the ${router} router.`), 'ERR_NOT_SUPPORTED')


### PR DESCRIPTION
This will need updating to only run on master & add `npx aegir update-last-successful-build` from https://github.com/ipfs/aegir/pull/419 as a post-build step