### PR TITLE
refactor: reuse error codes from interface-datastore

### DIFF
--- a/src/core/components/files-regular/refs-pull-stream.js
+++ b/src/core/components/files-regular/refs-pull-stream.js
@@ -10,6 +10,9 @@ const { DAGNode } = require('ipld-dag-pb')
 const { normalizePath } = require('./utils')
 const { Format } = require('./refs')
 
+const { Errors } = require('interface-datastore')
+const ERR_NOT_FOUND = Errors.notFoundError().code
+
 module.exports = function (self) {
   return function (ipfsPath, options) {
     options = options || {}
@@ -126,7 +129,7 @@ function objectStream (ipfs, rootCid, maxDepth, isUnique) {
     // Get this object's links
     getLinks(ipfs, node.cid, (err, links) => {
       if (err) {
-        if (err.code === 'ERR_NOT_FOUND') {
+        if (err.code === ERR_NOT_FOUND) {
           err.message = `Could not find object with CID: ${node.cid}`
         }
         return deferred.resolve(pull.error(err))

--- a/src/core/components/pin/gc.js
+++ b/src/core/components/pin/gc.js
@@ -10,6 +10,9 @@ const { default: Queue } = require('p-queue')
 // https://github.com/ipfs/js-ipfs-mfs/pull/58
 const { MFS_ROOT_KEY } = require('ipfs-mfs/src/core/utils/constants')
 
+const { Errors } = require('interface-datastore')
+const ERR_NOT_FOUND = Errors.notFoundError().code
+
 // Limit on the number of parallel block remove operations
 const BLOCK_RM_CONCURRENCY = 256
 
@@ -71,7 +74,7 @@ async function createMarkedSet (ipfs) {
       .then(mh => getDescendants(ipfs, new CID(mh)))
       .then(addPins)
       .catch(err => {
-        if (err.code === 'ERR_NOT_FOUND') {
+        if (err.code === ERR_NOT_FOUND) {
           log('No blocks in MFS')
           return []
         }

--- a/src/core/components/pin/pin-manager.js
+++ b/src/core/components/pin/pin-manager.js
@@ -13,6 +13,9 @@ const { cidToString } = require('../../../utils/cid')
 
 const createPinSet = require('./pin-set')
 
+const { Errors } = require('interface-datastore')
+const ERR_NOT_FOUND = Errors.notFoundError().code
+
 // arbitrary limit to the number of concurrent dag operations
 const WALK_DAG_CONCURRENCY_LIMIT = 300
 const IS_PINNED_WITH_TYPE_CONCURRENCY_LIMIT = 300
@@ -241,7 +244,7 @@ class PinManager {
     try {
       mh = await this.repo.datastore.get(PIN_DS_KEY)
     } catch (err) {
-      if (err.code === 'ERR_NOT_FOUND') {
+      if (err.code === ERR_NOT_FOUND) {
         this.log('No pinned blocks')
 
         return []

--- a/src/core/ipns/publisher.js
+++ b/src/core/ipns/publisher.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const PeerId = require('peer-id')
-const { Key } = require('interface-datastore')
+const { Key, Errors } = require('interface-datastore')
 const errcode = require('err-code')
 const promisify = require('promisify-es6')
 const debug = require('debug')
@@ -10,6 +10,7 @@ log.error = debug('ipfs:ipns:publisher:error')
 
 const ipns = require('ipns')
 
+const ERR_NOT_FOUND = Errors.notFoundError().code
 const defaultRecordLifetime = 60 * 60 * 1000
 
 // IpnsPublisher is capable of publishing and resolving names to the IPFS routing system.
@@ -142,7 +143,7 @@ class IpnsPublisher {
       // unmarshal data
       return this._unmarshalData(dsVal)
     } catch (err) {
-      if (err.code !== 'ERR_NOT_FOUND') {
+      if (err.code !== ERR_NOT_FOUND) {
         const errMsg = `unexpected error getting the ipns record ${peerId.id} from datastore`
         log.error(errMsg)
 
@@ -193,7 +194,7 @@ class IpnsPublisher {
     try {
       record = await this._getPublished(peerId, getPublishedOptions)
     } catch (err) {
-      if (err.code !== 'ERR_NOT_FOUND') {
+      if (err.code !== ERR_NOT_FOUND) {
         const errMsg = `unexpected error when determining the last published IPNS record for ${peerId.id}`
         log.error(errMsg)
 

--- a/src/core/ipns/resolver.js
+++ b/src/core/ipns/resolver.js
@@ -9,6 +9,9 @@ const debug = require('debug')
 const log = debug('ipfs:ipns:resolver')
 log.error = debug('ipfs:ipns:resolver:error')
 
+const { Errors } = require('interface-datastore')
+const ERR_NOT_FOUND = Errors.notFoundError().code
+
 const defaultMaximumRecursiveDepth = 32
 
 class IpnsResolver {
@@ -80,7 +83,7 @@ class IpnsResolver {
     } catch (err) {
       log.error(err)
 
-      if (err.code === 'ERR_NOT_FOUND') {
+      if (err.code === ERR_NOT_FOUND) {
         throw errcode(new Error(`record requested for ${name} was not found in the network`), 'ERR_NO_RECORD_FOUND')
       }
 
@@ -109,7 +112,7 @@ class IpnsResolver {
     } catch (err) {
       log.error(err)
 
-      if (err.code === 'ERR_NOT_FOUND') {
+      if (err.code === ERR_NOT_FOUND) {
         throw errcode(new Error(`public key requested for ${name} was not found in the network`), 'ERR_NO_RECORD_FOUND')
       }
 

--- a/test/core/gc.spec.js
+++ b/test/core/gc.spec.js
@@ -11,6 +11,7 @@ const IPFSFactory = require('ipfsd-ctl')
 const pEvent = require('p-event')
 const env = require('ipfs-utils/src/env')
 const IPFS = require('../../src/core')
+const { Errors } = require('interface-datastore')
 
 // We need to detect when a readLock or writeLock is requested for the tests
 // so we override the Mutex class to emit an event
@@ -195,7 +196,7 @@ describe('gc', function () {
       try {
         await rm2
       } catch (err) {
-        expect(err.code).eql('ERR_DB_DELETE_FAILED')
+        expect(err.code).eql(Errors.dbDeleteFailedError().code)
       }
 
       // Confirm second block has been removed

--- a/test/core/name.spec.js
+++ b/test/core/name.spec.js
@@ -17,7 +17,7 @@ const ipnsPath = require('../../src/core/ipns/path')
 const ipnsRouting = require('../../src/core/ipns/routing/config')
 const OfflineDatastore = require('../../src/core/ipns/routing/offline-datastore')
 const PubsubDatastore = require('../../src/core/ipns/routing/pubsub-datastore')
-const { Key } = require('interface-datastore')
+const { Key, Errors } = require('interface-datastore')
 
 const DaemonFactory = require('ipfsd-ctl')
 const df = DaemonFactory.create({
@@ -312,7 +312,7 @@ describe('name', function () {
     })
 
     it('should publish and then fail to resolve if does not find the record', async function () {
-      const stub = sinon.stub(node._ipns.resolver._routing, 'get').callsArgWith(1, { code: 'ERR_NOT_FOUND' })
+      const stub = sinon.stub(node._ipns.resolver._routing, 'get').callsArgWith(1, { code: Errors.notFoundError().code })
 
       await node.name.publish(ipfsRef, { resolve: false })
 


### PR DESCRIPTION
This PR replaces hardcoded strings with actual error codes from `interface-datastore` (such as `Errors.notFoundError`) making it much safer going forward.

@hugomrdias the new datastore for browser should return code from `interface-datastore` too, eg:

```js
const {  Errors } = require('interface-datastore')

if (!value) {
  return Errors.notFoundError()
}
```