### PR TITLE
fix: choose import strategy in ipfs.add

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -113,7 +113,7 @@ module.exports = {
     argv.resolve((async () => {
       const ipfs = await argv.getIpfs()
       const options = {
-        strategy: argv.trickle ? 'trickle' : 'balanced',
+        trickle: argv.trickle,
         shardSplitThreshold: argv.enableShardingExperiment
           ? argv.shardSplitThreshold
           : Infinity,

--- a/src/core/components/files-regular/add-async-iterator.js
+++ b/src/core/components/files-regular/add-async-iterator.js
@@ -21,6 +21,7 @@ module.exports = function (self) {
         ? 1000
         : Infinity
     }, options, {
+      strategy: 'balanced',
       chunker: chunkerOptions.chunker,
       chunkerOptions: chunkerOptions.chunkerOptions
     })
@@ -28,6 +29,11 @@ module.exports = function (self) {
     // CID v0 is for multihashes encoded with sha2-256
     if (opts.hashAlg && opts.cidVersion !== 1) {
       opts.cidVersion = 1
+    }
+
+    if (opts.trickle) {
+      opts.strategy = 'trickle'
+      delete opts.trickle
     }
 
     let total = 0

--- a/src/core/components/files-regular/add-async-iterator.js
+++ b/src/core/components/files-regular/add-async-iterator.js
@@ -33,8 +33,9 @@ module.exports = function (self) {
 
     if (opts.trickle) {
       opts.strategy = 'trickle'
-      delete opts.trickle
     }
+
+    delete opts.trickle
 
     let total = 0
 

--- a/src/http/api/resources/files-regular.js
+++ b/src/http/api/resources/files-regular.js
@@ -219,7 +219,7 @@ exports.add = {
           wrapWithDirectory: request.query['wrap-with-directory'],
           pin: request.query.pin,
           chunker: request.query.chunker,
-          strategy: request.query.trickle ? 'trickle' : 'balanced',
+          trickle: request.query.trickle,
           preload: request.query.preload
         })
       },


### PR DESCRIPTION
The interface spec says you should pass a `trickle` boolean to `ipfs.add` to get a trickle DAG, this PR makes us actually do that instead of passing `strategy: 'whatever'`.