### PR TITLE
docs: add temporary upgrade note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <br>
 </p>
 
-> **Upgrading from <0.40 to 0.41?** See the [release notes](https://github.com/ipfs/js-ipfs/issues/2656) for the list of API changes and the [migration guide](https://gist.github.com/alanshaw/04b2ddc35a6fff25c040c011ac6acf26).
+> **Upgrading from <=0.40 to 0.41?** See the [release notes](https://github.com/ipfs/js-ipfs/issues/2656) for the list of API changes and the [migration guide](https://gist.github.com/alanshaw/04b2ddc35a6fff25c040c011ac6acf26).
 
 ### Project status - `Alpha` <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@
   <br>
 </p>
 
+> **Upgrading from <0.40 to 0.41?** See the [release notes](https://github.com/ipfs/js-ipfs/issues/2656) for the list of API changes and the [migration guide](https://gist.github.com/alanshaw/04b2ddc35a6fff25c040c011ac6acf26).
+
 ### Project status - `Alpha` <!-- omit in toc -->
 
-We've come a long way, but this project is still in Alpha, lots of development is happening, API might change, beware of the Dragons 🐉..
+We've come a long way, but this project is still in Alpha, lots of development is happening, API might change, beware of the Dragons 🐉.
 
 **Want to get started?** Check our [examples folder](/examples) to learn how to spawn an IPFS node in Node.js and in the Browser.
 


### PR DESCRIPTION
Adds a temporary note at the top of the README to point people at the release notes and migration guide for the 0.41 release.