### PR TITLE
fix: skipped object.stat test

### DIFF
--- a/test/http-api/interface.js
+++ b/test/http-api/interface.js
@@ -89,14 +89,7 @@ describe('interface-ipfs-core over ipfs-http-client tests', function () {
     }
   }), overrides))
 
-  tests.object(commonFactory, {
-    skip: [
-      {
-        name: 'should respect timeout option',
-        reason: 'js-ipfs doesn\'t support timeout yet'
-      }
-    ]
-  })
+  tests.object(commonFactory)
 
   tests.pin(commonFactory)
 


### PR DESCRIPTION
This PR unskips `should respect timeout option` test of `object.stat()` over http-api as timeout is currently implemented as you can see [here](https://github.com/ipfs/js-ipfs-http-client/blob/master/src/object/stat.js#L22-L27). There's no need to be skipped. 