### PR TITLE
fix: correct redirect when it loads webui #2697

### DIFF
--- a/src/http/api/routes/webui.js
+++ b/src/http/api/routes/webui.js
@@ -20,7 +20,7 @@ module.exports = [
         const address = multiaddr(gateway).nodeAddress()
 
         port = address.port
-        host = address.host
+        host = address.address
       } catch (err) {
         // may not have gateway configured
         log.error(err)


### PR DESCRIPTION
Ref: [#2697 ]

This PR fixes the issue of being redirected to `http://undefined:9090/ipfs/...` after hitting webui URL.

License: MIT
Signed-off-by: ggarri <gabriel@lightstreams.io>