### PR TITLE
fix: reinstate hlsjs-ipfs-loader dep for video streaming example

### DIFF
--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -2,7 +2,7 @@
   <body>
     <video id="video" controls></video>
     <script src="./node_modules/ipfs/dist/index.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hlsjs-ipfs-loader@latest/dist/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>
   </body>


### PR DESCRIPTION
Otherwise the test times out. We have to specify the dist file in the url too, otherwise the test times out, not 100% sure why.

Follows on from #2826