### PR TITLE
refactor: switch to async peer-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,10 +302,9 @@ Instead of a boolean, you may provide an object with custom initialization optio
     ```js
     // Generating a Peer ID:
     const PeerId = require('peer-id')
-    PeerId.create({ bits: 2048 }, (err, peerId) => {
-      // Generates a new Peer ID, complete with public/private keypair
-      // See https://github.com/libp2p/js-peer-id
-    })
+    // Generates a new Peer ID, complete with public/private keypair
+    // See https://github.com/libp2p/js-peer-id
+    const peerId = await PeerId.create({ bits: 2048 })
     ```
 - `pass` (string) A passphrase to encrypt keys. You should generally use the [top-level `pass` option](#optionspass) instead of the `init.pass` option (this one will take its value from the top-level option if not set).
 - `profiles` (Array) Apply profile settings to config.

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "p-iteration": "^1.1.8",
     "p-queue": "^6.1.0",
     "peer-book": "^0.9.1",
-    "peer-id": "^0.12.2",
+    "peer-id": "^0.13.4",
     "peer-info": "~0.15.1",
     "progress": "^2.0.1",
     "promise-nodeify": "^3.0.1",

--- a/src/core/components/bitswap.js
+++ b/src/core/components/bitswap.js
@@ -21,7 +21,7 @@ module.exports = function bitswap (self) {
       let list
 
       if (peerId) {
-        peerId = PeerId.createFromB58String(peerId)
+        peerId = PeerId.createFromCID(peerId)
 
         list = self._bitswap.wantlistForPeer(peerId)
       } else {

--- a/src/core/components/dht.js
+++ b/src/core/components/dht.js
@@ -98,7 +98,7 @@ module.exports = (self) => {
      */
     findPeer: callbackify(async (peer) => { // eslint-disable-line require-await
       if (typeof peer === 'string') {
-        peer = PeerId.createFromB58String(peer)
+        peer = PeerId.createFromCID(peer)
       }
 
       return self.libp2p.peerRouting.findPeer(peer)
@@ -150,7 +150,7 @@ module.exports = (self) => {
     query: callbackify(async (peerId) => {
       if (typeof peerId === 'string') {
         try {
-          peerId = PeerId.createFromB58String(peerId)
+          peerId = PeerId.createFromCID(peerId)
         } catch (err) {
           log.error(err)
 

--- a/src/core/components/init.js
+++ b/src/core/components/init.js
@@ -3,7 +3,6 @@
 const peerId = require('peer-id')
 const mergeOptions = require('merge-options')
 const callbackify = require('callbackify')
-const promisify = require('promisify-es6')
 const defaultConfig = require('../runtime/config-nodejs.js')
 const Keychain = require('libp2p-keychain')
 const {
@@ -24,14 +23,14 @@ function createPeerId (self, opts) {
     if (typeof opts.privateKey === 'object') {
       return opts.privateKey
     } else {
-      return promisify(peerId.createFromPrivKey)(Buffer.from(opts.privateKey, 'base64'))
+      return peerId.createFromPrivKey(Buffer.from(opts.privateKey, 'base64'))
     }
   } else {
     // Generate peer identity keypair + transform to desired format + add to config.
     opts.log(`generating ${opts.bits}-bit RSA keypair...`, false)
     self.log('generating peer id: %s bits', opts.bits)
 
-    return promisify(peerId.create)({ bits: opts.bits })
+    return peerId.create({ bits: opts.bits })
   }
 }
 

--- a/src/core/components/ping-pull-stream.js
+++ b/src/core/components/ping-pull-stream.js
@@ -49,7 +49,7 @@ function getPeer (libp2pNode, statusStream, peerIdStr, cb) {
   let peerId
 
   try {
-    peerId = PeerId.createFromB58String(peerIdStr)
+    peerId = PeerId.createFromCID(peerIdStr)
   } catch (err) {
     return cb(err)
   }

--- a/src/core/components/pre-start.js
+++ b/src/core/components/pre-start.js
@@ -7,7 +7,6 @@ const Keychain = require('libp2p-keychain')
 const mergeOptions = require('merge-options')
 const NoKeychain = require('./no-keychain')
 const callbackify = require('callbackify')
-const promisify = require('promisify-es6')
 
 /*
  * Load stuff from Repo into memory
@@ -44,7 +43,7 @@ module.exports = function preStart (self) {
     }
 
     const privKey = config.Identity.PrivKey
-    const id = await promisify(peerId.createFromPrivKey)(privKey)
+    const id = await peerId.createFromPrivKey(privKey)
 
     // Import the private key as 'self', if needed.
     if (pass) {

--- a/src/core/ipns/publisher.js
+++ b/src/core/ipns/publisher.js
@@ -3,7 +3,6 @@
 const PeerId = require('peer-id')
 const { Key, Errors } = require('interface-datastore')
 const errcode = require('err-code')
-const promisify = require('promisify-es6')
 const debug = require('debug')
 const log = debug('ipfs:ipns:publisher')
 log.error = debug('ipfs:ipns:publisher:error')
@@ -26,7 +25,7 @@ class IpnsPublisher {
       throw errcode(new Error('invalid private key'), 'ERR_INVALID_PRIVATE_KEY')
     }
 
-    const peerId = await promisify(PeerId.createFromPrivKey)(privKey.bytes)
+    const peerId = await PeerId.createFromPrivKey(privKey.bytes)
     const record = await this._updateOrCreateRecord(privKey, value, lifetime, peerId)
 
     return this._putRecordToRouting(record, peerId)

--- a/src/core/ipns/republisher.js
+++ b/src/core/ipns/republisher.js
@@ -4,7 +4,6 @@ const ipns = require('ipns')
 const crypto = require('libp2p-crypto')
 const PeerId = require('peer-id')
 const errcode = require('err-code')
-const promisify = require('promisify-es6')
 
 const debug = require('debug')
 const log = debug('ipfs:ipns:republisher')
@@ -132,7 +131,7 @@ class IpnsRepublisher {
     }
 
     try {
-      const peerId = await promisify(PeerId.createFromPrivKey)(privateKey.bytes)
+      const peerId = await PeerId.createFromPrivKey(privateKey.bytes)
       const value = await this._getPreviousValue(peerId)
       await this._publisher.publishWithEOL(privateKey, value, defaultRecordLifetime)
     } catch (err) {

--- a/src/core/ipns/resolver.js
+++ b/src/core/ipns/resolver.js
@@ -4,7 +4,6 @@ const ipns = require('ipns')
 const crypto = require('libp2p-crypto')
 const PeerId = require('peer-id')
 const errcode = require('err-code')
-const CID = require('cids')
 
 const debug = require('debug')
 const log = debug('ipfs:ipns:resolver')
@@ -75,7 +74,7 @@ class IpnsResolver {
 
   // resolve ipns entries from the provided routing
   async _resolveName (name) {
-    const peerId = PeerId.createFromBytes(new CID(name).multihash) // TODO: change to `PeerId.createFromCID` when https://github.com/libp2p/js-peer-id/pull/105 lands and js-ipfs switched to async peer-id lib
+    const peerId = PeerId.createFromCID(name)
     const { routingKey } = ipns.getIdKeys(peerId.toBytes())
     let record
 

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -22,12 +22,9 @@ describe('bitswap', () => runOn((thing) => {
     ipfs('block get ' + key1).catch(() => {})
   })
 
-  before(function (done) {
-    PeerId.create({ bits: 512 }, (err, peer) => {
-      expect(err).to.not.exist()
-      peerId = peer.toB58String()
-      done()
-    })
+  before(async function () {
+    const peer = await PeerId.create({ bits: 512 })
+    peerId = peer.toB58String()
   })
 
   before(async () => {

--- a/test/cli/swarm.js
+++ b/test/cli/swarm.js
@@ -109,12 +109,9 @@ describe('swarm', () => {
     }
 
     describe('addrs', () => {
-      before((done) => {
-        PeerId.create({ bits: 512 }, (err, peerId) => {
-          if (err) return done(err)
-          peerInfo = new PeerInfo(peerId)
-          done()
-        })
+      before(async () => {
+        const peerId = await PeerId.create({ bits: 512 })
+        peerInfo = new PeerInfo(peerId)
       })
 
       it('should return addresses for all peers', (done) => {

--- a/test/core/name-pubsub.js
+++ b/test/core/name-pubsub.js
@@ -12,7 +12,6 @@ const ipns = require('ipns')
 const IPFS = require('../../src')
 const waitFor = require('../utils/wait-for')
 const delay = require('delay')
-const promisify = require('promisify-es6')
 
 const DaemonFactory = require('ipfsd-ctl')
 const df = DaemonFactory.create({
@@ -177,8 +176,8 @@ describe('name-pubsub', function () {
     await nodeB.pubsub.subscribe(topic, checkMessage)
     await nodeA.name.publish(ipfsRef, { resolve: false, key: testAccountName })
     await waitFor(alreadySubscribed)
-    const messageKey = await promisify(peerId.createFromPubKey)(publishedMessage.key)
-    const pubKeyPeerId = await promisify(peerId.createFromPubKey)(publishedMessageData.pubKey)
+    const messageKey = await peerId.createFromPubKey(publishedMessage.key)
+    const pubKeyPeerId = await peerId.createFromPubKey(publishedMessageData.pubKey)
 
     expect(pubKeyPeerId.toB58String()).not.to.equal(messageKey.toB58String())
     expect(pubKeyPeerId.toB58String()).to.equal(testAccount.id)


### PR DESCRIPTION
This PR switches to async `"peer-id": "^0.13.4"`

I originally made this for (#2566) before I realized it does not work with other deps that use non-async `peer-id`. 

cc @alanshaw  @vasco-santos @jacobheun to be aware of this