### PR TITLE
chore: change interface tests to async node creation

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,10 +1,8 @@
 'use strict'
 
 const IPFSFactory = require('ipfsd-ctl')
-const parallel = require('async/parallel')
 const MockPreloadNode = require('./test/utils/mock-preload-node')
 const EchoServer = require('interface-ipfs-core/src/utils/echo-http-server')
-const callbackify = require('callbackify')
 
 const ipfsdServer = IPFSFactory.createServer()
 const preloadNode = MockPreloadNode.createNode()
@@ -29,40 +27,26 @@ module.exports = {
   },
   hooks: {
     node: {
-      pre: (cb) => {
-        parallel([
-          (cb) => callbackify(preloadNode.start)(cb),
-          (cb) => echoServer.start(cb)
-        ], cb)
-      },
-      post: (cb) => {
-        parallel([
-          (cb) => callbackify(preloadNode.stop)(cb),
-          (cb) => echoServer.stop(cb)
-        ], cb)
-      }
+      pre: () => Promise.all([
+        preloadNode.start(),
+        echoServer.start()
+      ]),
+      post: () => Promise.all([
+        preloadNode.stop(),
+        echoServer.stop()
+      ])
     },
     browser: {
-      pre: (cb) => {
-        parallel([
-          (cb) => {
-            ipfsdServer.start()
-            cb()
-          },
-          (cb) => callbackify(preloadNode.start)(cb),
-          (cb) => echoServer.start(cb)
-        ], cb)
-      },
-      post: (cb) => {
-        parallel([
-          (cb) => {
-            ipfsdServer.stop()
-            cb()
-          },
-          (cb) => callbackify(preloadNode.stop)(cb),
-          (cb) => echoServer.stop(cb)
-        ], cb)
-      }
+      pre: () => Promise.all([
+        ipfsdServer.start(),
+        preloadNode.start(),
+        echoServer.start()
+      ]),
+      post: () => Promise.all([
+        ipfsdServer.stop(),
+        preloadNode.stop(),
+        echoServer.stop()
+      ])
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "^0.122.0",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#chore/update-tests-timeouts",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#chore/async-await-refactor",
+    "interface-ipfs-core": "^0.122.0",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#chore/update-tests-timeouts",
+    "interface-ipfs-core": "^0.124.1",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ipfs-bitswap": "^0.26.0",
     "ipfs-block": "~0.8.1",
     "ipfs-block-service": "~0.16.0",
-    "ipfs-http-client": "^40.0.1",
+    "ipfs-http-client": "ipfs/js-ipfs-http-client#control-peer-id-version",
     "ipfs-http-response": "~0.4.0",
     "ipfs-mfs": "^0.13.2",
     "ipfs-multipart": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#chore/update-tests-timeouts",
+    "interface-ipfs-core": "^0.124.0",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "^0.121.0",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#chore/async-await-refactor",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "p-iteration": "^1.1.8",
     "p-queue": "^6.1.0",
     "peer-book": "^0.9.1",
-    "peer-id": "^0.12.2",
+    "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",
     "pretty-bytes": "^5.3.0",
     "progress": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "^0.124.0",
+    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#chore/update-tests-timeouts",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ipfs-bitswap": "^0.26.0",
     "ipfs-block": "~0.8.1",
     "ipfs-block-service": "~0.16.0",
-    "ipfs-http-client": "ipfs/js-ipfs-http-client#control-peer-id-version",
+    "ipfs-http-client": "^40.0.1",
     "ipfs-http-response": "~0.4.0",
     "ipfs-mfs": "^0.13.2",
     "ipfs-multipart": "^0.2.0",

--- a/src/core/components/bootstrap.js
+++ b/src/core/components/bootstrap.js
@@ -45,8 +45,10 @@ module.exports = function bootstrap (self) {
         throw invalidMultiaddrError(multiaddr)
       }
 
+      let res = []
       const config = await self._repo.config.get()
       if (args.all) {
+        res = config.Bootstrap
         config.Bootstrap = []
       } else {
         config.Bootstrap = config.Bootstrap.filter((mh) => mh !== multiaddr)
@@ -54,7 +56,6 @@ module.exports = function bootstrap (self) {
 
       await self._repo.config.set(config)
 
-      const res = []
       if (!args.all && multiaddr) {
         res.push(multiaddr)
       }

--- a/test/cli/bootstrap.js
+++ b/test/cli/bootstrap.js
@@ -94,10 +94,12 @@ describe('bootstrap', () => runOnAndOff((thing) => {
   it('rm all bootstrap nodes', async function () {
     this.timeout(40 * 1000)
 
-    const out = await ipfs('bootstrap rm --all')
-    expect(out).to.equal('')
+    const outListBefore = await ipfs('bootstrap list')
 
-    const out2 = await ipfs('bootstrap list')
-    expect(out2).to.equal('')
+    const outRm = await ipfs('bootstrap rm --all')
+    expect(outRm).to.equal(outListBefore)
+
+    const outListAfter = await ipfs('bootstrap list')
+    expect(outListAfter).to.equal('')
   })
 }))

--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -8,7 +8,7 @@ const isNode = require('detect-node')
 describe('interface-ipfs-core tests', function () {
   this.timeout(20 * 1000)
 
-  const defaultCommonFactory = CommonFactory.create()
+  const defaultCommonFactory = CommonFactory.createAsync()
 
   tests.bitswap(defaultCommonFactory, { skip: !isNode })
 
@@ -20,7 +20,7 @@ describe('interface-ipfs-core tests', function () {
 
   tests.dag(defaultCommonFactory)
 
-  tests.dht(CommonFactory.create({
+  tests.dht(CommonFactory.createAsync({
     spawnOptions: {
       config: {
         Bootstrap: [],
@@ -53,7 +53,7 @@ describe('interface-ipfs-core tests', function () {
 
   tests.filesMFS(defaultCommonFactory)
 
-  tests.key(CommonFactory.create({
+  tests.key(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--pass ipfs-is-awesome-software'],
       initOptions: { bits: 512 },
@@ -71,21 +71,19 @@ describe('interface-ipfs-core tests', function () {
     }
   }))
 
-  tests.miscellaneous(CommonFactory.create({
-    // No need to stop, because the test suite does a 'stop' test.
-    createTeardown: () => cb => cb(),
+  tests.miscellaneous(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--pass ipfs-is-awesome-software', '--offline']
     }
   }))
 
-  tests.name(CommonFactory.create({
+  tests.name(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--pass ipfs-is-awesome-software', '--offline']
     }
   }))
 
-  tests.namePubsub(CommonFactory.create({
+  tests.namePubsub(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--enable-namesys-pubsub'],
       initOptions: { bits: 1024 },
@@ -120,7 +118,7 @@ describe('interface-ipfs-core tests', function () {
     }
   })
 
-  tests.pubsub(CommonFactory.create({
+  tests.pubsub(CommonFactory.createAsync({
     spawnOptions: {
       initOptions: { bits: 512 }
     }
@@ -134,5 +132,5 @@ describe('interface-ipfs-core tests', function () {
 
   tests.stats(defaultCommonFactory)
 
-  tests.swarm(CommonFactory.createAsync(), { skip: !isNode })
+  tests.swarm(defaultCommonFactory, { skip: !isNode })
 })

--- a/test/http-api/inject/bootstrap.js
+++ b/test/http-api/inject/bootstrap.js
@@ -83,7 +83,7 @@ module.exports = (http) => {
       })
 
       expect(res.statusCode).to.be.eql(200)
-      expect(res.result.Peers).to.be.eql([])
+      expect(res.result.Peers).to.be.eql(defaultList)
     })
   })
 }

--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -6,7 +6,7 @@ const CommonFactory = require('../utils/interface-common-factory')
 const path = require('path')
 
 describe('interface-ipfs-core over ipfs-http-client tests', () => {
-  const defaultCommonFactory = CommonFactory.create({
+  const defaultCommonFactory = CommonFactory.createAsync({
     factoryOptions: { exec: path.resolve(`${__dirname}/../../src/cli/bin.js`) }
   })
 
@@ -28,7 +28,7 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
     }]
   })
 
-  tests.dht(CommonFactory.create({
+  tests.dht(CommonFactory.createAsync({
     spawnOptions: {
       initOptions: { bits: 512 },
       config: {
@@ -54,7 +54,7 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
 
   tests.filesMFS(defaultCommonFactory)
 
-  tests.key(CommonFactory.create({
+  tests.key(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--pass ipfs-is-awesome-software'],
       initOptions: { bits: 512 },
@@ -73,21 +73,19 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
     }
   }))
 
-  tests.miscellaneous(CommonFactory.create({
-    // No need to stop, because the test suite does a 'stop' test.
-    createTeardown: () => cb => cb(),
+  tests.miscellaneous(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--pass ipfs-is-awesome-software', '--offline']
     }
   }))
 
-  tests.name(CommonFactory.create({
+  tests.name(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--pass ipfs-is-awesome-software', '--offline']
     }
   }))
 
-  tests.namePubsub(CommonFactory.create({
+  tests.namePubsub(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--enable-namesys-pubsub'],
       initOptions: { bits: 1024 },
@@ -118,7 +116,7 @@ describe('interface-ipfs-core over ipfs-http-client tests', () => {
 
   tests.ping(defaultCommonFactory)
 
-  tests.pubsub(CommonFactory.create({
+  tests.pubsub(CommonFactory.createAsync({
     spawnOptions: {
       initOptions: { bits: 512 }
     }

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -16,7 +16,7 @@ const DEFAULT_FACTORY_OPTIONS = {
 function createFactory (options) {
   options = options || {}
 
-  options.factoryOptions = options.factoryOptions || DEFAULT_FACTORY_OPTIONS
+  options.factoryOptions = options.factoryOptions || { ...DEFAULT_FACTORY_OPTIONS }
   options.spawnOptions = mergeOptions({
     initOptions: { bits: 512 },
     config: {
@@ -78,8 +78,9 @@ function createAsync (options = {}) {
     const nodes = []
     const setup = async (setupOptions = {}) => {
       options.factoryOptions = mergeOptions(
+        options.factoryOptions ? {} : { ...DEFAULT_FACTORY_OPTIONS },
         setupOptions.factoryOptions,
-        options.factoryOptions || DEFAULT_FACTORY_OPTIONS
+        options.factoryOptions
       )
 
       // When not an in proc daemon use the http-client js-ipfs depends on, not the one from ipfsd-ctl


### PR DESCRIPTION
This PR allows `interface-core` tests to create and spawn nodes asynchronously.

Related to:
https://github.com/ipfs/interface-js-ipfs-core/pull/562