### PR TITLE
fix: regression that dht could not be enabled through conf

### DIFF
--- a/packages/ipfs/src/core/components/index.js
+++ b/packages/ipfs/src/core/components/index.js
@@ -25,6 +25,7 @@ exports.dag = {
   resolve: require('./dag/resolve'),
   tree: require('./dag/tree')
 }
+exports.dht = require('./dht')
 exports.dns = require('./dns')
 exports.files = require('./files')
 exports.get = require('./get')

--- a/packages/ipfs/src/core/components/libp2p.js
+++ b/packages/ipfs/src/core/components/libp2p.js
@@ -9,7 +9,6 @@ module.exports = ({
   options,
   peerInfo,
   repo,
-  print,
   config
 }) => {
   options = options || {}

--- a/packages/ipfs/src/core/components/start.js
+++ b/packages/ipfs/src/core/components/start.js
@@ -160,6 +160,20 @@ function createApi ({
   dag.put = Components.dag.put({ ipld, pin, gcLock, preload })
   const add = Components.add({ ipld, preload, pin, gcLock, options: constructorOptions })
   const isOnline = Components.isOnline({ libp2p })
+
+  const dhtNotEnabled = async () => { // eslint-disable-line require-await
+    throw new NotEnabledError('dht not enabled')
+  }
+
+  const dht = get(libp2p, '_config.dht.enabled', false) ? Components.dht({ libp2p, repo }) : {
+    get: dhtNotEnabled,
+    put: dhtNotEnabled,
+    findProvs: dhtNotEnabled,
+    findPeer: dhtNotEnabled,
+    provide: dhtNotEnabled,
+    query: dhtNotEnabled
+  }
+
   const dns = Components.dns()
   const name = {
     pubsub: {
@@ -209,6 +223,7 @@ function createApi ({
     cat: Components.cat({ ipld, preload }),
     config: Components.config({ repo }),
     dag,
+    dht,
     dns,
     files,
     get: Components.get({ ipld, preload }),

--- a/packages/ipfs/test/core/dht.spec.js
+++ b/packages/ipfs/test/core/dht.spec.js
@@ -4,12 +4,85 @@
 
 const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const { isNode } = require('ipfs-utils/src/env')
-
 const factory = require('../utils/factory')
 
-// TODO: unskip when DHT is enabled: https://github.com/ipfs/js-ipfs/pull/1994
-describe.skip('dht', () => {
-  describe('enabled', () => {
+describe('dht', () => {
+  describe('enabled by config', () => {
+    const df = factory()
+    let ipfsd, ipfs
+
+    before(async function () {
+      this.timeout(30 * 1000)
+
+      ipfsd = await df.spawn({
+        ipfsOptions: {
+          libp2p: {
+            config: {
+              dht: {
+                enabled: true
+              }
+            }
+          }
+        }
+      })
+      ipfs = ipfsd.api
+    })
+
+    after(() => df.clean())
+
+    describe('put', () => {
+      it('should put a value when enabled', async () => {
+        await expect(ipfs.dht.put(Buffer.from('a'), Buffer.from('b')))
+          .to.eventually.be.undefined()
+      })
+    })
+
+    // TODO: unskip when DHT works: https://github.com/ipfs/js-ipfs/pull/1994
+    describe.skip('findprovs', () => {
+      it('should callback with error for invalid CID input', (done) => {
+        ipfs.dht.findProvs('INVALID CID', (err) => {
+          expect(err).to.exist()
+          expect(err.code).to.equal('ERR_INVALID_CID')
+          done()
+        })
+      })
+    })
+  })
+
+  describe('disabled by config', () => {
+    const df = factory()
+    let ipfsd, ipfs
+
+    before(async function () {
+      this.timeout(30 * 1000)
+
+      ipfsd = await df.spawn({
+        ipfsOptions: {
+          libp2p: {
+            config: {
+              dht: {
+                enabled: false
+              }
+            }
+          }
+        }
+      })
+      ipfs = ipfsd.api
+    })
+
+    after(() => df.clean())
+
+    describe('put', () => {
+      it('should error when DHT not available', async () => {
+        await expect(ipfs.dht.put(Buffer.from('a'), Buffer.from('b')))
+          .to.eventually.be.rejected()
+          .and.to.have.property('code', 'ERR_NOT_ENABLED')
+      })
+    })
+  })
+
+  describe('disabled in browser', () => {
+    if (isNode) { return }
     const df = factory()
     let ipfsd, ipfs
 
@@ -22,36 +95,11 @@ describe.skip('dht', () => {
 
     after(() => df.clean())
 
-    describe('findprovs', () => {
-      it('should callback with error for invalid CID input', (done) => {
-        ipfs.dht.findProvs('INVALID CID', (err) => {
-          expect(err).to.exist()
-          expect(err.code).to.equal('ERR_INVALID_CID')
-          done()
-        })
-      })
-    })
-  })
-
-  describe('disabled in browser', () => {
-    if (isNode) { return }
-    const df = factory()
-    let ipfsd, ipfs
-
-    before(async function (done) {
-      this.timeout(30 * 1000)
-
-      ipfsd = await df.spawn()
-      ipfs = ipfsd.api
-    })
-
-    after(() => df.clean())
-
     describe('put', () => {
       it('should error when DHT not available', async () => {
         await expect(ipfs.dht.put(Buffer.from('a'), Buffer.from('b')))
           .to.eventually.be.rejected()
-          .and.to.have.property('code', 'ERR_DHT_DISABLED')
+          .and.to.have.property('code', 'ERR_NOT_ENABLED')
       })
     })
   })


### PR DESCRIPTION
When the API Manager code came in, the DHT component seem to have been missed from the `start` component, this PR re-adds it.