### PR TITLE
docs: add download counts to http-api-client. recommend jsdelivr

### DIFF
--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -134,7 +134,6 @@ Instead of a local installation (and browserification) you may request a remote 
 
 To always request the latest version, use one of the following examples:
 
-````html
 ```html
 <!-- loading the minified version using jsDelivr -->
 <script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.min.js"></script>

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -135,12 +135,12 @@ Instead of a local installation (and browserification) you may request a remote 
 To always request the latest version, use one of the following examples:
 
 ````html
-<!-- loading the minified version using unpkg -->
-<script src="https://unpkg.com/ipfs-http-client/dist/index.min.js"></script>
+```html
+<!-- loading the minified version using jsDelivr -->
+<script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.min.js"></script>
 
-<!-- loading the human-readable (not minified) version using unpkg -->
-<script src="https://unpkg.com/ipfs-http-client/dist/index.js"></script>
-```
+<!-- loading the human-readable (not minified) version jsDelivr -->
+<script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.js"></script>
 
 
 For maximum security you may also decide to:

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -23,6 +23,8 @@
   <a href="https://github.com/RichardLitt/standard-readme"><img src="https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square" /></a>
   <a href=""><img src="https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square" /></a>
   <a href=""><img src="https://img.shields.io/badge/Node.js-%3E%3D10.0.0-orange.svg?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/ipfs-http-client"><img src="https://img.shields.io/npm/dm/ipfs-http-client.svg" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/ipfs-http-client"><img src="https://data.jsdelivr.com/v1/package/npm/ipfs-http-client/badge"/></a>
   <br>
 </p>
 
@@ -128,15 +130,18 @@ See the example in the [examples folder](examples/bundle-webpack) to get an idea
 
 **from CDN**
 
-Instead of a local installation (and browserification) you may request a remote copy of IPFS API from [unpkg CDN](https://unpkg.com/).
+Instead of a local installation (and browserification) you may request a remote copy of IPFS API from [jsDelivr](https://www.jsdelivr.com/package/npm/ipfs).
 
-To always request the latest version, use the following:
+To always request the latest version, use one of the following examples:
 
-```html
+````html
+<!-- loading the minified version using unpkg -->
 <script src="https://unpkg.com/ipfs-http-client/dist/index.min.js"></script>
+
+<!-- loading the human-readable (not minified) version using unpkg -->
+<script src="https://unpkg.com/ipfs-http-client/dist/index.js"></script>
 ```
 
-Note: remove the `.min` from the URL to get the human-readable (not minified) version.
 
 For maximum security you may also decide to:
 

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -140,7 +140,7 @@ To always request the latest version, use one of the following examples:
 
 <!-- loading the human-readable (not minified) version jsDelivr -->
 <script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.js"></script>
-
+```
 
 For maximum security you may also decide to:
 


### PR DESCRIPTION
This PR:
- Adds download counts
- Recommend jsdelivr (faster CDN) and gives us the download counts

Follows the one in js-ipfs https://github.com/ipfs/js-ipfs/pull/2826