### PR TITLE
docs: recommend jsdelivr to users and add download counts to the README

### DIFF
--- a/examples/browser-script-tag/README.md
+++ b/examples/browser-script-tag/README.md
@@ -3,7 +3,7 @@
 You can use IPFS in your in-browser JavaScript code with just a `<script>` tag.
 
 ```html
-<script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
 ```
 
 This exposes a global `Ipfs`; you can get a node by making a `new Ipfs()`.

--- a/examples/browser-video-streaming/README.md
+++ b/examples/browser-video-streaming/README.md
@@ -17,9 +17,9 @@ The fact that HLS content is just "a bunch of files" makes it a good choice for 
 The hls.js library ships with an HTTP based content loader only, but it's fortunately possible to configure custom content loaders as well, which is what makes IPFS streaming possible in this case. A loader implementation that fetches content using js-ipfs can be found [here](https://www.npmjs.com/package/hlsjs-ipfs-loader), and is easy to use on a regular HTML page:
 
 ```html
-<script src="https://unpkg.com/ipfs/dist/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
-<script src="https://unpkg.com/hlsjs-ipfs-loader@0.1.2/dist/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/hlsjs-ipfs-loader@0.1.2"></script>
 ```
 
 ## Generating HLS content

--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -2,7 +2,7 @@
   <body>
     <video id="video" controls></video>
     <script src="./node_modules/ipfs/dist/index.js"></script>
-    <script src="https://unpkg.com/hlsjs-ipfs-loader@0.2.3/dist/index.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>
   </body>

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -23,6 +23,8 @@
   <a href="https://github.com/RichardLitt/standard-readme"><img src="https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square" /></a>
   <a href=""><img src="https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square" /></a>
   <a href=""><img src="https://img.shields.io/badge/Node.js-%3E%3D10.0.0-orange.svg?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/ipfs-http-client"><img src="https://img.shields.io/npm/dm/ipfs-http-client.svg" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/ipfs-http-client"><img src="https://data.jsdelivr.com/v1/package/npm/ipfs-http-client/badge"/></a>
   <br>
 </p>
 
@@ -128,26 +130,28 @@ See the example in the [examples folder](examples/bundle-webpack) to get an idea
 
 **from CDN**
 
-Instead of a local installation (and browserification) you may request a remote copy of IPFS API from [unpkg CDN](https://unpkg.com/).
+Instead of a local installation (and browserification) you may request a remote copy of IPFS API from [jsDelivr](https://www.jsdelivr.com/package/npm/ipfs).
 
-To always request the latest version, use the following:
+To always request the latest version, use one of the following examples:
 
 ```html
-<script src="https://unpkg.com/ipfs-http-client/dist/index.min.js"></script>
-```
+<!-- loading the minified version using jsDelivr -->
+<script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.min.js"></script>
 
-Note: remove the `.min` from the URL to get the human-readable (not minified) version.
+<!-- loading the human-readable (not minified) version jsDelivr -->
+<script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.js"></script>
+```
 
 For maximum security you may also decide to:
 
 * reference a specific version of IPFS API (to prevent unexpected breaking changes when a newer latest version is published)
-* [generate a SRI hash](https://www.srihash.org/) of that version and use it to ensure integrity
+* [generate a SRI hash](https://www.srihash.org/) of that version and use it to ensure integrity. Learn more also at the [jsdelivr website](https://www.jsdelivr.com/using-sri-with-dynamic-files)
 * set the [CORS settings attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) to make anonymous requests to CDN
 
 Example:
 
 ```html
-<script src="https://unpkg.com/ipfs-http-client@9.0.0/dist/index.js"
+<script src="https://www.jsdelivr.com/package/npm/ipfs-http-client"
 integrity="sha384-5bXRcW9kyxxnSMbOoHzraqa7Z0PQWIao+cgeg327zit1hz5LZCEbIMx/LWKPReuB"
 crossorigin="anonymous"></script>
 ```

--- a/packages/ipfs/CHANGELOG.md
+++ b/packages/ipfs/CHANGELOG.md
@@ -492,7 +492,7 @@ Signed-off-by: Alan Shaw <alan.shaw@protocol.ai>
     * all IPLD formats included
 * In browser application bundle `require('ipfs')` bundled with webpack/browserify/etc.
     * only `ipld-dag-pb`, `ipld-dag-cbor` and `ipld-raw` included
-* CDN bundle `<script src="https://unpkg.com/ipfs/dist/index.min.js"></script>`
+* CDN bundle `<script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>`
     * all IPLD formats included
 
 Co-Authored-By: hugomrdias <mail@hugodias.me>

--- a/packages/ipfs/README.md
+++ b/packages/ipfs/README.md
@@ -27,6 +27,8 @@
   <a href="https://github.com/feross/standard"><img src="https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat"></a>
   <a href=""><img src="https://img.shields.io/badge/npm-%3E%3D6.0.0-orange.svg?style=flat" /></a>
   <a href=""><img src="https://img.shields.io/badge/Node.js-%3E%3D10.0.0-orange.svg?style=flat" /></a>
+  <a href="https://www.npmjs.com/package/ipfs"><img src="https://img.shields.io/npm/dm/ipfs.svg" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/ipfs"><img src="https://data.jsdelivr.com/v1/package/npm/ipfs/badge"/></a>
   <br>
 </p>
 
@@ -165,16 +167,8 @@ Once installed, please follow the [Getting Started Guide](https://docs.ipfs.io/i
 
 Learn how to bundle with browserify and webpack in the [`examples`](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs/examples) folder.
 
-You can also load it using a `<script>` using the [unpkg](https://unpkg.com) CDN **or** the [jsDelivr](https://www.jsdelivr.com/package/npm/ipfs) CDN. Inserting one of the following lines will make an `Ipfs` object available in the global namespace.
+You can also load it using a `<script>` using the [jsDelivr](https://www.jsdelivr.com/package/npm/ipfs) CDN. Inserting one of the following lines will make an `Ipfs` object available in the global namespace.
 
-```html
-<!-- loading the minified version using unpkg -->
-<script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
-
-<!-- loading the human-readable (not minified) version using unpkg -->
-<script src="https://unpkg.com/ipfs/dist/index.js"></script>
-```
-**OR THIS:**
 
 ```html
 <!-- loading the minified version using jsDelivr -->


### PR DESCRIPTION
This PR:
- Adds download counts
- Recommend jsdelivr (faster CDN) and gives us the download counts