### PR TITLE
chore: try caching on all environments again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 
-# TODO: enable when windows is faster on travis, currently causes "No output has been received in the last 10m0s"
-# cache: npm
-cache: false
-
 branches:
   only:
   - master


### PR DESCRIPTION
> Please note that as of July 2019, npm is cached by default on Travis CI

https://docs.travis-ci.com/user/caching/#npm-cache