### PR TITLE
feat: pass libp2pOptions to the bundle function

### DIFF
--- a/src/core/runtime/libp2p-browser.js
+++ b/src/core/runtime/libp2p-browser.js
@@ -8,73 +8,65 @@ const SECIO = require('libp2p-secio')
 const Bootstrap = require('libp2p-bootstrap')
 const KadDHT = require('libp2p-kad-dht')
 const GossipSub = require('libp2p-gossipsub')
-const libp2p = require('libp2p')
-const mergeOptions = require('merge-options')
 const multiaddr = require('multiaddr')
 
-class Node extends libp2p {
-  constructor (_options) {
-    const wrtcstar = new WebRTCStar({ id: _options.peerInfo.id })
+module.exports = ({ peerInfo, options }) => {
+  const wrtcstar = new WebRTCStar({ id: peerInfo.id })
 
-    // this can be replaced once optional listening is supported with the below code. ref: https://github.com/libp2p/interface-transport/issues/41
-    // const wsstar = new WebSocketStar({ id: _options.peerInfo.id })
-    const wsstarServers = _options.peerInfo.multiaddrs.toArray().map(String).filter(addr => addr.includes('p2p-websocket-star'))
-    _options.peerInfo.multiaddrs.replace(wsstarServers.map(multiaddr), '/p2p-websocket-star') // the ws-star-multi module will replace this with the chosen ws-star servers
-    const wsstar = new WebSocketStarMulti({ servers: wsstarServers, id: _options.peerInfo.id, ignore_no_online: !wsstarServers.length || _options.wsStarIgnoreErrors })
+  // this can be replaced once optional listening is supported with the below code. ref: https://github.com/libp2p/interface-transport/issues/41
+  // const wsstar = new WebSocketStar({ id: _options.peerInfo.id })
+  const wsstarServers = peerInfo.multiaddrs.toArray().map(String).filter(addr => addr.includes('p2p-websocket-star'))
+  peerInfo.multiaddrs.replace(wsstarServers.map(multiaddr), '/p2p-websocket-star') // the ws-star-multi module will replace this with the chosen ws-star servers
+  const wsstar = new WebSocketStarMulti({ servers: wsstarServers, id: peerInfo.id, ignore_no_online: !wsstarServers.length || options.wsStarIgnoreErrors })
 
-    const defaults = {
-      switch: {
-        denyTTL: 2 * 60 * 1e3, // 2 minute base
-        denyAttempts: 5, // back off 5 times
-        maxParallelDials: 100,
-        maxColdCalls: 25,
-        dialTimeout: 20e3
-      },
-      modules: {
-        transport: [
-          WS,
-          wrtcstar,
-          wsstar
-        ],
-        streamMuxer: [
-          Multiplex
-        ],
-        connEncryption: [
-          SECIO
-        ],
-        peerDiscovery: [
-          wrtcstar.discovery,
-          wsstar.discovery,
-          Bootstrap
-        ],
-        dht: KadDHT,
-        pubsub: GossipSub
-      },
-      config: {
-        peerDiscovery: {
-          autoDial: true,
-          bootstrap: {
-            enabled: true
-          },
-          webRTCStar: {
-            enabled: true
-          },
-          websocketStar: {
-            enabled: true
-          }
+  return {
+    switch: {
+      denyTTL: 2 * 60 * 1e3, // 2 minute base
+      denyAttempts: 5, // back off 5 times
+      maxParallelDials: 100,
+      maxColdCalls: 25,
+      dialTimeout: 20e3
+    },
+    modules: {
+      transport: [
+        WS,
+        wrtcstar,
+        wsstar
+      ],
+      streamMuxer: [
+        Multiplex
+      ],
+      connEncryption: [
+        SECIO
+      ],
+      peerDiscovery: [
+        wrtcstar.discovery,
+        wsstar.discovery,
+        Bootstrap
+      ],
+      dht: KadDHT,
+      pubsub: GossipSub
+    },
+    config: {
+      peerDiscovery: {
+        autoDial: true,
+        bootstrap: {
+          enabled: true
         },
-        dht: {
-          enabled: false
+        webRTCStar: {
+          enabled: true
         },
-        pubsub: {
-          enabled: true,
-          emitSelf: true
+        websocketStar: {
+          enabled: true
         }
+      },
+      dht: {
+        enabled: false
+      },
+      pubsub: {
+        enabled: true,
+        emitSelf: true
       }
     }
-
-    super(mergeOptions(defaults, _options))
   }
 }
-
-module.exports = Node

--- a/src/core/runtime/libp2p-nodejs.js
+++ b/src/core/runtime/libp2p-nodejs.js
@@ -9,75 +9,67 @@ const KadDHT = require('libp2p-kad-dht')
 const GossipSub = require('libp2p-gossipsub')
 const Multiplex = require('pull-mplex')
 const SECIO = require('libp2p-secio')
-const libp2p = require('libp2p')
-const mergeOptions = require('merge-options')
 const multiaddr = require('multiaddr')
 
-class Node extends libp2p {
-  constructor (_options) {
-    // this can be replaced once optional listening is supported with the below code. ref: https://github.com/libp2p/interface-transport/issues/41
-    // const wsstar = new WebSocketStar({ id: _options.peerInfo.id })
-    const wsstarServers = _options.peerInfo.multiaddrs.toArray().map(String).filter(addr => addr.includes('p2p-websocket-star'))
-    _options.peerInfo.multiaddrs.replace(wsstarServers.map(multiaddr), '/p2p-websocket-star') // the ws-star-multi module will replace this with the chosen ws-star servers
-    const wsstar = new WebSocketStarMulti({ servers: wsstarServers, id: _options.peerInfo.id, ignore_no_online: !wsstarServers.length || _options.wsStarIgnoreErrors })
+module.exports = ({ peerInfo, options }) => {
+  // this can be replaced once optional listening is supported with the below code. ref: https://github.com/libp2p/interface-transport/issues/41
+  // const wsstar = new WebSocketStar({ id: _options.peerInfo.id })
+  const wsstarServers = peerInfo.multiaddrs.toArray().map(String).filter(addr => addr.includes('p2p-websocket-star'))
+  peerInfo.multiaddrs.replace(wsstarServers.map(multiaddr), '/p2p-websocket-star') // the ws-star-multi module will replace this with the chosen ws-star servers
+  const wsstar = new WebSocketStarMulti({ servers: wsstarServers, id: peerInfo.id, ignore_no_online: !wsstarServers.length || options.wsStarIgnoreErrors })
 
-    const defaults = {
-      switch: {
-        denyTTL: 2 * 60 * 1e3, // 2 minute base
-        denyAttempts: 5, // back off 5 times
-        maxParallelDials: 150,
-        maxColdCalls: 50,
-        dialTimeout: 10e3 // Be strict with dial time
-      },
-      modules: {
-        transport: [
-          TCP,
-          WS,
-          wsstar
-        ],
-        streamMuxer: [
-          Multiplex
-        ],
-        connEncryption: [
-          SECIO
-        ],
-        peerDiscovery: [
-          MulticastDNS,
-          Bootstrap,
-          wsstar.discovery
-        ],
-        dht: KadDHT,
-        pubsub: GossipSub
-      },
-      config: {
-        peerDiscovery: {
-          autoDial: true,
-          mdns: {
-            enabled: true
-          },
-          bootstrap: {
-            enabled: true
-          },
-          websocketStar: {
-            enabled: true
-          }
+  return {
+    switch: {
+      denyTTL: 2 * 60 * 1e3, // 2 minute base
+      denyAttempts: 5, // back off 5 times
+      maxParallelDials: 150,
+      maxColdCalls: 50,
+      dialTimeout: 10e3 // Be strict with dial time
+    },
+    modules: {
+      transport: [
+        TCP,
+        WS,
+        wsstar
+      ],
+      streamMuxer: [
+        Multiplex
+      ],
+      connEncryption: [
+        SECIO
+      ],
+      peerDiscovery: [
+        MulticastDNS,
+        Bootstrap,
+        wsstar.discovery
+      ],
+      dht: KadDHT,
+      pubsub: GossipSub
+    },
+    config: {
+      peerDiscovery: {
+        autoDial: true,
+        mdns: {
+          enabled: true
         },
-        dht: {
-          kBucketSize: 20,
-          enabled: false,
-          randomWalk: {
-            enabled: false
-          }
+        bootstrap: {
+          enabled: true
         },
-        pubsub: {
-          enabled: true,
-          emitSelf: true
+        websocketStar: {
+          enabled: true
         }
+      },
+      dht: {
+        kBucketSize: 20,
+        enabled: false,
+        randomWalk: {
+          enabled: false
+        }
+      },
+      pubsub: {
+        enabled: true,
+        emitSelf: true
       }
     }
-
-    super(mergeOptions(defaults, _options))
   }
 }
-
-module.exports = Node

--- a/test/core/libp2p.spec.js
+++ b/test/core/libp2p.spec.js
@@ -135,7 +135,6 @@ describe('libp2p customization', function () {
 
       _libp2p.start((err) => {
         expect(err).to.not.exist()
-        console.log(_libp2p._transport)
         expect(_libp2p._transport).to.have.length(1)
         expect(_libp2p._transport[0] instanceof DummyTransport).to.equal(true)
         done()

--- a/test/core/libp2p.spec.js
+++ b/test/core/libp2p.spec.js
@@ -107,6 +107,40 @@ describe('libp2p customization', function () {
         done()
       })
     })
+
+    it('should pass libp2p options to libp2p bundle function', (done) => {
+      class DummyTransport {
+        filter () {
+          return []
+        }
+      }
+
+      const ipfs = {
+        _repo: {
+          datastore
+        },
+        _peerInfo: peerInfo,
+        _peerBook: peerBook,
+        // eslint-disable-next-line no-console
+        _print: console.log,
+        _options: {
+          libp2p: ({ libp2pOptions, peerInfo }) => {
+            libp2pOptions.modules.transport = [DummyTransport]
+            return new Libp2p(libp2pOptions)
+          }
+        }
+      }
+
+      _libp2p = libp2pComponent(ipfs, testConfig)
+
+      _libp2p.start((err) => {
+        expect(err).to.not.exist()
+        console.log(_libp2p._transport)
+        expect(_libp2p._transport).to.have.length(1)
+        expect(_libp2p._transport[0] instanceof DummyTransport).to.equal(true)
+        done()
+      })
+    })
   })
 
   describe('options', () => {


### PR DESCRIPTION
This allows bundle creation by merging/overriding option defaults instead of creating them in their entirety from scratch. This is for convenience.

The `libp2pOptions` passed to the bundle function include any options defined in the required runtime files (for Node.js/browser config).

To allow this, there is a slight change to `runtime/libp2p-nodejs.js` and `runtime/libp2p-browser.js` to return their options instead of a libp2p instance. This actually removes some repeated boilerplate.

e.g.

```js
const ipfs = await IPFS.create({
  libp2p: ({ libp2pOptions, peerInfo, ...rest }) => {
    // Merge, extend, override etc. etc.
    libp2pOptions.transports.push(...)
    return new Libp2p(libp2pOptions)
  }
})
```

resolves #2579