### PR TITLE
docs: fix ipfs.cat example

### DIFF
--- a/examples/ipfs-101/README.md
+++ b/examples/ipfs-101/README.md
@@ -111,9 +111,12 @@ async function main () {
 
   console.log('Added file:', filesAdded[0].path, filesAdded[0].hash)
 
-  const fileBuffer = await node.cat(filesAdded[0].hash)
+  const chunks = []
+  for await (const chunk of node.cat(filesAdded[0].hash)) {
+      chunks.push(chunk)
+  }
 
-  console.log('Added file contents:', fileBuffer.toString())
+  console.log('Added file contents:', Buffer.concat(chunks).toString())
 }
 
 main()


### PR DESCRIPTION
Old example was printing an AsyncGenerator object to the console

Updated code comes straight from https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#cat