### PR TITLE
feat: add --hidden flag to cli add command

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -11,7 +11,7 @@ const preloadNode = MockPreloadNode.createNode()
 const echoServer = EchoServer.createServer()
 
 module.exports = {
-  bundlesize: { maxSize: '650kB' },
+  bundlesize: { maxSize: '651kB' },
   webpack: {
     resolve: {
       mainFields: ['browser', 'main'],

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -106,6 +106,12 @@ module.exports = {
       type: 'boolean',
       default: true,
       describe: 'Preload this object when adding'
+    },
+    hidden: {
+      alias: 'H',
+      type: 'boolean',
+      default: false,
+      describe: 'Include files that are hidden. Only takes effect on recursive add.'
     }
   },
 
@@ -153,7 +159,7 @@ module.exports = {
       }
 
       const source = argv.file
-        ? globSource(argv.file, { recursive: argv.recursive })
+        ? globSource(argv.file, { recursive: argv.recursive, hidden: argv.hidden })
         : process.stdin // Pipe directly to ipfs.add
 
       let finalHash

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -165,6 +165,13 @@ describe('files', () => runOnAndOff((thing) => {
     expect(out).to.equal(recursiveGetDirResults.join('\n') + '\n')
   })
 
+  it('add recursively including hidden files', async function () {
+    this.timeout(60 * 1000)
+
+    const out = await ipfs('add -r -H test/fixtures/test-data/recursive-get-dir')
+    expect(out).to.include('added QmdBd5zgdJQHsyaaAm9Vnth7NWwj23gj3Ew17r6bTvVkch recursive-get-dir/.hidden.txt')
+  })
+
   it('add directory with trailing slash test', async function () {
     this.timeout(30 * 1000)
 

--- a/test/cli/files.js
+++ b/test/cli/files.js
@@ -417,12 +417,12 @@ describe('files', () => runOnAndOff((thing) => {
   it('get recursively', async function () {
     this.timeout(20 * 1000)
 
-    const outDir = path.join(process.cwd(), 'Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z')
+    const outDir = path.join(process.cwd(), 'QmTCaAvZ5dquoa2jrgTRa3gn9n4Ymrz8mEdePP8jiaTvf9')
     rimraf(outDir)
 
-    const out = await ipfs('get Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z')
+    const out = await ipfs('get QmTCaAvZ5dquoa2jrgTRa3gn9n4Ymrz8mEdePP8jiaTvf9')
     expect(out).to.eql(
-      'Saving file(s) Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z\n'
+      'Saving file(s) QmTCaAvZ5dquoa2jrgTRa3gn9n4Ymrz8mEdePP8jiaTvf9\n'
     )
 
     const expectedDir = path.join(process.cwd(), 'test', 'fixtures', 'test-data', 'recursive-get-dir')

--- a/test/fixtures/test-data/recursive-get-dir/.hidden.txt
+++ b/test/fixtures/test-data/recursive-get-dir/.hidden.txt
@@ -1,0 +1,1 @@
+This file is hidden!


### PR DESCRIPTION
This PR adds `--hidden` flag to CLI's `add` command.

Closes #1917.