### PR TITLE
fix: print peer id in swarm addresses on startup

### DIFF
--- a/examples/custom-libp2p/index.js
+++ b/examples/custom-libp2p/index.js
@@ -32,6 +32,7 @@ const libp2pBundle = (opts) => {
   const bootstrapList = opts.config.Bootstrap
 
   // Build and return our libp2p node
+  // n.b. for full configuration options, see https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md
   return new Libp2p({
     peerInfo,
     peerBook,
@@ -91,6 +92,17 @@ const libp2pBundle = (opts) => {
       pubsub: {
         enabled: true
       }
+    },
+    metrics: {
+      enabled: true,
+      computeThrottleMaxQueueSize: 1000,  // How many messages a stat will queue before processing
+      computeThrottleTimeout: 2000,       // Time in milliseconds a stat will wait, after the last item was added, before processing
+      movingAverageIntervals: [           // The moving averages that will be computed
+        60 * 1000, // 1 minute
+        5 * 60 * 1000, // 5 minutes
+        15 * 60 * 1000 // 15 minutes
+      ],
+      maxOldPeersRetention: 50            // How many disconnected peers we will retain stats for
     }
   })
 }

--- a/src/core/components/start.js
+++ b/src/core/components/start.js
@@ -57,7 +57,7 @@ module.exports = ({
 
     await libp2p.start()
 
-    peerInfo.multiaddrs.forEach(ma => print('Swarm listening on', ma.toString()))
+    peerInfo.multiaddrs.forEach(ma => print(`Swarm listening on ${ma}/p2p/${peerInfo.id.toB58String()}`))
 
     const ipnsRouting = routingConfig({ libp2p, repo, peerInfo, options: constructorOptions })
     const ipns = new IPNS(ipnsRouting, repo.datastore, peerInfo, keychain, { pass: initOptions.pass })


### PR DESCRIPTION
Since https://github.com/libp2p/js-libp2p/pull/558 js-libp2p now requires peer ids to be part of dialled multiaddrs.

Previously a user was able to copy/paste swarm addresses printed as part of the daemon starting up but now they can't because the peer id is not included in the console output.

This PR prints the node's peer id as part of the swarm address to let people continue doing this and fixes the custom-libp2p example.