### PR TITLE
chore: do not generate aegir docs on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "benchmark:node:core": "echo \"Error: no benchmarks yet\" && exit 1",
     "benchmark:node:http": "echo \"Error: no benchmarks yet\" && exit 1",
     "benchmark:browser": "echo \"Error: no benchmarks yet\" && exit 1",
-    "release": "aegir release -t node -t browser",
-    "release-minor": "aegir release --type minor -t node -t browser",
-    "release-major": "aegir release --type major -t node -t browser"
+    "release": "aegir release -t node -t browser --no-docs",
+    "release-minor": "aegir release --type minor -t node -t browser --no-docs",
+    "release-major": "aegir release --type major -t node -t browser --no-docs"
   },
   "dependencies": {
     "@hapi/ammo": "^4.0.0",


### PR DESCRIPTION
These are not used and get put into the `docs` directory which is no longer ignored so we end up with a dirty repo on release.

refs https://github.com/ipfs/js-ipfs/pull/2502#issuecomment-542711961