### PR TITLE
docs: fix links to core api spec/documentation

### DIFF
--- a/packages/interface-ipfs-core/README.md
+++ b/packages/interface-ipfs-core/README.md
@@ -152,26 +152,26 @@ tests.repo(createCommon, { only: ['should do a thing'] })
 In order to be considered "valid", an IPFS core implementation must expose the API described in [/SPEC](SPEC). You can also use this loose spec as documentation for consuming the core APIs. Here is an outline of the contents of that directory:
 
 - **Files**
-  - [files](/SPEC/FILES.md)
-  - [block](/SPEC/BLOCK.md)
-  - [repo (not spec'ed yet)](/SPEC/REPO)
+  - [files](./SPEC/FILES.md)
+  - [block](./SPEC/BLOCK.md)
+  - [repo (not spec'ed yet)](./SPEC/REPO.md)
 - **Graph**
-  - [dag](/SPEC/DAG.md)
-  - [object](/SPEC/OBJECT.md)
-  - [pin](/SPEC/PIN.md)
-- [**Name**](/SPEC/NAME.md)
+  - [dag](./SPEC/DAG.md)
+  - [object](./SPEC/OBJECT.md)
+  - [pin](./SPEC/PIN.md)
+- [**Name**](./SPEC/NAME.md)
 - **Network**
-  - [bootstrap](/SPEC/BOOSTRAP.md)
-  - [bitswap](/SPEC/BITSWAP.md)
-  - [dht](/SPEC/DHT.md)
-  - [pubsub](/SPEC/PUBSUB.md)
-  - [swarm](/SPEC/SWARM.md)
+  - [bootstrap](./SPEC/BOOTSTRAP.md)
+  - [bitswap](./SPEC/BITSWAP.md)
+  - [dht](./SPEC/DHT.md)
+  - [pubsub](./SPEC/PUBSUB.md)
+  - [swarm](./SPEC/SWARM.md)
 - **Node Management**
-  - [Miscellaneous](/SPEC/MISCELLANEOUS.md)
-  - [config](/SPEC/CONFIG.md)
-  - [key](/SPEC/KEY.md)
-  - [stats](/SPEC/STATS.md)
-  - [repo](/SPEC/REPO.md)
+  - [Miscellaneous](./SPEC/MISCELLANEOUS.md)
+  - [config](./SPEC/CONFIG.md)
+  - [key](./SPEC/KEY.md)
+  - [stats](./SPEC/STATS.md)
+  - [repo](./SPEC/REPO.md)
 
 ## Contribute
 


### PR DESCRIPTION
found some bad links while browsing the ipfs-core-interface documentation.
all are part of the api section of the readme here:
https://github.com/ipfs/js-ipfs/tree/master/packages/interface-ipfs-core#api

pr changes:
- links are changed to relative links `'/' -> './'`
- add file extension to repo api doc `'REPO' -> 'REPO.md'`
- fix typo for bootstrap api doc `'BOOSTRAP' -> 'BOOTSTRAP'`