### PR TITLE
fix: bootstrap rm return value when all option is set

### DIFF
--- a/src/core/components/bootstrap.js
+++ b/src/core/components/bootstrap.js
@@ -45,8 +45,10 @@ module.exports = function bootstrap (self) {
         throw invalidMultiaddrError(multiaddr)
       }
 
+      let res = []
       const config = await self._repo.config.get()
       if (args.all) {
+        res = config.Bootstrap
         config.Bootstrap = []
       } else {
         config.Bootstrap = config.Bootstrap.filter((mh) => mh !== multiaddr)
@@ -54,7 +56,6 @@ module.exports = function bootstrap (self) {
 
       await self._repo.config.set(config)
 
-      const res = []
       if (!args.all && multiaddr) {
         res.push(multiaddr)
       }

--- a/test/cli/bootstrap.js
+++ b/test/cli/bootstrap.js
@@ -94,10 +94,12 @@ describe('bootstrap', () => runOnAndOff((thing) => {
   it('rm all bootstrap nodes', async function () {
     this.timeout(40 * 1000)
 
-    const out = await ipfs('bootstrap rm --all')
-    expect(out).to.equal('')
+    const outListBefore = await ipfs('bootstrap list')
 
-    const out2 = await ipfs('bootstrap list')
-    expect(out2).to.equal('')
+    const outRm = await ipfs('bootstrap rm --all')
+    expect(outRm).to.equal(outListBefore)
+
+    const outListAfter = await ipfs('bootstrap list')
+    expect(outListAfter).to.equal('')
   })
 }))

--- a/test/http-api/inject/bootstrap.js
+++ b/test/http-api/inject/bootstrap.js
@@ -83,7 +83,7 @@ module.exports = (http) => {
       })
 
       expect(res.statusCode).to.be.eql(200)
-      expect(res.result.Peers).to.be.eql([])
+      expect(res.result.Peers).to.be.eql(defaultList)
     })
   })
 }


### PR DESCRIPTION
This PR fixes the return value of `bootstrap.rm()` when `all` option is set.

i.e.:
```ipfs.bootstrap.rm({ all: true })``` was returning `{ Peers: [] }`

But it should return `{ Peers: [address1, address2, ...] }` instead.