### PR TITLE
chore: allow externals to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,15 @@ after_success:
   - npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
 jobs:
+  allow_failures:
+    - name: external - ipfs-companion
+    - name: external - npm-on-ipfs
+    - name: external - ipfs-pubsub-room
+    - name: external - peer-base
+    - name: external - service-worker-gateway
+    - name: external - orbit-db
+    - name: external - ipfs-log
+    - name: external - sidetree
   include:
     - stage: check
       script:


### PR DESCRIPTION
We need to publish an rc for people to use to refactor their code to use the new API.
    
The `aegir` release commands require the `last-successful` build to have run in order to update the last known good build branch.
    
That build will not run until the external builds pass but we can't make them pass until they can be refactored to use the new API for which we need an rc.
    
The change to the `.travis.yml` in this PR allows the overall build to pass even though the external module builds are faiilng.

Depends on:

- [x] #2729 