### PR TITLE
feat: js-ipfs support of CIDs in /ipns/ content paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "execa": "^3.0.0",
     "form-data": "^2.5.1",
     "hat": "0.0.3",
-    "interface-ipfs-core": "^0.117.2",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#feat/peerid-as-cid",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "execa": "^3.0.0",
     "form-data": "^2.5.1",
     "hat": "0.0.3",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#feat/peerid-as-cid",
+    "interface-ipfs-core": "^0.118.0",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/src/core/components/name.js
+++ b/src/core/components/name.js
@@ -6,7 +6,7 @@ const human = require('human-to-milliseconds')
 const crypto = require('libp2p-crypto')
 const errcode = require('err-code')
 const mergeOptions = require('merge-options')
-const mh = require('multihashes')
+const CID = require('cids')
 const isDomain = require('is-domain-name')
 const promisify = require('promisify-es6')
 
@@ -155,7 +155,7 @@ module.exports = function name (self) {
 
       const [namespace, hash, ...remainder] = name.slice(1).split('/')
       try {
-        mh.fromB58String(hash)
+        new CID(hash) // eslint-disable-line no-new
       } catch (err) {
         // lets check if we have a domain ex. /ipns/ipfs.io and resolve with dns
         if (isDomain(hash)) {

--- a/src/core/ipns/resolver.js
+++ b/src/core/ipns/resolver.js
@@ -4,6 +4,7 @@ const ipns = require('ipns')
 const crypto = require('libp2p-crypto')
 const PeerId = require('peer-id')
 const errcode = require('err-code')
+const CID = require('cids')
 
 const debug = require('debug')
 const log = debug('ipfs:ipns:resolver')
@@ -74,7 +75,7 @@ class IpnsResolver {
 
   // resolve ipns entries from the provided routing
   async _resolveName (name) {
-    const peerId = PeerId.createFromB58String(name)
+    const peerId = PeerId.createFromBytes(new CID(name).multihash) // TODO: change to `PeerId.createFromCID` when https://github.com/libp2p/js-peer-id/pull/105 lands and js-ipfs switched to async peer-id lib
     const { routingKey } = ipns.getIdKeys(peerId.toBytes())
     let record
 

--- a/test/core/name.spec.js
+++ b/test/core/name.spec.js
@@ -13,6 +13,7 @@ const ipnsRouting = require('../../src/core/ipns/routing/config')
 const OfflineDatastore = require('../../src/core/ipns/routing/offline-datastore')
 const PubsubDatastore = require('../../src/core/ipns/routing/pubsub-datastore')
 const { Key, Errors } = require('interface-datastore')
+const CID = require('cids')
 
 const DaemonFactory = require('ipfsd-ctl')
 const df = DaemonFactory.create({
@@ -369,6 +370,16 @@ describe('name', function () {
       const res = await node.add(fixture)
       await node.name.publish(`/ipfs/${res[0].hash}`)
       const value = await ipnsPath.resolvePath(node, `/ipns/${nodeId}`)
+
+      expect(value).to.exist()
+    })
+
+    it('should resolve an ipns path with PeerID as CIDv1 in Base32 correctly', async function () {
+      const res = await node.add(fixture)
+      await node.name.publish(`/ipfs/${res[0].hash}`)
+      let peerCid = new CID(nodeId)
+      if (peerCid.version === 0) peerCid = peerCid.toV1() // future-proofing
+      const value = await ipnsPath.resolvePath(node, `/ipns/${peerCid.toString('base32')}`)
 
       expect(value).to.exist()
     })

--- a/test/http-api/inject/name.js
+++ b/test/http-api/inject/name.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const CID = require('cids')
 const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const checkAll = (bits) => string => bits.every(bit => string.includes(bit))
 
@@ -40,6 +41,32 @@ module.exports = (http) => {
       res = await api.inject({
         method: 'GET',
         url: '/api/v0/name/resolve'
+      })
+
+      expect(res).to.exist()
+      expect(res.result.Path).to.satisfy(checkAll([`/ipfs/${cid}`]))
+    })
+
+    it('should publish and resolve a record with explicit CIDv1 in Base32', async function () {
+      this.timeout(160 * 1000)
+
+      // ensure PeerID is represented as CIDv1 in Base32
+      const { id } = await http.api._ipfs.id()
+      let cidv1 = new CID(id)
+      if (cidv1.version === 0) cidv1 = cidv1.toV1() // future-proofing
+      const peerIdAsCidv1b32 = cidv1.toString('base32')
+
+      let res = await api.inject({
+        method: 'GET',
+        url: `/api/v0/name/publish?arg=${cid}&resolve=false`
+      })
+
+      expect(res).to.exist()
+      expect(res.result.Value).to.equal(`/ipfs/${cid}`)
+
+      res = await api.inject({
+        method: 'GET',
+        url: `/api/v0/name/resolve?arg=${peerIdAsCidv1b32}`
       })
 
       expect(res).to.exist()


### PR DESCRIPTION
### Motivation

We want root identifiers of content paths to be usable in case-insensitive contexts such as [subdomains](https://github.com/ipfs/in-web-browsers/issues/89). 
While we can use [CIDv1 encoded in Base32](https://github.com/ipfs/ipfs/issues/337) in `/ipfs/` namespace, Identifiers in `/ipns/` are still hardcoded to Base58btc,

Libp2p approved [RFC 0001: Text Peer Ids as CIDs](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md) recently, and we need to implement it in js-ipfs.

## Changes

This PR implements `Stage 1: Parse CIDs as peer ID` from https://github.com/libp2p/specs/issues/216. It makes `/ipns/{cidv1}` work without waiting for `PeerId.createFromCID` from  https://github.com/libp2p/js-peer-id/pull/105, which means we can merge this before async refactor is done. 

**This PR does not change the default PeerID representation**, 
all it does is to allow use of CIDs in `/ipns/` paths and add tests.

cc https://github.com/ipfs/ipfs/issues/337, https://github.com/libp2p/specs/issues/216, https://github.com/libp2p/specs/pull/209, https://github.com/ipfs/go-ipfs/issues/5287