### PR TITLE
feat: add human flag to repo stat cli command

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ipfs-http-response": "~0.4.0",
     "ipfs-mfs": "^0.13.0",
     "ipfs-multipart": "^0.2.0",
-    "ipfs-repo": "^0.29.0",
+    "ipfs-repo": "github:ipfs/js-ipfs-repo#feat/remove-options-object-from-stat",
     "ipfs-unixfs": "~0.1.16",
     "ipfs-unixfs-exporter": "^0.38.0",
     "ipfs-unixfs-importer": "^0.40.0",

--- a/src/cli/commands/repo/stat.js
+++ b/src/cli/commands/repo/stat.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const prettyBytes = require('pretty-bytes')
+
 module.exports = {
   command: 'stat',
 
@@ -15,14 +17,23 @@ module.exports = {
 
   handler (argv) {
     argv.resolve((async () => {
-      const ipfs = await argv.getIpfs()
-      const stats = await ipfs.repo.stat({ human: argv.human })
-      argv.print(`repo status
-  number of objects: ${stats.numObjects}
-  repo size: ${stats.repoSize}
-  repo path: ${stats.repoPath}
-  version: ${stats.version}
-  maximum storage: ${stats.storageMax}`)
+      const { getIpfs, human } = argv
+
+      const ipfs = await getIpfs()
+      const stats = await ipfs.repo.stat()
+
+      if (human) {
+        stats.numObjects = stats.numObjects.toNumber()
+        stats.repoSize = prettyBytes(stats.repoSize.toNumber()).toUpperCase()
+        stats.storageMax = prettyBytes(stats.storageMax.toNumber()).toUpperCase()
+      }
+
+      argv.print(
+`NumObjects: ${stats.numObjects}
+RepoSize: ${stats.repoSize}
+StorageMax: ${stats.storageMax}
+RepoPath: ${stats.repoPath}
+Version: ${stats.version}`)
     })())
   }
 }

--- a/src/core/components/repo.js
+++ b/src/core/components/repo.js
@@ -40,10 +40,8 @@ module.exports = function repo (self) {
 
     gc: require('./pin/gc')(self),
 
-    stat: callbackify.variadic(async (options) => {
-      options = options || {}
-
-      const stats = await self._repo.stat(options)
+    stat: callbackify.variadic(async () => {
+      const stats = await self._repo.stat()
 
       return {
         numObjects: stats.numObjects,

--- a/src/http/api/resources/repo.js
+++ b/src/http/api/resources/repo.js
@@ -35,8 +35,7 @@ exports.version = async (request, h) => {
 
 exports.stat = async (request, h) => {
   const { ipfs } = request.server.app
-  const human = request.query.human === 'true'
-  const stat = await ipfs.repo.stat({ human })
+  const stat = await ipfs.repo.stat()
 
   return h.response({
     NumObjects: stat.numObjects,

--- a/test/cli/repo.js
+++ b/test/cli/repo.js
@@ -12,6 +12,24 @@ describe('repo', () => runOnAndOff((thing) => {
     ipfs = thing.ipfs
   })
 
+  it('get repo stats', async () => {
+    const stats = await ipfs('repo stat')
+    expect(stats).to.match(/^NumObjects:\s\d+$/m)
+    expect(stats).to.match(/^RepoSize:\s\d+$/m)
+    expect(stats).to.match(/^StorageMax:\s\d+$/m)
+    expect(stats).to.match(/^RepoPath:\s.+$/m)
+    expect(stats).to.match(/^Version:\s\d+$/m)
+  })
+
+  it('get human readable repo stats', async () => {
+    const stats = await ipfs('repo stat --human')
+    expect(stats).to.match(/^NumObjects:\s\d+$/m)
+    expect(stats).to.match(/^RepoSize:\s+[\d.]+\s[PTGMK]?B$/gm)
+    expect(stats).to.match(/^StorageMax:\s+[\d.]+\s[PTGMK]?B$/gm)
+    expect(stats).to.match(/^RepoPath:\s.+$/m)
+    expect(stats).to.match(/^Version:\s\d+$/m)
+  })
+
   it('get the repo version', async () => {
     const out = await ipfs('repo version')
     expect(out).to.eql(`${repoVersion}\n`)


### PR DESCRIPTION
This PR adds `--human` flag to `repo stat` command.

**Usage:** 
```sh
> jsipfs repo stat --human
```

**Output:**
```sh
NumObjects: 16
RepoSize: 30.1 KB
StorageMax: 9.01 PB
RepoPath: /var/folders/l1/(...)
Version: 7
```

This PR supersedes https://github.com/ipfs/js-ipfs/pull/2592. 
Reason: https://github.com/ipfs/js-ipfs-repo/pull/213#issuecomment-555488344.

⚠️This PR needs the following PR merged and released before this one can be:
- [ ] https://github.com/ipfs/js-ipfs-repo/pull/216