### PR TITLE
test: run examples/externals on PRs too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,55 +104,46 @@ jobs:
         - IPFS_JS_EXEC=./../../src/cli/bin.js IPFS_REUSEPORT=false npx aegir test -t electron-renderer -f ./test/browser.js --bail --timeout 10000
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - ipfs-companion
       script:
         - npm run test:external -- ipfs-companion https://github.com/ipfs-shipyard/ipfs-companion.git
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - npm-on-ipfs
       script:
         - npm run test:external -- npm-on-ipfs https://github.com/ipfs-shipyard/npm-on-ipfs.git
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - ipfs-pubsub-room
       script:
         - npm run test:external -- ipfs-pubsub-room https://github.com/ipfs-shipyard/ipfs-pubsub-room.git --branch upgrade-to-latest-js-ipfs-rc
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - peer-base
       script:
         - npm run test:external -- peer-base https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - service-worker-gateway
       script:
         - npm run test:external -- service-worker-gateway https://github.com/ipfs-shipyard/service-worker-gateway.git
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - orbit-db
       script:
         - npm run test:external -- orbit-db https://github.com/orbitdb/orbit-db.git
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - ipfs-log
       script:
         - npm run test:external -- ipfs-log https://github.com/orbitdb/ipfs-log.git
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: external - sidetree
       script:
         - npm run test:external -- sidetree https://github.com/decentralized-identity/sidetree.git
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-add-readable-stream
       script:
         - cd examples
@@ -160,7 +151,6 @@ jobs:
         - npm run test -- browser-add-readable-stream
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-browserify
       script:
         - cd examples
@@ -168,7 +158,6 @@ jobs:
         - npm run test -- browser-browserify
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-create-react-app
       script:
         - cd examples
@@ -176,7 +165,6 @@ jobs:
         - npm run test -- browser-create-react-app
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-mfs
       script:
         - cd examples
@@ -184,7 +172,6 @@ jobs:
         - npm run test -- browser-mfs
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-parceljs
       script:
         - cd examples
@@ -192,7 +179,6 @@ jobs:
         - npm run test -- browser-parceljs
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-readablestream
       script:
         - cd examples
@@ -200,7 +186,6 @@ jobs:
         - npm run test -- browser-readablestream
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-script-tag
       script:
         - cd examples
@@ -208,7 +193,6 @@ jobs:
         - npm run test -- browser-script-tag
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-video-streaming
       script:
         - cd examples
@@ -216,7 +200,6 @@ jobs:
         - npm run test -- browser-video-streaming
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-vue
       script:
         - cd examples
@@ -224,7 +207,6 @@ jobs:
         - npm run test -- browser-vue
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - browser-webpack
       script:
         - cd examples
@@ -232,7 +214,6 @@ jobs:
         - npm run test -- browser-webpack
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - circuit-relaying
       script:
         - cd examples
@@ -240,7 +221,6 @@ jobs:
         - npm run test -- circuit-relaying
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - custom-ipfs-repo
       script:
         - cd examples
@@ -248,7 +228,6 @@ jobs:
         - npm run test -- custom-ipfs-repo
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - custom-libp2p
       script:
         - cd examples
@@ -256,7 +235,6 @@ jobs:
         - npm run test -- custom-libp2p
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - exchange-files-in-browser
       script:
         - cd examples
@@ -264,7 +242,6 @@ jobs:
         - npm run test -- exchange-files-in-browser
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - explore-ethereum-blockchain
       script:
         - cd examples
@@ -272,7 +249,6 @@ jobs:
         - npm run test -- explore-ethereum-blockchain
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - ipfs-101
       script:
         - cd examples
@@ -280,7 +256,6 @@ jobs:
         - npm run test -- ipfs-101
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - running-multiple-nodes
       script:
         - cd examples
@@ -288,7 +263,6 @@ jobs:
         - npm run test -- running-multiple-nodes
 
     - stage: test
-      if: branch =~ /^release\/.*$/
       name: example - traverse-ipld-graphs
       script:
         - cd examples

