### PR TITLE
fix: multiaddr validation to add peer id for listening

### DIFF
--- a/packages/ipfs/src/core/components/start.js
+++ b/packages/ipfs/src/core/components/start.js
@@ -39,6 +39,9 @@ module.exports = ({
       config.Addresses.Swarm.forEach(addr => {
         let ma = multiaddr(addr)
 
+        // multiaddrs that go via a signalling server or other intermediary (e.g. stardust,
+        // webrtc-star) can have the intermediary's peer ID in the address, so append our
+        // peer ID to the end of it
         const maId = ma.getPeerId()
         if (maId && maId !== peerInfo.id.toB58String()) {
           ma = ma.encapsulate(`/p2p/${peerInfo.id.toB58String()}`)

--- a/packages/ipfs/src/core/components/start.js
+++ b/packages/ipfs/src/core/components/start.js
@@ -39,7 +39,8 @@ module.exports = ({
       config.Addresses.Swarm.forEach(addr => {
         let ma = multiaddr(addr)
 
-        if (ma.getPeerId()) {
+        const maId = ma.getPeerId()
+        if (maId && maId !== peerInfo.id.toB58String()) {
           ma = ma.encapsulate(`/p2p/${peerInfo.id.toB58String()}`)
         }
 


### PR DESCRIPTION
When we add the own peer id to a multiaddr, we should verify if it already has it, or if it is an address of `circuit-relay` / `stardust`. Otherwise, we might end up with multiaddrs like:  `/ip4/127.0.0.1/tcp/5892/ws/p2p/PEER_ID/p2p/PEER_ID`