### PR TITLE
feat: add bitswap stat cli human option

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "peer-book": "^0.9.1",
     "peer-id": "^0.12.2",
     "peer-info": "~0.15.1",
+    "pretty-bytes": "^5.3.0",
     "progress": "^2.0.1",
     "promise-nodeify": "^3.0.1",
     "promisify-es6": "^1.0.3",

--- a/src/cli/commands/bitswap/stat.js
+++ b/src/cli/commands/bitswap/stat.js
@@ -2,6 +2,7 @@
 
 const multibase = require('multibase')
 const { cidToString } = require('../../../utils/cid')
+const prettyBytes = require('pretty-bytes')
 
 module.exports = {
   command: 'stat',
@@ -13,24 +14,42 @@ module.exports = {
       describe: 'Number base to display CIDs in. Note: specifying a CID base for v0 CIDs will have no effect.',
       type: 'string',
       choices: multibase.names
+    },
+    human: {
+      type: 'boolean',
+      default: false
     }
   },
 
-  handler ({ getIpfs, print, cidBase, resolve }) {
+  handler ({ getIpfs, print, cidBase, resolve, human }) {
     resolve((async () => {
       const ipfs = await getIpfs()
       const stats = await ipfs.bitswap.stat()
-      stats.wantlist = stats.wantlist.map(k => cidToString(k['/'], { base: cidBase, upgrade: false }))
-      stats.peers = stats.peers || []
+
+      if (human) {
+        stats.blocksReceived = stats.blocksReceived.toNumber()
+        stats.blocksSent = stats.blocksSent.toNumber()
+        stats.dataReceived = prettyBytes(stats.dataReceived.toNumber()).toUpperCase()
+        stats.dataSent = prettyBytes(stats.dataSent.toNumber()).toUpperCase()
+        stats.dupBlksReceived = stats.dupBlksReceived.toNumber()
+        stats.dupDataReceived = prettyBytes(stats.dupDataReceived.toNumber()).toUpperCase()
+        stats.wantlist = `[${stats.wantlist.length} keys]`
+      } else {
+        const wantlist = stats.wantlist.map((elem) => cidToString(elem['/'], { base: cidBase, upgrade: false }))
+        stats.wantlist = `[${wantlist.length} keys]
+            ${wantlist.join('\n            ')}`
+      }
 
       print(`bitswap status
-  blocks received: ${stats.blocksReceived}
-  dup blocks received: ${stats.dupBlksReceived}
-  dup data received: ${stats.dupDataReceived}B
-  wantlist [${stats.wantlist.length} keys]
-    ${stats.wantlist.join('\n    ')}
-  partners [${stats.peers.length}]
-    ${stats.peers.join('\n    ')}`)
+        provides buffer: ${stats.provideBufLen}
+        blocks received: ${stats.blocksReceived}
+        blocks sent: ${stats.blocksSent}
+        data received: ${stats.dataReceived}
+        data sent: ${stats.dataSent}
+        dup blocks received: ${stats.dupBlksReceived}
+        dup data received: ${stats.dupDataReceived}
+        wantlist ${stats.wantlist}
+        partners [${stats.peers.length}]`)
     })())
   }
 }

--- a/test/cli/bitswap.js
+++ b/test/cli/bitswap.js
@@ -67,17 +67,38 @@ describe('bitswap', () => runOn((thing) => {
     this.timeout(20 * 1000)
 
     const out = await ipfs('bitswap stat')
-    expect(out).to.include([
-      'bitswap status',
-      '  blocks received: 0',
-      '  dup blocks received: 0',
-      '  dup data received: 0B',
-      // We sometimes pick up partners while the tests run and the order of
-      // wanted keys is not defined so our assertion ends here.
-      '  wantlist [2 keys]'
-    ].join('\n'))
+
+    expect(out).to.include('bitswap status')
+    expect(out).to.match(/provides buffer:\s\d+$/m)
+    expect(out).to.match(/blocks received:\s\d+$/m)
+    expect(out).to.match(/blocks sent:\s\d+$/m)
+    expect(out).to.match(/data received:\s\d+$/m)
+    expect(out).to.match(/data sent:\s\d+$/m)
+    expect(out).to.match(/dup blocks received:\s\d+$/m)
+    expect(out).to.match(/dup data received:\s\d+$/m)
+    expect(out).to.match(/wantlist\s\[\d+\skeys\]$/m)
     expect(out).to.include(key0)
     expect(out).to.include(key1)
+    expect(out).to.match(/partners\s\[\d+\]$/m)
+  })
+
+  it('stat --human', async function () {
+    this.timeout(20 * 1000)
+
+    const out = await ipfs('bitswap stat --human')
+
+    expect(out).to.include('bitswap status')
+    expect(out).to.match(/provides buffer:\s\d+$/m)
+    expect(out).to.match(/blocks received:\s\d+$/m)
+    expect(out).to.match(/blocks sent:\s\d+$/m)
+    expect(out).to.match(/data received:\s+[\d.]+\s[PTGMK]?B$/m)
+    expect(out).to.match(/data sent:\s+[\d.]+\s[PTGMK]?B$/m)
+    expect(out).to.match(/dup blocks received:\s\d+$/m)
+    expect(out).to.match(/dup data received:\s+[\d.]+\s[PTGMK]?B$/m)
+    expect(out).to.match(/wantlist\s\[\d+\skeys\]$/m)
+    expect(out).to.not.include(key0)
+    expect(out).to.not.include(key1)
+    expect(out).to.match(/partners\s\[\d+\]$/m)
   })
 
   it('should get stats with wantlist CIDs encoded in specified base', async function () {


### PR DESCRIPTION
This PR adds `--human` flag to `bitswap stat` command.

**Usage:** 
```sh
> jsipfs bitswap stat --human
```

**Output:**
```sh
bitswap status
        provides buffer: 0
        blocks received: 0
        blocks sent: 0
        data received: 0 B
        data sent: 0 B
        dup blocks received: 0
        dup data received: 0 B
        wantlist [2 keys]
        partners [0]
```

This PR supersedes https://github.com/ipfs/js-ipfs/pull/2608. 