### PR TITLE
chore: only run build on PRs, master and releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ language: node_js
 # cache: npm
 cache: false
 
+branches:
+  only:
+  - master
+  - /^release\/.*$/
+
 stages:
   - check
   - test


### PR DESCRIPTION
Currently Travis is set to build PRs and all branches. We need to build PRs to test code from forked repos and we also want CI to run on changes to master & `release/*` branches.

However if we push a branch to ipfs/js-ipfs and create a PR it gets built twice - once for the PR and once for the branch, as you can see in the checks section of PRs:

![image](https://user-images.githubusercontent.com/665810/65672673-53817580-e041-11e9-9e5e-c96a5100e20e.png)

If I've read [the docs](https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches) correctly, the change in this PR should only run the build on master and release branches - it should still run on PRs.