### PR TITLE
chore: update testing externals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,42 +121,42 @@ jobs:
     - stage: test
       name: external - ipfs-webui
       script:
-        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
+        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
 
     - stage: test
       name: external - ipfs-companion
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
+        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
 
     - stage: test
       name: external - npm-on-ipfs
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
+        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
 
     - stage: test
       name: external - peer-base
       script:
-        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
+        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
 
     - stage: test
       name: external - service-worker-gateway
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/service-worker-gateway.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - npm run test:external -- https://github.com/ipfs-shipyard/service-worker-gateway.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_BRANCH"
 
     - stage: test
       name: external - orbit-db
       script:
-        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
+        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
 
     - stage: test
       name: external - ipfs-log
       script:
-        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
+        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
 
     - stage: test
       name: external - sidetree
       script:
-        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
+        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
 
     - stage: test
       name: example - browser-add-readable-stream

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,42 +121,42 @@ jobs:
     - stage: test
       name: external - ipfs-webui
       script:
-        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
+        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: external - ipfs-companion
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
+        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: external - npm-on-ipfs
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
+        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: external - peer-base
       script:
-        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
+        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: external - service-worker-gateway
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/service-worker-gateway.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_BRANCH"
+        - npm run test:external -- https://github.com/ipfs-shipyard/service-worker-gateway.git --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: external - orbit-db
       script:
-        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
+        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: external - ipfs-log
       script:
-        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
+        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: external - sidetree
       script:
-        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_BRANCH
+        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#"${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
     - stage: test
       name: example - browser-add-readable-stream

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
     - name: external - orbit-db
     - name: external - ipfs-log
     - name: external - sidetree
+    - name: external - webui
   include:
     - stage: check
       script:
@@ -120,42 +121,42 @@ jobs:
     - stage: test
       name: external - ipfs-webui
       script:
-        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: external - ipfs-companion
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: external - npm-on-ipfs
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: external - peer-base
       script:
-        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: external - service-worker-gateway
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/service-worker-gateway.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - npm run test:external -- https://github.com/ipfs-shipyard/service-worker-gateway.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: external - orbit-db
       script:
-        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: external - ipfs-log
       script:
-        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: external - sidetree
       script:
-        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
+        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
 
     - stage: test
       name: example - browser-add-readable-stream

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,42 +120,42 @@ jobs:
     - stage: test
       name: external - ipfs-webui
       script:
-        - E2E_IPFSD_TYPE=js npm run test:external -- ipfs-webui https://github.com/ipfs-shipyard/ipfs-webui.git
+        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: external - ipfs-companion
       script:
-        - npm run test:external -- ipfs-companion https://github.com/ipfs-shipyard/ipfs-companion.git
+        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: external - npm-on-ipfs
       script:
-        - npm run test:external -- npm-on-ipfs https://github.com/ipfs-shipyard/npm-on-ipfs.git
+        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: external - peer-base
       script:
-        - npm run test:external -- peer-base https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc
+        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: external - service-worker-gateway
       script:
-        - npm run test:external -- service-worker-gateway https://github.com/ipfs-shipyard/service-worker-gateway.git
+        - npm run test:external -- https://github.com/ipfs-shipyard/service-worker-gateway.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: external - orbit-db
       script:
-        - npm run test:external -- orbit-db https://github.com/orbitdb/orbit-db.git
+        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: external - ipfs-log
       script:
-        - npm run test:external -- ipfs-log https://github.com/orbitdb/ipfs-log.git
+        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: external - sidetree
       script:
-        - npm run test:external -- sidetree https://github.com/decentralized-identity/sidetree.git
+        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT_ID
 
     - stage: test
       name: example - browser-add-readable-stream

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,22 +121,22 @@ jobs:
     - stage: test
       name: external - ipfs-webui
       script:
-        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - E2E_IPFSD_TYPE=js npm run test:external -- https://github.com/ipfs-shipyard/ipfs-webui.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
 
     - stage: test
       name: external - ipfs-companion
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - npm run test:external -- https://github.com/ipfs-shipyard/ipfs-companion.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
 
     - stage: test
       name: external - npm-on-ipfs
       script:
-        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - npm run test:external -- https://github.com/ipfs-shipyard/npm-on-ipfs.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
 
     - stage: test
       name: external - peer-base
       script:
-        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - npm run test:external -- https://github.com/achingbrain/peer-base.git --branch upgrade-to-latest-ipfs-rc --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
 
     - stage: test
       name: external - service-worker-gateway
@@ -146,17 +146,17 @@ jobs:
     - stage: test
       name: external - orbit-db
       script:
-        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - npm run test:external -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
 
     - stage: test
       name: external - ipfs-log
       script:
-        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - npm run test:external -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
 
     - stage: test
       name: external - sidetree
       script:
-        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#"$TRAVIS_COMMIT"
+        - npm run test:external -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@github:ipfs/js-ipfs#$TRAVIS_COMMIT
 
     - stage: test
       name: example - browser-add-readable-stream

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:interop:browser": "IPFS_JS_EXEC=$PWD/src/cli/bin.js IPFS_JS_MODULE=$PWD IPFS_REUSEPORT=false ipfs-interop -- -t browser",
     "test:interop:electron-main": "IPFS_JS_EXEC=$PWD/src/cli/bin.js IPFS_JS_MODULE=$PWD IPFS_REUSEPORT=false ipfs-interop -- -t electron-main -f ./test/node.js",
     "test:interop:electron-renderer": "IPFS_JS_EXEC=$PWD/src/cli/bin.js IPFS_JS_MODULE=$PWD IPFS_REUSEPORT=false ipfs-interop -- -t electron-renderer -f ./test/browser.js",
-    "test:external": "aegir test-external",
+    "test:external": "aegir test-dependant",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
     "benchmark": "echo \"Error: no benchmarks yet\" && exit 1",
     "benchmark:node": "echo \"Error: no benchmarks yet\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "yargs-promise": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "github:ipfs/aegir#test-dependants",
+    "aegir": "^21.1.0",
     "base64url": "^3.0.1",
     "clear-module": "^4.0.0",
     "delay": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "yargs-promise": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^21.0.2",
+    "aegir": "github:ipfs/aegir#test-dependants",
     "base64url": "^3.0.1",
     "clear-module": "^4.0.0",
     "delay": "^4.1.0",


### PR DESCRIPTION
I've generalised the aegir test-externals command so it's not js-ipfs specific any more and can be used by our other projects, hopefully by aegir itself too to catch breakage.  This change updates our invocation of the command.