--- a/examples/browser-browserify/package.json
+++ b/examples/browser-browserify/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "browserify": "^16.2.3",
     "concat-stream": "^2.0.0",
+    "execa": "^3.2.0",
     "http-server": "~0.11.1",
     "ipfs": "file:../../"
   },

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "aegir": "^20.0.0",
+    "execa": "^3.2.0",
     "ipfs-css": "^0.13.1",
     "parcel-bundler": "^1.6.2",
     "tachyons": "^4.9.1"

--- a/examples/circuit-relaying/test.js
+++ b/examples/circuit-relaying/test.js
@@ -17,7 +17,7 @@ const {
 const pkg = require('./package.json')
 
 async function testUI (url, relay, localPeerIdFile, remotePeerIdFile) {
-  const proc = execa('nightwatch', [ path.join(__dirname, 'test.js') ], {
+  const proc = execa('nightwatch', [path.join(__dirname, 'test.js')], {
     cwd: path.resolve(__dirname, '../'),
     env: {
       ...process.env,
@@ -26,7 +26,8 @@ async function testUI (url, relay, localPeerIdFile, remotePeerIdFile) {
       IPFS_RELAY_ADDRESS: relay,
       IPFS_LOCAL_PEER_ID_FILE: localPeerIdFile,
       IPFS_REMOTE_PEER_ID_FILE: remotePeerIdFile
-    }
+    },
+    all: true
   })
   proc.all.on('data', (data) => {
     process.stdout.write(data)
@@ -41,7 +42,7 @@ async function runTest () {
     config: {
       Addresses: {
         Swarm: [
-          `/ip4/127.0.0.1/tcp/0/ws`
+          '/ip4/127.0.0.1/tcp/0/ws'
         ]
       },
       Bootstrap: [],

--- a/examples/custom-ipfs-repo/index.js
+++ b/examples/custom-ipfs-repo/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const log = require('why-is-node-running')
-
 const IPFS = require('ipfs')
 const Repo = require('ipfs-repo')
 const fsLock = require('ipfs-repo/src/lock')

--- a/examples/custom-ipfs-repo/package.json
+++ b/examples/custom-ipfs-repo/package.json
@@ -12,5 +12,8 @@
     "datastore-fs": "^0.9.1",
     "ipfs": "file:../../",
     "ipfs-repo": "^0.28.0"
+  },
+  "devDependencies": {
+    "execa": "^3.2.0"
   }
 }

--- a/examples/custom-ipfs-repo/test.js
+++ b/examples/custom-ipfs-repo/test.js
@@ -5,8 +5,9 @@ const execa = require('execa')
 const fs = require('fs')
 
 async function test () {
-  const proc = execa('node', [ path.join(__dirname, 'index.js') ], {
-    cwd: path.resolve(__dirname)
+  const proc = execa('node', [path.join(__dirname, 'index.js')], {
+    cwd: path.resolve(__dirname),
+    all: true
   })
   proc.all.on('data', (data) => {
     process.stdout.write(data)

--- a/examples/custom-libp2p/package.json
+++ b/examples/custom-libp2p/package.json
@@ -19,5 +19,8 @@
     "libp2p-tcp": "~0.13.0",
     "libp2p-websocket-star": "~0.10.2",
     "pull-mplex": "~0.1.0"
+  },
+  "devDependencies": {
+    "execa": "^3.2.0"
   }
 }

--- a/examples/custom-libp2p/test.js
+++ b/examples/custom-libp2p/test.js
@@ -16,8 +16,9 @@ const PeerBook = require('peer-book')
 async function test () {
   let output = ''
 
-  const proc = execa('node', [ path.join(__dirname, 'index.js') ], {
-    cwd: path.resolve(__dirname)
+  const proc = execa('node', [path.join(__dirname, 'index.js')], {
+    cwd: path.resolve(__dirname),
+    all: true
   })
   proc.all.on('data', async (data) => {
     process.stdout.write(data)

--- a/examples/exchange-files-in-browser/package.json
+++ b/examples/exchange-files-in-browser/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "devDependencies": {
     "browserify": "^16.2.3",
+    "execa": "^3.2.0",
     "http-server": "~0.11.1"
   },
   "dependencies": {

--- a/examples/exchange-files-in-browser/test.js
+++ b/examples/exchange-files-in-browser/test.js
@@ -163,6 +163,8 @@ module.exports[pkg.name] = function (browser) {
       .click('#fetch-btn')
   }
 
+  browser.pause(1000)
+
   // but should both see the added file
   browser.expect.element('#file-history').text.to.contain(process.env.IPFS_CID)
 

--- a/examples/exchange-files-in-browser/test.js
+++ b/examples/exchange-files-in-browser/test.js
@@ -17,13 +17,14 @@ const {
 const pkg = require('./package.json')
 
 async function testUI (env) {
-  const proc = execa('nightwatch', [ path.join(__dirname, 'test.js') ], {
+  const proc = execa('nightwatch', [path.join(__dirname, 'test.js')], {
     cwd: path.resolve(__dirname, '../'),
     env: {
       ...process.env,
       ...env,
       CI: true
-    }
+    },
+    all: true
   })
   proc.all.on('data', (data) => {
     process.stdout.write(data)
@@ -38,7 +39,7 @@ async function runTest () {
     config: {
       Addresses: {
         Swarm: [
-          `/ip4/127.0.0.1/tcp/0/ws`
+          '/ip4/127.0.0.1/tcp/0/ws'
         ]
       },
       Bootstrap: []
@@ -59,7 +60,7 @@ async function runTest () {
       throw new Error(`Could not find web socket address in ${id.addresses}`)
     }
 
-    let workspaceName = `test-${Date.now()}`
+    const workspaceName = `test-${Date.now()}`
     const peerA = path.join(os.tmpdir(), `test-${Date.now()}-a.txt`)
     const peerB = path.join(os.tmpdir(), `test-${Date.now()}-b.txt`)
 

--- a/examples/explore-ethereum-blockchain/test.js
+++ b/examples/explore-ethereum-blockchain/test.js
@@ -20,7 +20,7 @@ async function runTest () {
     disposable: true
   })
 
-  let cids = []
+  const cids = []
 
   console.info('Importing eth-blocks')
   for (const file of await fs.readdir(path.join(__dirname, 'eth-stuffs'))) {

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "chromedriver": "^77.0.0",
     "delay": "^4.1.0",
-    "execa": "^2.1.0",
+    "execa": "^3.2.0",
     "fs-extra": "^8.1.0",
     "http-server": "~0.11.1",
     "nightwatch": "^1.2.4",

--- a/examples/run-in-electron/main.js
+++ b/examples/run-in-electron/main.js
@@ -6,11 +6,13 @@ const IPFS = require('ipfs')
 let mainWindow
 
 function createWindow () {
-  mainWindow = new BrowserWindow({ width: 800,
+  mainWindow = new BrowserWindow({
+    width: 800,
     height: 600,
     webPreferences: {
       nodeIntegration: true
-    } })
+    }
+  })
 
   // and load the index.html of the app.
   mainWindow.loadFile('index.html')

--- a/examples/running-multiple-nodes/test.js
+++ b/examples/running-multiple-nodes/test.js
@@ -11,7 +11,7 @@ const {
   waitForOutput
 } = require('../utils')
 
-async function  testCli () {
+async function testCli () {
   await Promise.all([
     startCliNode(),
     startCliNode()

--- a/examples/test-all.js
+++ b/examples/test-all.js
@@ -24,7 +24,7 @@ async function testAll () {
       continue
     }
 
-    await waitForOutput('npm info ok', 'npm', ['test', '--', dir], {
+    await waitForOutput('npm info ok', 'npm', ['test', '--verbose', '--', dir], {
       cwd: __dirname
     })
   }

--- a/examples/test.js
+++ b/examples/test.js
@@ -76,7 +76,8 @@ async function build (dir) {
   }
 
   const proc = execa('npm', ['run', build], {
-    cwd: dir
+    cwd: dir,
+    all: true
   })
   proc.all.on('data', (data) => {
     process.stdout.write(data)

--- a/examples/test.js
+++ b/examples/test.js
@@ -42,7 +42,8 @@ async function installDeps (dir) {
   }
 
   const proc = execa.command('npm install', {
-    cwd: dir
+    cwd: dir,
+    all: true
   })
   proc.all.on('data', (data) => {
     process.stdout.write(data)
@@ -93,12 +94,13 @@ async function runBrowserTest (dir) {
 
   console.info('Running tests at', server.url)
 
-  const proc = execa('nightwatch', [ path.join(dir, 'test.js') ], {
+  const proc = execa('nightwatch', [path.join(dir, 'test.js')], {
     cwd: __dirname,
     env: {
       ...process.env,
       IPFS_EXAMPLE_TEST_URL: server.url
-    }
+    },
+    all: true
   })
   proc.all.on('data', (data) => {
     process.stdout.write(data)

--- a/examples/traverse-ipld-graphs/test.js
+++ b/examples/traverse-ipld-graphs/test.js
@@ -19,7 +19,7 @@ async function runTest () {
   await waitForOutput('capoeira', path.resolve(__dirname, 'get-path-accross-formats.js'))
 
   console.info('Testing tree.js')
-  await waitForOutput("'hobbies/0/Links'\n]", path.resolve(__dirname, 'tree.js'))
+  await waitForOutput("'hobbies/0/Links'", path.resolve(__dirname, 'tree.js'))
 
   console.info('Testing eth.js')
   await waitForOutput('302516', path.resolve(__dirname, 'eth.js'))

--- a/examples/traverse-ipld-graphs/test.js
+++ b/examples/traverse-ipld-graphs/test.js
@@ -19,7 +19,7 @@ async function runTest () {
   await waitForOutput('capoeira', path.resolve(__dirname, 'get-path-accross-formats.js'))
 
   console.info('Testing tree.js')
-  await waitForOutput("'hobbies/0/Links' ]", path.resolve(__dirname, 'tree.js'))
+  await waitForOutput("'hobbies/0/Links'\n]", path.resolve(__dirname, 'tree.js'))
 
   console.info('Testing eth.js')
   await waitForOutput('302516', path.resolve(__dirname, 'eth.js'))

--- a/examples/utils.js
+++ b/examples/utils.js
@@ -73,7 +73,8 @@ async function startServer (dir) {
           env: {
             ...process.env,
             CI: true // needed for some "clever" build tools
-          }
+          },
+          all: true
         })
         proc.all.on('data', (data) => {
           process.stdout.write(data)
@@ -120,12 +121,12 @@ async function waitForOutput (expectedOutput, command, args = [], opts = {}) {
     command = 'node'
   }
 
-  const proc = execa(command, args, opts)
+  const proc = execa(command, args, { ...opts, all: true })
   let output = ''
-  let time = 120000
+  const time = 120000
 
-  let timeout = setTimeout(() => {
-    throw new Error(`Did not see "${expectedOutput}" in output from "${[command].concat(args).join(' ')}" after ${time/1000}s`)
+  const timeout = setTimeout(() => {
+    throw new Error(`Did not see "${expectedOutput}" in output from "${[command].concat(args).join(' ')}" after ${time / 1000}s`)
   }, time)
 
   proc.all.on('data', (data) => {

--- a/examples/utils.js
+++ b/examples/utils.js
@@ -11,7 +11,8 @@ async function startServer (dir) {
       let output = ''
 
       const proc = execa.command(`http-server ${path} -a 127.0.0.1`, {
-        cwd: __dirname
+        cwd: __dirname,
+        all: true
       })
       proc.all.on('data', (data) => {
         process.stdout.write(data)


### PR DESCRIPTION
We run automated tests of IPFS examples & external repos on our release branches, but there's no good reason not to run them on every PR instead to give people early warning of breakages.

This PR changes the `.travis.yml` file to run all tests on every submitted PR.