### PR TITLE
Refactor refs tests

### DIFF
--- a/packages/interface-ipfs-core/src/refs.js
+++ b/packages/interface-ipfs-core/src/refs.js
@@ -314,14 +314,14 @@ function getRefsTests () {
 function loadPbContent (ipfs, node) {
   const store = {
     putData: async (data) => {
-      const res = await ipfs.block.put(new DAGNode(data).serialize());
-      return res.cid;
+      const res = await ipfs.block.put(new DAGNode(data).serialize())
+      return res.cid
     },
     putLinks: async (links) => {
       const res = await ipfs.block.put(new DAGNode('', links.map(({ name, cid }) => {
-        return new DAGLink(name, 8, cid);
-      })).serialize());
-      return res.cid;
+        return new DAGLink(name, 8, cid)
+      })).serialize())
+      return res.cid
     }
   }
   return loadContent(ipfs, store, node)
@@ -330,10 +330,10 @@ function loadPbContent (ipfs, node) {
 function loadDagContent (ipfs, node) {
   const store = {
     putData: async (data) => {
-      const inner = new UnixFS({ type: 'file', data: data });
-      const serialized = new DAGNode(inner.marshal()).serialize();
-      const res = await ipfs.block.put(serialized);
-      return res.cid;
+      const inner = new UnixFS({ type: 'file', data: data })
+      const serialized = new DAGNode(inner.marshal()).serialize()
+      const res = await ipfs.block.put(serialized)
+      return res.cid
     },
     putLinks: (links) => {
       const obj = {}


### PR DESCRIPTION
Minor changes to refs to stop using `ipfs.add` and `ipfs.object.put` in favor of `ipfs.block.put` with test-local formatting. Tested against `go-ipfs-0.4.23` the CIDs do not change. This is result of discussions at https://github.com/ipfs-rust/rust-ipfs/issues/92#issuecomment-602686606 and at least another PR for `refs-local.js` should be coming later.

Sorry for the semicolons, I don't know the semicolon insertion rules by heart :)