### PR TITLE
fix: fix exchange in files example

### DIFF
--- a/examples/exchange-files-in-browser/package.json
+++ b/examples/exchange-files-in-browser/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "ipfs": "^0.41.0",
+    "it-all": "^1.0.1",
+    "it-last": "^1.0.1",
     "test-ipfs-example": "^1.0.0"
   },
   "browser": {


### PR DESCRIPTION
The test for this example did not go as far as downloading the file and asserting the contents are correct - that part had not been refactored to be async/await happy so wasn't working.

I've expanded the test to perform the download too.