### PR TITLE
docs: fix urlSource example typo

### DIFF
--- a/packages/interface-ipfs-core/SPEC/FILES.md
+++ b/packages/interface-ipfs-core/SPEC/FILES.md
@@ -191,7 +191,7 @@ Both js-ipfs and js-ipfs-http-client export a utility to make importing a file f
 
 ```js
 const IPFS = require('ipfs')
-const { globSource } = IPFS
+const { urlSource } = IPFS
 
 const ipfs = await IPFS.create()
 


### PR DESCRIPTION
fixes a small typo in the example here:  https://github.com/ipfs/js-ipfs/blob/master/packages/interface-ipfs-core/SPEC/FILES.md#importing-a-file-from-a-url

Closes https://github.com/ipfs/js-ipfs/issues/2941