### PR TITLE
Bump ipfs repo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ipfs-http-response": "~0.4.0",
     "ipfs-mfs": "^0.13.0",
     "ipfs-multipart": "^0.2.0",
-    "ipfs-repo": "mboperator/js-ipfs-repo#bump-p-queue",
+    "ipfs-repo": "^0.28.1",
     "ipfs-unixfs": "~0.1.16",
     "ipfs-unixfs-exporter": "^0.38.0",
     "ipfs-unixfs-importer": "^0.40.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ipfs-http-response": "~0.4.0",
     "ipfs-mfs": "^0.13.0",
     "ipfs-multipart": "^0.2.0",
-    "ipfs-repo": "mboperator/ipfs-repo#bump-p-queue",
+    "ipfs-repo": "mboperator/js-ipfs-repo#bump-p-queue",
     "ipfs-unixfs": "~0.1.16",
     "ipfs-unixfs-exporter": "^0.38.0",
     "ipfs-unixfs-importer": "^0.40.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ipfs-http-response": "~0.4.0",
     "ipfs-mfs": "^0.13.0",
     "ipfs-multipart": "^0.2.0",
-    "ipfs-repo": "^0.28.0",
+    "ipfs-repo": "mboperator/ipfs-repo#bump-p-queue",
     "ipfs-unixfs": "~0.1.16",
     "ipfs-unixfs-exporter": "^0.38.0",
     "ipfs-unixfs-importer": "^0.40.0",


### PR DESCRIPTION
Bumps `ipfs-repo` to the version which consumes `p-queue@^6` in an effort to fix #2374