### PR TITLE
chore: remove ipfs-pubsub-room from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
   allow_failures:
     - name: external - ipfs-companion
     - name: external - npm-on-ipfs
-    - name: external - ipfs-pubsub-room
     - name: external - peer-base
     - name: external - service-worker-gateway
     - name: external - orbit-db
@@ -127,11 +126,6 @@ jobs:
       name: external - npm-on-ipfs
       script:
         - npm run test:external -- npm-on-ipfs https://github.com/ipfs-shipyard/npm-on-ipfs.git
-
-    - stage: test
-      name: external - ipfs-pubsub-room
-      script:
-        - npm run test:external -- ipfs-pubsub-room https://github.com/ipfs-shipyard/ipfs-pubsub-room.git
 
     - stage: test
       name: external - peer-base

--- a/docs/RELEASE_ISSUE_TEMPLATE.md
+++ b/docs/RELEASE_ISSUE_TEMPLATE.md
@@ -32,7 +32,6 @@
       - [ ] ~~[ipfs-desktop](https://github.com/ipfs-shipyard/ipfs-desktop)~~ (Does not depend on `js-ipfs` or `js-ipfs-http-client`)
       - [ ] [ipfs-companion](https://github.com/ipfs-shipyard/ipfs-companion)
       - [ ] [npm-on-ipfs](https://github.com/ipfs-shipyard/npm-on-ipfs)
-      - [ ] [ipfs-pubsub-room](https://github.com/ipfs-shipyard/ipfs-pubsub-room)
       - [ ] [peer-base](https://github.com/peer-base/peer-base)
       - [ ] [service-worker-gateway](https://github.com/ipfs-shipyard/service-worker-gateway)
     - [ ] Third party application testing


### PR DESCRIPTION
It does not depend on IPFS or the HTTP client.

https://github.com/ipfs-shipyard/ipfs-pubsub-room

Looks like this was a recent change https://github.com/ipfs-shipyard/ipfs-pubsub-room/pull/73