### PR TITLE
fix: make init options look like go-ipfs

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -23,12 +23,12 @@ module.exports = {
         default: '2048',
         describe: 'Number of bits to use in the generated RSA private key (defaults to 2048)'
       })
-      .option('emptyRepo', {
+      .option('empty-repo', {
         alias: 'e',
         type: 'boolean',
         describe: "Don't add and pin help files to the local storage"
       })
-      .option('privateKey', {
+      .option('private-key', {
         alias: 'k',
         type: 'string',
         describe: 'Pre-generated private key to use for the repo'


### PR DESCRIPTION
Change emptyRepo and privateKey to kebab-case, while still supporting camelCase.
This make the cli output look like go-ipfs to avoid confusion.