### PR TITLE
fix: requires the ipfs-repo version with a fix for #2629 at a minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ipfs-http-response": "~0.3.1",
     "ipfs-mfs": "^0.13.0",
     "ipfs-multipart": "^0.2.0",
-    "ipfs-repo": "^0.28.0",
+    "ipfs-repo": "^0.28.2",
     "ipfs-unixfs": "~0.1.16",
     "ipfs-unixfs-exporter": "^0.38.0",
     "ipfs-unixfs-importer": "^0.40.0",


### PR DESCRIPTION
Fixes #2629 and restores access to pre-0.39.0 repos though any repos created with 0.39.0 will not be accessible by default.

Should be released in a patch release to `v0.39.0`.