### PR TITLE
fix: revert evergreen webui

### DIFF
--- a/src/http/api/routes/webui.js
+++ b/src/http/api/routes/webui.js
@@ -30,7 +30,7 @@ module.exports = [
         host = 'gateway.ipfs.io'
       }
 
-      return h.redirect(`${scheme}://${host}:${port}/ipns/webui.ipfs.io`)
+      return h.redirect(`${scheme}://${host}:${port}/ipfs/QmcjeTciMNgEBe4xXvEaA4TQtwTRkXucx7DmKWViXSmX7m`)
     }
   }
 ]


### PR DESCRIPTION
Until we can resolve DNS names over HTTPS we can't trust that someone hasn't hijacked the request, so revert the use of an IPNS name to get the latest web ui CID.

Refs:
 * https://github.com/ipfs/helia-ipns/issues/53
 * https://github.com/ipfs/go-ipfs/pull/6530#issuecomment-513275280