### PR TITLE
fix: tag stdin with mtime and mode when piping to cli 'add'

### DIFF
--- a/packages/ipfs/src/cli/commands/add.js
+++ b/packages/ipfs/src/cli/commands/add.js
@@ -236,7 +236,11 @@ module.exports = {
         mode: argv.mode,
         mtime
       })
-      : getStdin() // Pipe directly to ipfs.add
+      : {
+        content: getStdin(),
+        mode: argv.mode,
+        mtime
+      } // Pipe to ipfs.add tagging with mode and mtime
 
     let finalCid
 

--- a/packages/ipfs/test/cli/files-regular.js
+++ b/packages/ipfs/test/cli/files-regular.js
@@ -157,12 +157,36 @@ describe('files', () => {
   it('add from pipe', async () => {
     const cid = new CID('QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
 
-    ipfs.add.withArgs(matchIterable(), defaultAddArgs()).returns([{
+    ipfs.add.withArgs(sinon.match({
+      content: matchIterable()
+    }), defaultAddArgs()).returns([{
       cid,
       path: 'readme'
     }])
 
     const proc = cli('add', {
+      ipfs,
+      getStdin: function * () {
+        yield Buffer.from('hello\n')
+      }
+    })
+
+    const out = await proc
+    expect(out).to.equal(`added ${cid} ${cid}\n`)
+  })
+
+  it('add from pipe with mtime=100', async () => {
+    const cid = new CID('QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
+
+    ipfs.add.withArgs(sinon.match({
+      content: matchIterable(),
+      mtime: { secs: 100 }
+    }), defaultAddArgs()).returns([{
+      cid,
+      path: 'readme'
+    }])
+
+    const proc = cli('add --mtime=100', {
       ipfs,
       getStdin: function * () {
         yield Buffer.from('hello\n')


### PR DESCRIPTION
Converts the stdin stream to a async iterator of one file and tags that file with the mtime and
mode.

fixes #2763