### PR TITLE
fix: add default args for ipfs.add

### DIFF
--- a/packages/ipfs-http-client/src/lib/to-url-search-params.js
+++ b/packages/ipfs-http-client/src/lib/to-url-search-params.js
@@ -6,7 +6,7 @@ const mtimeToObject = require('./mtime-to-object')
 module.exports = (args, options) => {
   const searchParams = new URLSearchParams(options)
 
-  if (args === undefined) {
+  if (args === undefined || args === null) {
     args = []
   } else if (!Array.isArray(args)) {
     args = [args]

--- a/packages/ipfs/src/cli/commands/add.js
+++ b/packages/ipfs/src/cli/commands/add.js
@@ -74,7 +74,8 @@ module.exports = {
     },
     'raw-leaves': {
       type: 'boolean',
-      describe: 'Use raw blocks for leaf nodes. (experimental)'
+      describe: 'Use raw blocks for leaf nodes. (experimental)',
+      default: false
     },
     'cid-version': {
       type: 'integer',
@@ -89,7 +90,8 @@ module.exports = {
     hash: {
       type: 'string',
       choices: Object.keys(mh.names),
-      describe: 'Hash function to use. Will set CID version to 1 if used. (experimental)'
+      describe: 'Hash function to use. Will set CID version to 1 if used. (experimental)',
+      default: 'sha2-256'
     },
     quiet: {
       alias: 'q',
@@ -174,9 +176,7 @@ module.exports = {
     const { ipfs, print, isDaemon, getStdin } = argv.ctx
     const options = {
       trickle: argv.trickle,
-      shardSplitThreshold: argv.enableShardingExperiment
-        ? argv.shardSplitThreshold
-        : Infinity,
+      shardSplitThreshold: argv.shardSplitThreshold,
       cidVersion: argv.cidVersion,
       rawLeaves: argv.rawLeaves,
       onlyHash: argv.onlyHash,
@@ -185,7 +185,6 @@ module.exports = {
       pin: argv.pin,
       chunker: argv.chunker,
       preload: argv.preload,
-      nonatomic: argv.nonatomic,
       fileImportConcurrency: argv.fileImportConcurrency,
       blockWriteConcurrency: argv.blockWriteConcurrency,
       progress: () => {}

--- a/packages/ipfs/test/cli/files-regular.js
+++ b/packages/ipfs/test/cli/files-regular.js
@@ -25,11 +25,11 @@ const HASH_ALGS = [
 function defaultAddArgs (overrides) {
   return {
     trickle: false,
-    shardSplitThreshold: Infinity,
+    shardSplitThreshold: 1000,
     cidVersion: 0,
-    rawLeaves: undefined,
+    rawLeaves: false,
     onlyHash: false,
-    hashAlg: undefined,
+    hashAlg: 'sha2-256',
     wrapWithDirectory: false,
     pin: true,
     chunker: 'size-262144',

--- a/packages/ipfs/test/cli/files-regular.js
+++ b/packages/ipfs/test/cli/files-regular.js
@@ -34,7 +34,6 @@ function defaultAddArgs (overrides) {
     pin: true,
     chunker: 'size-262144',
     preload: true,
-    nonatomic: undefined,
     fileImportConcurrency: 50,
     blockWriteConcurrency: 10,
     progress: sinon.match.func,


### PR DESCRIPTION
So we don't send invalid args over http.  Also removes `nonatomic` option, not sure how that got in there.