### PR TITLE
fix: only try to get ipfs if argv is present

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -49,7 +49,7 @@ cli
     }
   })
   .catch(({ error, argv }) => {
-    getIpfs = argv.getIpfs
+    getIpfs = argv && argv.getIpfs
     if (error.message) {
       print(error.message)
       debug(error)


### PR DESCRIPTION
Sometimes you've done something silly like required a module that isn't installed or called a method that isn't a property of an object in which case `argv` won't have a value, causing an unrelated error to appear.

This PR just makes sure `argv` has a value before trying to access `argv.getIpfs`