### PR TITLE
chore: update libp2p-keychain dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "libp2p-floodsub": "^0.18.0",
     "libp2p-gossipsub": "~0.0.5",
     "libp2p-kad-dht": "~0.16.0",
-    "libp2p-keychain": "^0.5.1",
+    "libp2p-keychain": "^0.5.2",
     "libp2p-mdns": "~0.12.0",
     "libp2p-record": "~0.7.0",
     "libp2p-secio": "~0.11.0",


### PR DESCRIPTION
Was causing 2 versions of node-forge to be included in the bundle.