### PR TITLE
chore: revert #2647 upgrade to libp2p-delegated-content-routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "libp2p": "^0.26.2",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-crypto": "^0.16.2",
-    "libp2p-delegated-content-routing": "^0.4.1",
+    "libp2p-delegated-content-routing": "^0.3.1",
     "libp2p-delegated-peer-routing": "^0.3.1",
     "libp2p-floodsub": "^0.18.0",
     "libp2p-gossipsub": "~0.0.5",


### PR DESCRIPTION
Reverts ipfs/js-ipfs#2647 to see if it fixes the examples.