### PR TITLE
fix: trailing slash in ls crash

### DIFF
--- a/src/cli/commands/ls.js
+++ b/src/cli/commands/ls.js
@@ -48,11 +48,7 @@ module.exports = {
       const multihashWidth = Math.max.apply(null, links.map((file) => file.hash.length))
       const sizeWidth = Math.max.apply(null, links.map((file) => String(file.size).length))
 
-      let pathParts = key.split('/')
-
-      if (key.startsWith('/ipfs/')) {
-        pathParts = pathParts.slice(2)
-      }
+      let pathParts = key.replace(/\/ipfs\/|\/$/g, '').split('/')
 
       links.forEach(link => {
         const fileName = link.type === 'dir' ? `${link.name || ''}/` : link.name

--- a/test/cli/ls.js
+++ b/test/cli/ls.js
@@ -40,7 +40,7 @@ describe('ls', () => runOnAndOff((thing) => {
 
   it('adds a header, -v', async function () {
     this.timeout(20 * 1000)
-    const out = await ipfs('ls /ipfs/Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z -v')
+    const out = await ipfs('ls /ipfs/Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z/ -v')
     expect(out).to.eql(
       'Hash                                           Size Name\n' +
       'QmamKEPmEH9RUsqRQsfNf5evZQDQPYL9KXg1ADeT7mkHkT -    blocks/\n' +


### PR DESCRIPTION
When executing command like "jsipfs ls /ipfs/.../" result was a crash.
This patch introduces removing of traling slash