### PR TITLE
dht.provide() should accept string keys (#2573)

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "execa": "^3.0.0",
     "form-data": "^2.5.1",
     "hat": "0.0.3",
-    "interface-ipfs-core": "^0.118.0",
+    "interface-ipfs-core": "^0.119.0",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/src/core/components/dht.js
+++ b/src/core/components/dht.js
@@ -119,7 +119,18 @@ module.exports = (self) => {
       if (!Array.isArray(keys)) {
         keys = [keys]
       }
-
+      for (var i in keys){
+        if (typeof keys[i] === 'string') {
+          try {
+            keys[i] = new CID(keys[i])
+          } catch (err) {
+            log.error(err)
+  
+            throw errcode(err, 'ERR_INVALID_CID')
+          }
+        }
+      }
+      
       // ensure blocks are actually local
       const has = await every(keys, (key) => {
         return self._repo.blocks.has(key)

--- a/src/core/components/dht.js
+++ b/src/core/components/dht.js
@@ -119,18 +119,17 @@ module.exports = (self) => {
       if (!Array.isArray(keys)) {
         keys = [keys]
       }
-      for (var i in keys){
+      for (var i in keys) {
         if (typeof keys[i] === 'string') {
           try {
             keys[i] = new CID(keys[i])
           } catch (err) {
             log.error(err)
-  
             throw errcode(err, 'ERR_INVALID_CID')
           }
         }
       }
-      
+
       // ensure blocks are actually local
       const has = await every(keys, (key) => {
         return self._repo.blocks.has(key)


### PR DESCRIPTION
Solving https://github.com/ipfs/js-ipfs/issues/2573
ipfs.dht.provide() now accepts strings as well as CID objects, and attempts to convert them to the latter.