### PR TITLE
chore: split test jobs into stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
 stages:
   - check
   - test
+  - interop
+  - externals
+  - examples
   - tag
 
 node_js:
@@ -73,193 +76,193 @@ jobs:
       script:
         - npx aegir test -t electron-renderer --bail --timeout 10000
 
-    - stage: test
-      name: interop - node
+    - stage: interop
+      name: node
       script:
         - cd node_modules/ipfs-interop
         - IPFS_JS_EXEC=./../../src/cli/bin.js IPFS_REUSEPORT=false npx aegir test -t node --bail
 
-    - stage: test
-      name: interop - browser
+    - stage: interop
+      name: browser
       script:
         - cd node_modules/ipfs-interop
         - IPFS_JS_EXEC=./../../src/cli/bin.js IPFS_REUSEPORT=false npx aegir test -t browser --bail
 
-    - stage: test
-      name: interop - electron-main
+    - stage: interop
+      name: electron-main
       os: osx
       script:
         - cd node_modules/ipfs-interop
         - IPFS_JS_EXEC=./../../src/cli/bin.js IPFS_REUSEPORT=false npx aegir test -t electron-main -f ./test/node.js --bail --timeout 10000
 
-    - stage: test
-      name: interop - electron-renderer
+    - stage: interop
+      name: electron-renderer
       os: osx
       script:
         - cd node_modules/ipfs-interop
         - IPFS_JS_EXEC=./../../src/cli/bin.js IPFS_REUSEPORT=false npx aegir test -t electron-renderer -f ./test/browser.js --bail --timeout 10000
 
-    - stage: test
-      name: external - ipfs-companion
+    - stage: externals
+      name: ipfs-companion
       script:
         - npm run test:external -- ipfs-companion https://github.com/ipfs-shipyard/ipfs-companion.git
 
-    - stage: test
-      name: external - npm-on-ipfs
+    - stage: externals
+      name: npm-on-ipfs
       script:
         - npm run test:external -- npm-on-ipfs https://github.com/ipfs-shipyard/npm-on-ipfs.git
 
-    - stage: test
-      name: external - ipfs-pubsub-room
+    - stage: externals
+      name: ipfs-pubsub-room
       script:
         - npm run test:external -- ipfs-pubsub-room https://github.com/ipfs-shipyard/ipfs-pubsub-room.git --branch upgrade-to-latest-js-ipfs-rc
 
-    - stage: test
-      name: external - peer-base
+    - stage: externals
+      name: peer-base
       script:
         - npm run test:external -- peer-base https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc
 
-    - stage: test
-      name: external - service-worker-gateway
+    - stage: externals
+      name: service-worker-gateway
       script:
         - npm run test:external -- service-worker-gateway https://github.com/ipfs-shipyard/service-worker-gateway.git
 
-    - stage: test
-      name: external - orbit-db
+    - stage: externals
+      name: orbit-db
       script:
         - npm run test:external -- orbit-db https://github.com/orbitdb/orbit-db.git
 
-    - stage: test
-      name: external - ipfs-log
+    - stage: externals
+      name: ipfs-log
       script:
         - npm run test:external -- ipfs-log https://github.com/orbitdb/ipfs-log.git
 
-    - stage: test
-      name: external - sidetree
+    - stage: externals
+      name: sidetree
       script:
         - npm run test:external -- sidetree https://github.com/decentralized-identity/sidetree.git
 
-    - stage: test
-      name: example - browser-add-readable-stream
+    - stage: examples
+      name: browser-add-readable-stream
       script:
         - cd examples
         - npm install
         - npm run test -- browser-add-readable-stream
 
-    - stage: test
-      name: example - browser-browserify
+    - stage: examples
+      name: browser-browserify
       script:
         - cd examples
         - npm install
         - npm run test -- browser-browserify
 
-    - stage: test
-      name: example - browser-create-react-app
+    - stage: examples
+      name: browser-create-react-app
       script:
         - cd examples
         - npm install
         - npm run test -- browser-create-react-app
 
-    - stage: test
-      name: example - browser-mfs
+    - stage: examples
+      name: browser-mfs
       script:
         - cd examples
         - npm install
         - npm run test -- browser-mfs
 
-    - stage: test
-      name: example - browser-parceljs
+    - stage: examples
+      name: browser-parceljs
       script:
         - cd examples
         - npm install
         - npm run test -- browser-parceljs
 
-    - stage: test
-      name: example - browser-readablestream
+    - stage: examples
+      name: browser-readablestream
       script:
         - cd examples
         - npm install
         - npm run test -- browser-readablestream
 
-    - stage: test
-      name: example - browser-script-tag
+    - stage: examples
+      name: browser-script-tag
       script:
         - cd examples
         - npm install
         - npm run test -- browser-script-tag
 
-    - stage: test
-      name: example - browser-video-streaming
+    - stage: examples
+      name: browser-video-streaming
       script:
         - cd examples
         - npm install
         - npm run test -- browser-video-streaming
 
-    - stage: test
-      name: example - browser-vue
+    - stage: examples
+      name: browser-vue
       script:
         - cd examples
         - npm install
         - npm run test -- browser-vue
 
-    - stage: test
-      name: example - browser-webpack
+    - stage: examples
+      name: browser-webpack
       script:
         - cd examples
         - npm install
         - npm run test -- browser-webpack
 
-    - stage: test
-      name: example - circuit-relaying
+    - stage: examples
+      name: circuit-relaying
       script:
         - cd examples
         - npm install
         - npm run test -- circuit-relaying
 
-    - stage: test
-      name: example - custom-ipfs-repo
+    - stage: examples
+      name: custom-ipfs-repo
       script:
         - cd examples
         - npm install
         - npm run test -- custom-ipfs-repo
 
-    - stage: test
-      name: example - custom-libp2p
+    - stage: examples
+      name: custom-libp2p
       script:
         - cd examples
         - npm install
         - npm run test -- custom-libp2p
 
-    - stage: test
-      name: example - exchange-files-in-browser
+    - stage: examples
+      name: exchange-files-in-browser
       script:
         - cd examples
         - npm install
         - npm run test -- exchange-files-in-browser
 
-    - stage: test
-      name: example - explore-ethereum-blockchain
+    - stage: examples
+      name: explore-ethereum-blockchain
       script:
         - cd examples
         - npm install
         - npm run test -- explore-ethereum-blockchain
 
-    - stage: test
-      name: example - ipfs-101
+    - stage: examples
+      name: ipfs-101
       script:
         - cd examples
         - npm install
         - npm run test -- ipfs-101
 
-    - stage: test
-      name: example - running-multiple-nodes
+    - stage: examples
+      name: running-multiple-nodes
       script:
         - cd examples
         - npm install
         - npm run test -- running-multiple-nodes
 
-    - stage: test
-      name: example - traverse-ipld-graphs
+    - stage: examples
+      name: traverse-ipld-graphs
       script:
         - cd examples
         - npm install


### PR DESCRIPTION
The current test stage uses _all_ the workers we have available in Travis and starves other projects from running their tests. This change separates interop, externals and examples into stages that only execute if the previous was successful. This means that we use fewer workers concurrently and fewer workers overall since a failure in the main tests will not process and run interop/externals and examples tests. This is at the expense of slower overall CI.