### PR TITLE
chore(package): update ipfs-utils to version 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "ipfs-unixfs": "^0.3.0",
     "ipfs-unixfs-exporter": "^0.41.0",
     "ipfs-unixfs-importer": "^0.44.0",
-    "ipfs-utils": "^0.7.1",
+    "ipfs-utils": "^0.7.2",
     "ipld": "~0.25.0",
     "ipld-bitcoin": "~0.3.0",
     "ipld-dag-cbor": "~0.15.0",


### PR DESCRIPTION
Fixes a problem where `--preserve-mtime` was not working.