### PR TITLE
fix: repo gc error key name

### DIFF
--- a/src/http/api/resources/repo.js
+++ b/src/http/api/resources/repo.js
@@ -17,7 +17,7 @@ exports.gc = {
     const filtered = res.filter(r => !r.err || streamErrors)
     const response = filtered.map(r => {
       return {
-        Err: r.err && r.err.message,
+        Error: r.err && r.err.message,
         Key: !r.err && { '/': r.cid.toString() }
       }
     })


### PR DESCRIPTION
Should be `Error` not `Err`. https://docs.ipfs.io/reference/api/http/#api-v0-repo-gc