### PR TITLE
fix: unskip bitswap.wantlist test

### DIFF
--- a/test/core/interface.spec.js
+++ b/test/core/interface.spec.js
@@ -33,12 +33,7 @@ describe('interface-ipfs-core tests', function () {
   }
   const commonFactory = createFactory(commonOptions, overrides)
 
-  tests.bitswap(commonFactory, {
-    skip: isNode ? null : [{
-      name: 'should get the wantlist by peer ID for a different node',
-      reason: 'FIXME: Does not find wantlist list in the browser'
-    }]
-  })
+  tests.bitswap(commonFactory)
 
   tests.block(commonFactory)
 


### PR DESCRIPTION
`bitswap.wantlist()` doesn't need to be skipped anymore in the browser. The problem was solved on https://github.com/ipfs/interface-js-ipfs-core/pull/564 by [this commit](https://github.com/ipfs/interface-js-ipfs-core/pull/564/commits/6881e7274fb8c0e91eceeeaf862d7de3dffc4281).