### PR TITLE
test: E2E tests against ipfs-webui HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,11 @@ jobs:
         - npm run test:interop:electron-renderer -- --bail --timeout 10000
 
     - stage: test
+      name: external - ipfs-webui
+      script:
+        - E2E_IPFSD_TYPE=js npm run test:external -- ipfs-webui https://github.com/ipfs-shipyard/ipfs-webui.git
+
+    - stage: test
       name: external - ipfs-companion
       script:
         - npm run test:external -- ipfs-companion https://github.com/ipfs-shipyard/ipfs-companion.git


### PR DESCRIPTION
> Parent: https://github.com/ipfs-shipyard/ipfs-webui/issues/1164
> go-ipfs counterpart: https://github.com/ipfs/go-ipfs/pull/6825

This PR adds TravisCI config for running ipfs-webui's end to end tests against js-ipfs from  this repo.

It does not increase CI time, as its runs in parallel to other tests, and those take much longer:

> ![time](https://user-images.githubusercontent.com/157609/72625409-09eacc80-3949-11ea-978c-ccf05a5371cc.png)

**Note:** It uses `aegir test-external` which runs tests twice: first time against release version of js-ipfs, and if that is green, then against version from this repo. If not, we exit without error. That way we avoid breaking the js-ipfs build if upstream ipfs-webui is not green. 


### TODO


- [x] webui needs `build` before e2e runx
- [x] ensure binary from `HEAD` is used during second time webui's `test`  is run
	- ipfs-webui switched  to [ipfsd-ctl v1.0.6](https://github.com/ipfs/js-ipfsd-ctl/releases/tag/v1.0.6) with a fix
- [x] there is false-positive bug that needs to be fixed
  - <del>suspect:  `aegir test-external` returns `0` if test with original `js-ipfs` fails</del> its by design ;)

cc @autonome @hugomrdias @alanshaw 