### PR TITLE
perf: debounce pin flush

### DIFF
--- a/src/core/components/pin.js
+++ b/src/core/components/pin.js
@@ -59,7 +59,7 @@ module.exports = (self) => {
         results.forEach(key => pinset.add(key))
 
         // persist updated pin sets to datastore
-        await pinManager.flushPins()
+        pinManager.flushPins()
 
         return results.map(hash => ({ hash }))
       }
@@ -134,7 +134,7 @@ module.exports = (self) => {
         })
 
         // persist updated pin sets to datastore
-        await pinManager.flushPins()
+        pinManager.flushPins()
 
         self.log(`Removed pins: ${results}`)
 

--- a/src/core/components/pin/pin-manager.js
+++ b/src/core/components/pin/pin-manager.js
@@ -10,7 +10,8 @@ const multicodec = require('multicodec')
 const dagCborLinks = require('dag-cbor-links')
 const debug = require('debug')
 const { cidToString } = require('../../../utils/cid')
-
+const delay = require('delay')
+const AbortController = require('abort-controller')
 const createPinSet = require('./pin-set')
 
 const { Errors } = require('interface-datastore')
@@ -106,43 +107,65 @@ class PinManager {
   // Encode and write pin key sets to the datastore:
   // a DAGLink for each of the recursive and direct pinsets
   // a DAGNode holding those as DAGLinks, a kind of root pin
-  async flushPins () {
-    const [
-      dLink,
-      rLink
-    ] = await Promise.all([
-      // create a DAGLink to the node with direct pins
-      this.pinset.storeSet(this.directKeys())
-        .then((result) => {
-          return new DAGLink(PinTypes.direct, result.node.size, result.cid)
-        }),
-      // create a DAGLink to the node with recursive pins
-      this.pinset.storeSet(this.recursiveKeys())
-        .then((result) => {
-          return new DAGLink(PinTypes.recursive, result.node.size, result.cid)
-        }),
-      // the pin-set nodes link to a special 'empty' node, so make sure it exists
-      this.dag.put(new DAGNode(Buffer.alloc(0)), {
-        version: 0,
-        format: multicodec.DAG_PB,
-        hashAlg: multicodec.SHA2_256,
-        preload: false
-      })
-    ])
+  async flushPins () { // eslint-disable-line require-await
+    if (this._flushingPins) {
+      this._flushingPins.controller.abort()
+    }
 
-    // create a root node with DAGLinks to the direct and recursive DAGs
-    const rootNode = new DAGNode(Buffer.alloc(0), [dLink, rLink])
-    const rootCid = await this.dag.put(rootNode, {
-      version: 0,
-      format: multicodec.DAG_PB,
-      hashAlg: multicodec.SHA2_256,
-      preload: false
-    })
+    const controller = new AbortController()
 
-    // save root to datastore under a consistent key
-    await this.repo.datastore.put(PIN_DS_KEY, rootCid.buffer)
+    this._flushingPins = {
+      controller,
+      promise: delay(100)
+        .then(async () => {
+          if (controller.signal.aborted) {
+          // return current promise that is flushing pins
+            return this._flushingPins.promise
+          }
 
-    this.log(`Flushed pins with root: ${rootCid}`)
+          this._flushingPins = null
+
+          const [
+            dLink,
+            rLink
+          ] = await Promise.all([
+          // create a DAGLink to the node with direct pins
+            this.pinset.storeSet(this.directKeys())
+              .then((result) => {
+                return new DAGLink(PinTypes.direct, result.node.size, result.cid)
+              }),
+            // create a DAGLink to the node with recursive pins
+            this.pinset.storeSet(this.recursiveKeys())
+              .then((result) => {
+                return new DAGLink(PinTypes.recursive, result.node.size, result.cid)
+              }),
+            // the pin-set nodes link to a special 'empty' node, so make sure it exists
+            this.dag.put(new DAGNode(Buffer.alloc(0)), {
+              version: 0,
+              format: multicodec.DAG_PB,
+              hashAlg: multicodec.SHA2_256,
+              preload: false
+            })
+          ])
+
+          // create a root node with DAGLinks to the direct and recursive DAGs
+          const rootNode = new DAGNode(Buffer.alloc(0), [dLink, rLink])
+          const rootCid = await this.dag.put(rootNode, {
+            version: 0,
+            format: multicodec.DAG_PB,
+            hashAlg: multicodec.SHA2_256,
+            preload: false
+          })
+
+          // save root to datastore under a consistent key
+          await this.repo.datastore.put(PIN_DS_KEY, rootCid.buffer)
+
+          this.log(`Flushed pins with root: ${rootCid}`)
+        })
+        .catch(err => this.log(`Could not flush pins: ${err}`))
+    }
+
+    return this._flushingPins.promise
   }
 
   async load () {


### PR DESCRIPTION
When importing a directory of files, after every block is added we pin it and flush pins to the repo.  This is really slow and if we are adding lots of files, the pinset is out of date almost immediately so this PR debounces flushing pins until after we've stopped adding things.
    
A call to `pinManager.flushPins` will return a promise, and that promise will resolve once the pins have been flushed, but it will first wait 100ms and see if any subsequent flushes have been requested in that time - if so that promise will end early and return the promise created by the later flush request.