### PR TITLE
docs: examples do not need to be installed

### DIFF
--- a/examples/browser-browserify/README.md
+++ b/examples/browser-browserify/README.md
@@ -4,10 +4,9 @@ In this example, you will find a boilerplate you can use to guide yourself into 
 
 ## Run this example
 
-First install dependencies in the project root directory with `npm install`, then build the browser bundle with `npm run build`. Then in this directory run:
+First install dependencies in the project root directory with `npm install`. Then in this directory run:
 
 ```bash
-> npm install
 > npm start
 ```
 

--- a/examples/browser-mfs/README.md
+++ b/examples/browser-mfs/README.md
@@ -18,7 +18,7 @@ Navigate into this directory:
 $ cd js-ipfs/examples/browser-mfs
 ```
 
-In this directory:
+In this directory run:
 
 ```
 $ npm start

--- a/examples/browser-mfs/README.md
+++ b/examples/browser-mfs/README.md
@@ -21,7 +21,6 @@ $ cd js-ipfs/examples/browser-mfs
 In this directory:
 
 ```
-$ npm install
 $ npm start
 ```
 

--- a/examples/browser-parceljs/README.md
+++ b/examples/browser-parceljs/README.md
@@ -10,7 +10,6 @@ that you can follow it for creating Parcel.js bundled js-ipfs DApps.
 want to serve the example over IPFS)
 1. Open a new terminal
 1. `cd` into this folder
-1. Run `npm install`
 
 ## Running this example in development mode with auto-reloading
 

--- a/examples/browser-readablestream/README.md
+++ b/examples/browser-readablestream/README.md
@@ -9,7 +9,6 @@ Take a look at [`index.js`](./index.js) to see a working example.
 In this directory:
 
 ```
-$ npm install
 $ npm start
 ```
 

--- a/examples/browser-vue/README.md
+++ b/examples/browser-vue/README.md
@@ -6,12 +6,6 @@ A minimal demonstration of how to use `js-ipfs` with `Vue`.
 
 This project was bootstrapped with [Vue CLI](https://cli.vuejs.org/).
 
-## Project setup
-
-```bash
-npm install
-```
-
 ### Compiles and hot-reloads for development
 
 ```bash

--- a/examples/browser-webpack/README.md
+++ b/examples/browser-webpack/README.md
@@ -4,10 +4,9 @@
 
 ## Run this example
 
-Once the daemon is on, run the following commands within this folder:
+Once the daemon is on, run the following command within this folder:
 
 ```bash
-> npm install
 > npm start
 ```
 

--- a/examples/circuit-relaying/README.md
+++ b/examples/circuit-relaying/README.md
@@ -247,13 +247,9 @@ Look out for an address similar to `/ip4/127.0.0.1/tcp/4003/ws/ipfs/Qm...`. Note
 
 ### 2. Configure and run the bundled example
 
-Now that we have ipfs installed and initialized, let's set up the included example. This is a standard npm package, so the usual `npm install` should get us going. Let's `cd` into the `examples/circuit-relaying` directory and run:
+Now that we have ipfs installed and initialized, let's set up the included example. This is a standard npm package, so the usual `npm install` should get us going. Let's `cd` into the `examples/circuit-relaying` directory.
 
-```sh
-npm install
-```
-
-After it finishes, we should be able to run the project with `npm start` and get output similar to:
+We should be able to run the project with `npm start` and get output similar to:
 
 ```sh
 npm start

--- a/examples/custom-ipfs-repo/README.md
+++ b/examples/custom-ipfs-repo/README.md
@@ -10,7 +10,6 @@ You can find full details on customization in the [IPFS Repo Docs](https://githu
 ## Run this example
 
 ```
-> npm install
 > npm start
 ```
 

--- a/examples/custom-libp2p/README.md
+++ b/examples/custom-libp2p/README.md
@@ -7,7 +7,6 @@ This example shows you how to make full use of the ipfs configuration to create 
 Running this example should result in metrics being logged out to the console every few seconds.
 
 ```
-> npm install
 > npm start
 ```
 

--- a/examples/exchange-files-in-browser/README.md
+++ b/examples/exchange-files-in-browser/README.md
@@ -144,11 +144,9 @@ By default it will listen to all incoming connections on port 13579.  Override t
 
 Make sure you're in `js-ipfs/examples/exchange-files-in-browser`.
 
-We'll need to install and bundle the dependencies to run the app. Let's do it:
+We'll need to bundle the dependencies to run the app. Let's do it:
 
 ```sh
-> npm install
-...
 > npm run bundle
 ...
 > npm start

--- a/examples/run-in-electron/README.md
+++ b/examples/run-in-electron/README.md
@@ -5,6 +5,5 @@
 To try it by yourself, do:
 
 ```
-> npm install
 > npm start
 ```


### PR DESCRIPTION
With the project structure updated to lerna, the `examples` do not need to be installed, as the dependencies get installed when the main project is installed.

This PR removed the `npm install` instruction from all the example `README` files that had it.