### PR TITLE
fix: report correct swarm addresses after listening on new addrs

### DIFF
--- a/src/core/components/id.js
+++ b/src/core/components/id.js
@@ -3,15 +3,20 @@
 const pkgversion = require('../../../package.json').version
 const multiaddr = require('multiaddr')
 
-module.exports = ({ peerInfo }) => {
+module.exports = ({ peerInfo, libp2p }) => {
   return async function id () { // eslint-disable-line require-await
     const id = peerInfo.id.toB58String()
+    let addresses = []
+
+    if (libp2p) {
+      // only available while the node is running
+      addresses = libp2p.transportManager.getAddrs()
+    }
 
     return {
       id,
       publicKey: peerInfo.id.pubKey.bytes.toString('base64'),
-      addresses: peerInfo.multiaddrs
-        .toArray()
+      addresses: addresses
         .map(ma => {
           const str = ma.toString()
 

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -208,7 +208,7 @@ function createApi ({
     dns,
     files,
     get: Components.get({ ipld, preload }),
-    id: Components.id({ peerInfo }),
+    id: Components.id({ peerInfo, libp2p }),
     init: async () => { throw new AlreadyInitializedError() }, // eslint-disable-line require-await
     isOnline,
     key: {

--- a/test/core/id.spec.js
+++ b/test/core/id.spec.js
@@ -1,0 +1,52 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
+const multiaddr = require('multiaddr')
+const { isBrowser, isWebWorker } = require('ipfs-utils/src/env')
+const factory = require('../utils/factory')
+
+describe('id', function () {
+  this.timeout(60 * 1000)
+  const df = factory()
+  let node
+
+  before(async () => {
+    node = (await df.spawn({
+      type: 'proc',
+      ipfsOptions: {
+        config: {
+          Addresses: {
+            Swarm: []
+          }
+        }
+      }
+    })).api
+  })
+
+  after(async () => {
+    await node.stop()
+  })
+
+  it('should return swarm ports opened after startup', async function () {
+    if (isWebWorker) {
+      // TODO: webworkers are not currently dialable
+      return this.skip()
+    }
+
+    await expect(node.id()).to.eventually.have.property('addresses').that.is.empty()
+
+    let servers = [
+      multiaddr('/ip4/127.0.0.1/tcp/0')
+    ]
+
+    if (isBrowser) {
+      servers = [
+        multiaddr('/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star')
+      ]
+    }
+
+    await node.libp2p.transportManager.listen(servers)
+    await expect(node.id()).to.eventually.have.property('addresses').that.is.not.empty()
+  })
+})


### PR DESCRIPTION
The user may start the node with no swarm addresses to speed up startup times - if they then use libp2p to listen on new transports we should return the addresses currently being listened on instead of those configured at startup.

refs #2508