### PR TITLE
chore: enable caching, disable on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+cache: npm
 
 branches:
   only:
@@ -50,6 +51,9 @@ jobs:
     - name: external - ipfs-log
     - name: external - sidetree
   include:
+    - os: windows
+      cache: false
+
     - stage: check
       script:
         - npx aegir build --bundlesize


### PR DESCRIPTION
From what I remember, we disabled npm caching in this build because windows builds were timing out when it tried to restore the cache due to no output being received.

This change re-enables caching but turns it off on windows so at least the other builds should be faster.