### PR TITLE
License update to dual MIT and Apache 2

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,5 @@
+This project is transitioning from an MIT-only license to a dual MIT/Apache-2.0 license.
+Unless otherwise noted, all code contributed prior to 2019-11-21 and not contributed by
+a user listed in [this signoff issue](https://github.com/ipfs/js-ipfs/issues/2552) is
+licensed under MIT-only. All new contributions (and past contributions since 2019-11-21)
+are licensed under a dual MIT/Apache-2.0 license.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 This project is transitioning from an MIT-only license to a dual MIT/Apache-2.0 license.
 Unless otherwise noted, all code contributed prior to 2019-11-21 and not contributed by
-a user listed in [this signoff issue](https://github.com/ipfs/js-ipfs/issues/2552) is
+a user listed in [this signoff issue](https://github.com/ipfs/js-ipfs/issues/2624) is
 licensed under MIT-only. All new contributions (and past contributions since 2019-11-21)
 are licensed under a dual MIT/Apache-2.0 license.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,5 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Juan Batiz-Benet
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "homepage": "https://js.ipfs.io",
   "bugs": "https://github.com/ipfs/js-ipfs/issues",
-  "license": "MIT",
+  "license": "(Apache-2.0 OR MIT)",
   "leadMaintainer": "Alan Shaw <alan@tableflip.io>",
   "files": [
     "src",


### PR DESCRIPTION
Updated the license as mentioned in issue #2552. This closes #2552 