### PR TITLE
refactor: aegir pre and post hooks on both node and browser

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,10 +1,8 @@
 'use strict'
 
 const IPFSFactory = require('ipfsd-ctl')
-const parallel = require('async/parallel')
 const MockPreloadNode = require('./test/utils/mock-preload-node')
 const EchoServer = require('interface-ipfs-core/src/utils/echo-http-server')
-const callbackify = require('callbackify')
 
 const ipfsdServer = IPFSFactory.createServer()
 const preloadNode = MockPreloadNode.createNode()
@@ -29,40 +27,26 @@ module.exports = {
   },
   hooks: {
     node: {
-      pre: (cb) => {
-        parallel([
-          (cb) => callbackify(preloadNode.start)(cb),
-          (cb) => echoServer.start(cb)
-        ], cb)
-      },
-      post: (cb) => {
-        parallel([
-          (cb) => callbackify(preloadNode.stop)(cb),
-          (cb) => echoServer.stop(cb)
-        ], cb)
-      }
+      pre: () => Promise.all([
+        preloadNode.start(),
+        echoServer.start()
+      ]),
+      post: () => Promise.all([
+        preloadNode.stop(),
+        echoServer.stop()
+      ])
     },
     browser: {
-      pre: (cb) => {
-        parallel([
-          (cb) => {
-            ipfsdServer.start()
-            cb()
-          },
-          (cb) => callbackify(preloadNode.start)(cb),
-          (cb) => echoServer.start(cb)
-        ], cb)
-      },
-      post: (cb) => {
-        parallel([
-          (cb) => {
-            ipfsdServer.stop()
-            cb()
-          },
-          (cb) => callbackify(preloadNode.stop)(cb),
-          (cb) => echoServer.stop(cb)
-        ], cb)
-      }
+      pre: () => Promise.all([
+        ipfsdServer.start(),
+        preloadNode.start(),
+        echoServer.start()
+      ]),
+      post: () => Promise.all([
+        ipfsdServer.stop(),
+        preloadNode.stop(),
+        echoServer.stop()
+      ])
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#refactor/http-server-util",
+    "interface-ipfs-core": "^0.124.0",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "execa": "^3.0.0",
     "form-data": "^3.0.0",
     "hat": "0.0.3",
-    "interface-ipfs-core": "^0.121.0",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#refactor/http-server-util",
     "ipfs-interop": "^0.1.1",
     "ipfsd-ctl": "^0.47.2",
     "libp2p-websocket-star": "~0.10.2",


### PR DESCRIPTION
This PR refactors `.aegir.js` `pre` and `post` hooks. Both of them do not need `async/parallel` anymore as they are returning a `promise` instead.

Depends on:
- https://github.com/ipfs/interface-js-ipfs-core/pull/565