### PR TITLE
fix: pass timeout arg to server

### DIFF
--- a/packages/interface-ipfs-core/src/dht/find-provs.js
+++ b/packages/interface-ipfs-core/src/dht/find-provs.js
@@ -67,8 +67,20 @@ module.exports = (common, options) => {
       }
 
       const cidV0 = await fakeCid()
+      const start = Date.now()
+      let res
 
-      await expect(all(nodeA.dht.findProvs(cidV0, options))).to.be.rejected()
+      try {
+        res = await all(nodeA.dht.findProvs(cidV0, options))
+      } catch (err) {
+        // rejected by http client
+        expect(err).to.have.property('name', 'TimeoutError')
+        return
+      }
+
+      // rejected by the server, errors don't work over http - https://github.com/ipfs/js-ipfs/issues/2519
+      expect(res).to.be.an('array').with.lengthOf(0)
+      expect(Date.now() - start).to.be.lessThan(100)
     })
   })
 }

--- a/packages/ipfs-http-client/src/add.js
+++ b/packages/ipfs-http-client/src/add.js
@@ -11,9 +11,9 @@ module.exports = configure((api) => {
     const progressFn = options.progress
 
     const res = await api.post('add', {
-      searchParams: toUrlSearchParams(null, {
-        ...options,
+      searchParams: toUrlSearchParams({
         'stream-channels': true,
+        ...options,
         progress: Boolean(progressFn)
       }),
       timeout: options.timeout,

--- a/packages/ipfs-http-client/src/bitswap/stat.js
+++ b/packages/ipfs-http-client/src/bitswap/stat.js
@@ -3,11 +3,12 @@
 const { BigNumber } = require('bignumber.js')
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('bitswap/stat', {
-      searchParams: options,
+      searchParams: toUrlSearchParams(options),
       timeout: options.timeout,
       signal: options.signal
     })

--- a/packages/ipfs-http-client/src/bitswap/unwant.js
+++ b/packages/ipfs-http-client/src/bitswap/unwant.js
@@ -2,15 +2,17 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, options = {}) => {
-    options.arg = typeof cid === 'string' ? cid : new CID(cid).toString()
-
     const res = await api.post('bitswap/unwant', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: typeof cid === 'string' ? cid : new CID(cid).toString(),
+        ...options
+      })
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/bitswap/wantlist.js
+++ b/packages/ipfs-http-client/src/bitswap/wantlist.js
@@ -2,6 +2,7 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (peer, options = {}) => {
@@ -12,7 +13,7 @@ module.exports = configure(api => {
     const res = await (await api.post('bitswap/wantlist', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })).json()
 
     return (res.Keys || []).map(k => new CID(k['/']))

--- a/packages/ipfs-http-client/src/block/get.js
+++ b/packages/ipfs-http-client/src/block/get.js
@@ -4,18 +4,21 @@ const Block = require('ipfs-block')
 const CID = require('cids')
 const { Buffer } = require('buffer')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, options = {}) => {
     cid = new CID(cid)
-    options.arg = cid.toString()
 
-    const rsp = await api.post('block/get', {
+    const res = await api.post('block/get', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: cid.toString(),
+        ...options
+      })
     })
 
-    return new Block(Buffer.from(await rsp.arrayBuffer()), cid)
+    return new Block(Buffer.from(await res.arrayBuffer()), cid)
   }
 })

--- a/packages/ipfs-http-client/src/block/put.js
+++ b/packages/ipfs-http-client/src/block/put.js
@@ -5,6 +5,7 @@ const CID = require('cids')
 const multihash = require('multihashes')
 const multipartRequest = require('../lib/multipart-request')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   async function put (data, options = {}) {
@@ -36,7 +37,7 @@ module.exports = configure(api => {
       const response = await api.post('block/put', {
         timeout: options.timeout,
         signal: options.signal,
-        searchParams: options,
+        searchParams: toUrlSearchParams(options),
         ...(
           await multipartRequest(data)
         )

--- a/packages/ipfs-http-client/src/block/rm.js
+++ b/packages/ipfs-http-client/src/block/rm.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const CID = require('cids')
-const merge = require('merge-options')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * rm (cid, options = {}) {
@@ -10,23 +10,14 @@ module.exports = configure(api => {
       cid = [cid]
     }
 
-    options = merge(
-      options,
-      {
-        'stream-channels': true
-      }
-    )
-
-    const searchParams = new URLSearchParams(options)
-
-    cid.forEach(cid => {
-      searchParams.append('arg', new CID(cid).toString())
-    })
-
     const res = await api.post('block/rm', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: searchParams
+      searchParams: toUrlSearchParams({
+        arg: cid.map(cid => new CID(cid).toString()),
+        'stream-channels': true,
+        ...options
+      })
     })
 
     for await (const removed of res.ndjson()) {

--- a/packages/ipfs-http-client/src/block/stat.js
+++ b/packages/ipfs-http-client/src/block/stat.js
@@ -2,18 +2,20 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, options = {}) => {
-    options.arg = (new CID(cid)).toString()
-
-    const response = await api.post('block/stat', {
+    const res = await api.post('block/stat', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: new CID(cid).toString(),
+        ...options
+      })
     })
-    const res = await response.json()
+    const data = await res.json()
 
-    return { cid: new CID(res.Key), size: res.Size }
+    return { cid: new CID(data.Key), size: data.Size }
   }
 })

--- a/packages/ipfs-http-client/src/bootstrap/add.js
+++ b/packages/ipfs-http-client/src/bootstrap/add.js
@@ -2,6 +2,7 @@
 
 const Multiaddr = require('multiaddr')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (addr, options = {}) => {
@@ -10,12 +11,13 @@ module.exports = configure(api => {
       addr = null
     }
 
-    options.arg = addr
-
     const res = await api.post('bootstrap/add', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: addr,
+        ...options
+      })
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/bootstrap/list.js
+++ b/packages/ipfs-http-client/src/bootstrap/list.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('bootstrap/list', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/bootstrap/rm.js
+++ b/packages/ipfs-http-client/src/bootstrap/rm.js
@@ -2,6 +2,7 @@
 
 const Multiaddr = require('multiaddr')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (addr, options = {}) => {
@@ -10,12 +11,13 @@ module.exports = configure(api => {
       addr = null
     }
 
-    options.arg = addr
-
     const res = await api.post('bootstrap/rm', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: addr,
+        ...options
+      })
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/cat.js
+++ b/packages/ipfs-http-client/src/cat.js
@@ -1,22 +1,18 @@
 'use strict'
 
 const CID = require('cids')
-const merge = require('merge-options')
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * cat (path, options = {}) {
-    options = merge(
-      options,
-      {
-        arg: typeof path === 'string' ? path : new CID(path).toString()
-      }
-    )
-
     const res = await api.post('cat', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: typeof path === 'string' ? path : new CID(path).toString(),
+        ...options
+      })
     })
 
     yield * res.iterator()

--- a/packages/ipfs-http-client/src/commands.js
+++ b/packages/ipfs-http-client/src/commands.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('commands', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/config/get.js
+++ b/packages/ipfs-http-client/src/config/get.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (key, options = {}) => {
@@ -10,12 +11,15 @@ module.exports = configure(api => {
     }
 
     const url = key ? 'config' : 'config/show'
-    const rsp = await api.post(url, {
+    const res = await api.post(url, {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: { arg: key }
+      searchParams: toUrlSearchParams({
+        arg: key,
+        ...options
+      })
     })
-    const data = await rsp.json()
+    const data = await res.json()
 
     return key ? data.Value : data
   }

--- a/packages/ipfs-http-client/src/config/profiles/apply.js
+++ b/packages/ipfs-http-client/src/config/profiles/apply.js
@@ -1,19 +1,22 @@
 'use strict'
 
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (profile, options = {}) => {
-    options.arg = profile
-    const response = await api.post('config/profile/apply', {
+    const res = await api.post('config/profile/apply', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: profile,
+        ...options
+      })
     })
-    const res = await response.json()
+    const data = await res.json()
 
     return {
-      original: res.OldCfg, updated: res.NewCfg
+      original: data.OldCfg, updated: data.NewCfg
     }
   }
 })

--- a/packages/ipfs-http-client/src/config/profiles/list.js
+++ b/packages/ipfs-http-client/src/config/profiles/list.js
@@ -2,13 +2,14 @@
 
 const toCamel = require('../../lib/object-to-camel')
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('config/profile/list', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })
 
     const data = await res.json()

--- a/packages/ipfs-http-client/src/config/replace.js
+++ b/packages/ipfs-http-client/src/config/replace.js
@@ -3,13 +3,14 @@
 const { Buffer } = require('buffer')
 const multipartRequest = require('../lib/multipart-request')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (config, options = {}) => {
     const res = await api.post('config/replace', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options,
+      searchParams: toUrlSearchParams(options),
       ...(
         await multipartRequest(Buffer.from(JSON.stringify(config)))
       )

--- a/packages/ipfs-http-client/src/dag/put.js
+++ b/packages/ipfs-http-client/src/dag/put.js
@@ -5,6 +5,7 @@ const CID = require('cids')
 const multihash = require('multihashes')
 const configure = require('../lib/configure')
 const multipartRequest = require('../lib/multipart-request')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (dagNode, options = {}) => {
@@ -42,20 +43,15 @@ module.exports = configure(api => {
       serialized = dagNode
     }
 
-    // TODO normalize hash property name
-    options.hash = options.hashAlg
-    options.hashAlg = null
-    const searchParams = new URLSearchParams(options)
-
-    const rsp = await api.post('dag/put', {
+    const res = await api.post('dag/put', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams,
+      searchParams: toUrlSearchParams(options),
       ...(
         await multipartRequest(serialized)
       )
     })
-    const data = await rsp.json()
+    const data = await res.json()
 
     return new CID(data.Cid['/'])
   }

--- a/packages/ipfs-http-client/src/dag/resolve.js
+++ b/packages/ipfs-http-client/src/dag/resolve.js
@@ -2,6 +2,7 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, path, options = {}) => {
@@ -10,14 +11,13 @@ module.exports = configure(api => {
       path = null
     }
 
-    options.arg = path
-      ? [cid, path].join(path.startsWith('/') ? '' : '/')
-      : `${cid}`
-
     const res = await api.post('dag/resolve', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: path ? [cid, path].join(path.startsWith('/') ? '' : '/') : `${cid}`,
+        ...options
+      })
     })
 
     const data = await res.json()

--- a/packages/ipfs-http-client/src/dht/find-peer.js
+++ b/packages/ipfs-http-client/src/dht/find-peer.js
@@ -4,15 +4,17 @@ const { Buffer } = require('buffer')
 const CID = require('cids')
 const multiaddr = require('multiaddr')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function findPeer (peerId, options = {}) {
-    options.arg = `${Buffer.isBuffer(peerId) ? new CID(peerId) : peerId}`
-
     const res = await api.post('dht/findpeer', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: `${Buffer.isBuffer(peerId) ? new CID(peerId) : peerId}`,
+        ...options
+      })
     })
 
     for await (const data of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/find-provs.js
+++ b/packages/ipfs-http-client/src/dht/find-provs.js
@@ -3,14 +3,17 @@
 const CID = require('cids')
 const multiaddr = require('multiaddr')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * findProvs (cid, options = {}) {
-    options.arg = `${new CID(cid)}`
     const res = await api.post('dht/findprovs', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: `${new CID(cid)}`,
+        ...options
+      })
     })
 
     for await (const message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/get.js
+++ b/packages/ipfs-http-client/src/dht/get.js
@@ -3,6 +3,7 @@
 const { Buffer } = require('buffer')
 const encodeBufferURIComponent = require('../lib/encode-buffer-uri-component')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function get (key, options = {}) {
@@ -10,11 +11,13 @@ module.exports = configure(api => {
       throw new Error('invalid key')
     }
 
-    options.key = encodeBufferURIComponent(key)
     const res = await api.post('dht/get', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        key: encodeBufferURIComponent(key),
+        ...options
+      })
     })
 
     for await (const message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/provide.js
+++ b/packages/ipfs-http-client/src/dht/provide.js
@@ -4,18 +4,19 @@ const CID = require('cids')
 const multiaddr = require('multiaddr')
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * provide (cids, options = {}) {
     cids = Array.isArray(cids) ? cids : [cids]
 
-    const searchParams = new URLSearchParams(options)
-    cids.forEach(cid => searchParams.append('arg', `${new CID(cid)}`))
-
     const res = await api.post('dht/provide', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: cids.map(cid => new CID(cid).toString()),
+        ...options
+      })
     })
 
     for await (let message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/put.js
+++ b/packages/ipfs-http-client/src/dht/put.js
@@ -4,17 +4,20 @@ const CID = require('cids')
 const multiaddr = require('multiaddr')
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * put (key, value, options = {}) {
-    const searchParams = new URLSearchParams(options)
-
-    searchParams.append('arg', key)
-    searchParams.append('arg', value)
     const res = await api.post('dht/put', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: [
+          key,
+          value
+        ],
+        ...options
+      })
     })
 
     for await (let message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/query.js
+++ b/packages/ipfs-http-client/src/dht/query.js
@@ -4,14 +4,17 @@ const CID = require('cids')
 const multiaddr = require('multiaddr')
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * query (peerId, options = {}) {
-    options.arg = new CID(peerId)
     const res = await api.post('dht/query', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: new CID(peerId),
+        ...options
+      })
     })
 
     for await (let message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/diag/cmds.js
+++ b/packages/ipfs-http-client/src/diag/cmds.js
@@ -1,12 +1,14 @@
 'use strict'
+
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('diag/cmds', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/diag/net.js
+++ b/packages/ipfs-http-client/src/diag/net.js
@@ -1,12 +1,14 @@
 'use strict'
+
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('diag/net', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
+      searchParams: toUrlSearchParams(options)
     })
     return res.json()
   }

--- a/packages/ipfs-http-client/src/diag/sys.js
+++ b/packages/ipfs-http-client/src/diag/sys.js
@@ -1,12 +1,14 @@
 'use strict'
+
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('diag/sys', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
+      searchParams: toUrlSearchParams(options)
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/dns.js
+++ b/packages/ipfs-http-client/src/dns.js
@@ -1,14 +1,17 @@
 'use strict'
 
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (domain, options = {}) => {
-    options.arg = domain
     const res = await api.post('dns', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: domain,
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/files/chmod.js
+++ b/packages/ipfs-http-client/src/files/chmod.js
@@ -8,7 +8,11 @@ module.exports = configure(api => {
     const res = await api.post('files/chmod', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(path, { ...options, mode })
+      searchParams: toUrlSearchParams({
+        arg: path,
+        mode,
+        ...options
+      })
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/cp.js
+++ b/packages/ipfs-http-client/src/files/cp.js
@@ -12,10 +12,10 @@ module.exports = configure(api => {
     const res = await api.post('files/cp', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(
-        sources.map(src => CID.isCID(src) ? `/ipfs/${src}` : src),
-        options
-      )
+      searchParams: toUrlSearchParams({
+        arg: sources.map(src => CID.isCID(src) ? `/ipfs/${src}` : src),
+        ...options
+      })
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/flush.js
+++ b/packages/ipfs-http-client/src/files/flush.js
@@ -2,6 +2,7 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (path, options = {}) => {
@@ -10,12 +11,13 @@ module.exports = configure(api => {
       path = '/'
     }
 
-    options.arg = path
-
     const res = await api.post('files/flush', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: path,
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/files/ls.js
+++ b/packages/ipfs-http-client/src/files/ls.js
@@ -15,18 +15,17 @@ module.exports = configure(api => {
     const res = await api.post('files/ls', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(
-        CID.isCID(path) ? `/ipfs/${path}` : path, {
-          ...options,
+      searchParams: toUrlSearchParams({
+        arg: CID.isCID(path) ? `/ipfs/${path}` : path,
 
-          // TODO the args below are not in the go-ipfs or interface core
-          stream: options.stream == null ? true : options.stream,
-          long: options.long == null ? true : options.long,
+        // TODO the args below are not in the go-ipfs or interface core docs
+        stream: options.stream == null ? true : options.stream,
+        long: options.long == null ? true : options.long,
 
-          // TODO: remove after go-ipfs 0.5 is released
-          l: options.long == null ? true : options.long
-        }
-      )
+        // TODO: remove after go-ipfs 0.5 is released
+        l: options.long == null ? true : options.long,
+        ...options
+      })
     })
 
     for await (const result of res.ndjson()) {

--- a/packages/ipfs-http-client/src/files/ls.js
+++ b/packages/ipfs-http-client/src/files/ls.js
@@ -19,12 +19,12 @@ module.exports = configure(api => {
         arg: CID.isCID(path) ? `/ipfs/${path}` : path,
 
         // TODO the args below are not in the go-ipfs or interface core docs
-        stream: options.stream == null ? true : options.stream,
         long: options.long == null ? true : options.long,
 
         // TODO: remove after go-ipfs 0.5 is released
         l: options.long == null ? true : options.long,
-        ...options
+        ...options,
+        stream: true
       })
     })
 

--- a/packages/ipfs-http-client/src/files/mkdir.js
+++ b/packages/ipfs-http-client/src/files/mkdir.js
@@ -8,7 +8,10 @@ module.exports = configure(api => {
     const res = await api.post('files/mkdir', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(path, options)
+      searchParams: toUrlSearchParams({
+        arg: path,
+        ...options
+      })
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/mv.js
+++ b/packages/ipfs-http-client/src/files/mv.js
@@ -12,10 +12,10 @@ module.exports = configure(api => {
     const res = await api.post('files/mv', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(
-        sources.map(src => CID.isCID(src) ? `/ipfs/${src}` : src),
-        options
-      )
+      searchParams: toUrlSearchParams({
+        arg: sources.map(src => CID.isCID(src) ? `/ipfs/${src}` : src),
+        ...options
+      })
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/read.js
+++ b/packages/ipfs-http-client/src/files/read.js
@@ -10,9 +10,10 @@ module.exports = configure(api => {
     const res = await api.post('files/read', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(path, {
-        ...options,
-        count: options.count || options.length
+      searchParams: toUrlSearchParams({
+        arg: path,
+        count: options.count || options.length,
+        ...options
       })
     })
 

--- a/packages/ipfs-http-client/src/files/rm.js
+++ b/packages/ipfs-http-client/src/files/rm.js
@@ -11,7 +11,10 @@ module.exports = configure(api => {
     const res = await api.post('files/rm', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(sources, options)
+      searchParams: toUrlSearchParams({
+        arg: sources,
+        ...options
+      })
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/stat.js
+++ b/packages/ipfs-http-client/src/files/stat.js
@@ -15,7 +15,10 @@ module.exports = configure(api => {
     const res = await api.post('files/stat', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(path, options)
+      searchParams: toUrlSearchParams({
+        arg: path,
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/files/touch.js
+++ b/packages/ipfs-http-client/src/files/touch.js
@@ -8,7 +8,10 @@ module.exports = configure(api => {
     const res = await api.post('files/touch', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(path, options)
+      searchParams: toUrlSearchParams({
+        arg: path,
+        ...options
+      })
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/write.js
+++ b/packages/ipfs-http-client/src/files/write.js
@@ -11,10 +11,11 @@ module.exports = configure(api => {
     const res = await api.post('files/write', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(path, {
-        ...options,
+      searchParams: toUrlSearchParams({
+        arg: path,
         streamChannels: true,
-        count: options.count || options.length
+        count: options.count || options.length,
+        ...options
       }),
       ...(
         await multipartRequest({

--- a/packages/ipfs-http-client/src/get-endpoint-config.js
+++ b/packages/ipfs-http-client/src/get-endpoint-config.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const configure = require('./lib/configure')
 
 module.exports = configure(api => {

--- a/packages/ipfs-http-client/src/get.js
+++ b/packages/ipfs-http-client/src/get.js
@@ -4,15 +4,17 @@ const Tar = require('it-tar')
 const { Buffer } = require('buffer')
 const CID = require('cids')
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * get (path, options = {}) {
-    options.arg = `${Buffer.isBuffer(path) ? new CID(path) : path}`
-
     const res = await api.post('get', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: `${Buffer.isBuffer(path) ? new CID(path) : path}`,
+        ...options
+      })
     })
 
     const extractor = Tar.extract()

--- a/packages/ipfs-http-client/src/id.js
+++ b/packages/ipfs-http-client/src/id.js
@@ -3,13 +3,14 @@
 const toCamel = require('./lib/object-to-camel')
 const multiaddr = require('multiaddr')
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('id', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
+      searchParams: toUrlSearchParams(options)
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/export.js
+++ b/packages/ipfs-http-client/src/key/export.js
@@ -1,5 +1,7 @@
 'use strict'
+
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (name, password, options = {}) => {
@@ -8,13 +10,14 @@ module.exports = configure(api => {
       password = null
     }
 
-    options.arg = name
-    options.password = password
-
     const res = await api.post('key/export', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: name,
+        password: password,
+        ...options
+      })
     })
 
     return res.text()

--- a/packages/ipfs-http-client/src/key/gen.js
+++ b/packages/ipfs-http-client/src/key/gen.js
@@ -2,14 +2,17 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (name, options = {}) => {
-    options.arg = name
     const res = await api.post('key/gen', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: name,
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/import.js
+++ b/packages/ipfs-http-client/src/key/import.js
@@ -2,6 +2,7 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (name, pem, password, options = {}) => {
@@ -10,15 +11,15 @@ module.exports = configure(api => {
       password = null
     }
 
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', name)
-    searchParams.set('pem', pem)
-    searchParams.set('password', password)
-
     const res = await api.post('key/import', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: name,
+        pem,
+        password,
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/list.js
+++ b/packages/ipfs-http-client/src/key/list.js
@@ -2,13 +2,14 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('key/list', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
+      searchParams: toUrlSearchParams(options)
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/rename.js
+++ b/packages/ipfs-http-client/src/key/rename.js
@@ -2,17 +2,20 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (oldName, newName, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', oldName)
-    searchParams.append('arg', newName)
-
     const res = await api.post('key/rename', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: [
+          oldName,
+          newName
+        ],
+        ...options
+      })
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/key/rm.js
+++ b/packages/ipfs-http-client/src/key/rm.js
@@ -2,16 +2,17 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (name, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', name)
-
     const res = await api.post('key/rm', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: name,
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/lib/to-url-search-params.js
+++ b/packages/ipfs-http-client/src/lib/to-url-search-params.js
@@ -3,32 +3,43 @@
 const modeToString = require('./mode-to-string')
 const mtimeToObject = require('./mtime-to-object')
 
-module.exports = (args, options) => {
-  const searchParams = new URLSearchParams(options)
-
-  if (args === undefined || args === null) {
-    args = []
-  } else if (!Array.isArray(args)) {
-    args = [args]
+module.exports = ({ arg, searchParams, hashAlg, mtime, mode, ...options } = {}) => {
+  if (searchParams) {
+    options = {
+      ...options,
+      ...searchParams
+    }
   }
 
-  args.forEach(arg => searchParams.append('arg', arg))
-
-  if (options.hashAlg) {
-    searchParams.set('hash', options.hashAlg)
-    searchParams.delete('hashAlg')
+  if (hashAlg) {
+    options.hash = hashAlg
   }
 
-  if (options.mtime != null) {
-    const mtime = mtimeToObject(options.mtime)
+  if (mtime != null) {
+    mtime = mtimeToObject(mtime)
 
-    searchParams.set('mtime', mtime.secs)
-    searchParams.set('mtime-nsecs', mtime.nsecs)
+    options.mtime = mtime.secs
+    options.mtimeNsecs = mtime.nsecs
   }
 
-  if (options.mode != null) {
-    searchParams.set('mode', modeToString(options.mode))
+  if (mode != null) {
+    options.mode = modeToString(mode)
   }
 
-  return searchParams
+  if (options.timeout && !isNaN(options.timeout)) {
+    // server API expects timeouts as strings
+    options.timeout = `${options.timeout}ms`
+  }
+
+  if (arg === undefined || arg === null) {
+    arg = []
+  } else if (!Array.isArray(arg)) {
+    arg = [arg]
+  }
+
+  const urlSearchParams = new URLSearchParams(options)
+
+  arg.forEach(arg => urlSearchParams.append('arg', arg))
+
+  return urlSearchParams
 }

--- a/packages/ipfs-http-client/src/log/level.js
+++ b/packages/ipfs-http-client/src/log/level.js
@@ -2,17 +2,20 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (subsystem, level, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.append('arg', subsystem)
-    searchParams.append('arg', level)
-
     const res = await api.post('log/level', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: [
+          subsystem,
+          level
+        ],
+        ...options
+      })
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/log/ls.js
+++ b/packages/ipfs-http-client/src/log/ls.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('log/ls', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
+      searchParams: toUrlSearchParams(options)
     })
 
     const data = await res.json()

--- a/packages/ipfs-http-client/src/log/tail.js
+++ b/packages/ipfs-http-client/src/log/tail.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * tail (options = {}) {
     const res = await api.post('log/tail', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })
 
     yield * res.ndjson()

--- a/packages/ipfs-http-client/src/ls.js
+++ b/packages/ipfs-http-client/src/ls.js
@@ -3,16 +3,17 @@
 const { Buffer } = require('buffer')
 const CID = require('cids')
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * ls (path, options = {}) {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${Buffer.isBuffer(path) ? new CID(path) : path}`)
-
     const res = await api.post('ls', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: `${Buffer.isBuffer(path) ? new CID(path) : path}`,
+        ...options
+      })
     })
 
     for await (let result of res.ndjson()) {

--- a/packages/ipfs-http-client/src/mount.js
+++ b/packages/ipfs-http-client/src/mount.js
@@ -2,13 +2,14 @@
 
 const toCamel = require('./lib/object-to-camel')
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('dns', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/publish.js
+++ b/packages/ipfs-http-client/src/name/publish.js
@@ -2,16 +2,17 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (path, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', path)
-
     const res = await api.post('name/publish', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: path,
+        ...options
+      })
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/pubsub/cancel.js
+++ b/packages/ipfs-http-client/src/name/pubsub/cancel.js
@@ -2,16 +2,17 @@
 
 const toCamel = require('../../lib/object-to-camel')
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (name, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', name)
-
     const res = await api.post('name/pubsub/cancel', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: name,
+        ...options
+      })
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/pubsub/state.js
+++ b/packages/ipfs-http-client/src/name/pubsub/state.js
@@ -2,13 +2,14 @@
 
 const toCamel = require('../../lib/object-to-camel')
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('name/pubsub/state', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
+      searchParams: toUrlSearchParams(options)
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/pubsub/subs.js
+++ b/packages/ipfs-http-client/src/name/pubsub/subs.js
@@ -1,12 +1,14 @@
 'use strict'
 
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await api.post('name/pubsub/subs', {
       timeout: options.timeout,
-      signal: options.signal
+      signal: options.signal,
+      searchParams: toUrlSearchParams(options)
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/name/resolve.js
+++ b/packages/ipfs-http-client/src/name/resolve.js
@@ -1,17 +1,18 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * (path, options = {}) {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', path)
-    searchParams.set('stream', options.stream || true)
-
     const res = await api.post('name/resolve', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: path,
+        stream: options.stream || true,
+        ...options
+      })
     })
 
     for await (const result of res.ndjson()) {

--- a/packages/ipfs-http-client/src/name/resolve.js
+++ b/packages/ipfs-http-client/src/name/resolve.js
@@ -10,8 +10,8 @@ module.exports = configure(api => {
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,
-        stream: options.stream || true,
-        ...options
+        ...options,
+        stream: true
       })
     })
 

--- a/packages/ipfs-http-client/src/object/data.js
+++ b/packages/ipfs-http-client/src/object/data.js
@@ -3,16 +3,17 @@
 const { Buffer } = require('buffer')
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function data (cid, options = {}) {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`)
-
     const res = await api.post('object/data', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
+        ...options
+      })
     })
     const data = await res.arrayBuffer()
 

--- a/packages/ipfs-http-client/src/object/get.js
+++ b/packages/ipfs-http-client/src/object/get.js
@@ -4,17 +4,18 @@ const { Buffer } = require('buffer')
 const CID = require('cids')
 const { DAGNode, DAGLink } = require('ipld-dag-pb')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`)
-    searchParams.set('data-encoding', 'base64')
-
     const res = await api.post('object/get', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
+        dataEncoding: 'base64',
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/object/links.js
+++ b/packages/ipfs-http-client/src/object/links.js
@@ -4,16 +4,17 @@ const { Buffer } = require('buffer')
 const CID = require('cids')
 const { DAGLink } = require('ipld-dag-pb')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`)
-
     const res = await api.post('object/links', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
+        ...options
+      })
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/object/new.js
+++ b/packages/ipfs-http-client/src/object/new.js
@@ -2,6 +2,7 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (template, options = {}) => {
@@ -10,13 +11,13 @@ module.exports = configure(api => {
       template = null
     }
 
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', template)
-
     const res = await api.post('object/new', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: template,
+        ...options
+      })
     })
 
     const { Hash } = await res.json()

--- a/packages/ipfs-http-client/src/object/patch/append-data.js
+++ b/packages/ipfs-http-client/src/object/patch/append-data.js
@@ -4,20 +4,23 @@ const { Buffer } = require('buffer')
 const CID = require('cids')
 const multipartRequest = require('../../lib/multipart-request')
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, data, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`)
-
-    const { Hash } = await (await api.post('object/patch/append-data', {
+    const res = await api.post('object/patch/append-data', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams,
+      searchParams: toUrlSearchParams({
+        arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
+        ...options
+      }),
       ...(
         await multipartRequest(data)
       )
-    })).json()
+    })
+
+    const { Hash } = await res.json()
 
     return new CID(Hash)
   }

--- a/packages/ipfs-http-client/src/object/patch/rm-link.js
+++ b/packages/ipfs-http-client/src/object/patch/rm-link.js
@@ -3,18 +3,23 @@
 const { Buffer } = require('buffer')
 const CID = require('cids')
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, dLink, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.append('arg', `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`)
-    searchParams.append('arg', dLink.Name || dLink.name || null)
-
-    const { Hash } = await (await api.post('object/patch/rm-link', {
+    const res = await api.post('object/patch/rm-link', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
-    })).json()
+      searchParams: toUrlSearchParams({
+        arg: [
+          `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
+          dLink.Name || dLink.name || null
+        ],
+        ...options
+      })
+    })
+
+    const { Hash } = await res.json()
 
     return new CID(Hash)
   }

--- a/packages/ipfs-http-client/src/object/patch/set-data.js
+++ b/packages/ipfs-http-client/src/object/patch/set-data.js
@@ -4,16 +4,19 @@ const { Buffer } = require('buffer')
 const CID = require('cids')
 const multipartRequest = require('../../lib/multipart-request')
 const configure = require('../../lib/configure')
+const toUrlSearchParams = require('../../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, data, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`)
-
     const { Hash } = await (await api.post('object/patch/set-data', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams,
+      searchParams: toUrlSearchParams({
+        arg: [
+          `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`
+        ],
+        ...options
+      }),
       ...(
         await multipartRequest(data)
       )

--- a/packages/ipfs-http-client/src/object/put.js
+++ b/packages/ipfs-http-client/src/object/put.js
@@ -5,6 +5,7 @@ const { DAGNode } = require('ipld-dag-pb')
 const { Buffer } = require('buffer')
 const multipartRequest = require('../lib/multipart-request')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (obj, options = {}) => {
@@ -46,7 +47,7 @@ module.exports = configure(api => {
     const res = await api.post('object/put', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options,
+      searchParams: toUrlSearchParams(options),
       ...(
         await multipartRequest(buf)
       )

--- a/packages/ipfs-http-client/src/object/stat.js
+++ b/packages/ipfs-http-client/src/object/stat.js
@@ -3,18 +3,19 @@
 const { Buffer } = require('buffer')
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (cid, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`)
-
     let res
     try {
       res = await (await api.post('object/stat', {
         timeout: options.timeout,
         signal: options.signal,
-        searchParams
+        searchParams: toUrlSearchParams({
+          arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
+          ...options
+        })
       })).json()
     } catch (err) {
       if (err.name === 'TimeoutError') {

--- a/packages/ipfs-http-client/src/pin/add.js
+++ b/packages/ipfs-http-client/src/pin/add.js
@@ -2,18 +2,19 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (paths, options = {}) => {
     paths = Array.isArray(paths) ? paths : [paths]
 
-    const searchParams = new URLSearchParams(options)
-    paths.forEach(path => searchParams.append('arg', `${path}`))
-
     const res = await (await api.post('pin/add', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: paths.map(path => `${path}`),
+        ...options
+      })
     })).json()
 
     return (res.Pins || []).map(cid => ({ cid: new CID(cid) }))

--- a/packages/ipfs-http-client/src/pin/ls.js
+++ b/packages/ipfs-http-client/src/pin/ls.js
@@ -2,6 +2,7 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * ls (path, options = {}) {
@@ -12,14 +13,14 @@ module.exports = configure(api => {
 
     path = Array.isArray(path) ? path : [path]
 
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('stream', options.stream || true)
-    path.forEach(p => searchParams.append('arg', `${p}`))
-
     const res = await api.post('pin/ls', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
+      searchParams: toUrlSearchParams({
+        arg: path.map(p => `${p}`),
+        stream: options.stream || true,
+        ...options
+      })
     })
 
     for await (const pin of res.ndjson()) {

--- a/packages/ipfs-http-client/src/pin/ls.js
+++ b/packages/ipfs-http-client/src/pin/ls.js
@@ -18,8 +18,8 @@ module.exports = configure(api => {
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path.map(p => `${p}`),
-        stream: options.stream || true,
-        ...options
+        ...options,
+        stream: true
       })
     })
 

--- a/packages/ipfs-http-client/src/pin/rm.js
+++ b/packages/ipfs-http-client/src/pin/rm.js
@@ -2,18 +2,21 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (path, options = {}) => {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${path}`)
-
-    const res = await (await api.post('pin/rm', {
+    const res = await api.post('pin/rm', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
-    })).json()
+      searchParams: toUrlSearchParams({
+        arg: `${path}`,
+        ...options
+      })
+    })
 
-    return (res.Pins || []).map(cid => ({ cid: new CID(cid) }))
+    const data = await res.json()
+
+    return (data.Pins || []).map(cid => ({ cid: new CID(cid) }))
   }
 })

--- a/packages/ipfs-http-client/src/ping.js
+++ b/packages/ipfs-http-client/src/ping.js
@@ -2,16 +2,17 @@
 
 const toCamel = require('./lib/object-to-camel')
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * ping (peerId, options = {}) {
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', `${peerId}`)
-
     const res = await api.post('ping', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams,
+      searchParams: toUrlSearchParams({
+        arg: `${peerId}`,
+        ...options
+      }),
       transform: toCamel
     })
 

--- a/packages/ipfs-http-client/src/pubsub/ls.js
+++ b/packages/ipfs-http-client/src/pubsub/ls.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const { Strings } = await (await api.post('pubsub/ls', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
+      searchParams: toUrlSearchParams(options)
     })).json()
 
     return Strings || []

--- a/packages/ipfs-http-client/src/pubsub/peers.js
+++ b/packages/ipfs-http-client/src/pubsub/peers.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (topic, options = {}) => {
@@ -9,14 +10,16 @@ module.exports = configure(api => {
       topic = null
     }
 
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', topic)
-
-    const { Strings } = await (await api.post('pubsub/peers', {
+    const res = await api.post('pubsub/peers', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
-    })).json()
+      searchParams: toUrlSearchParams({
+        arg: topic,
+        ...options
+      })
+    })
+
+    const { Strings } = await res.json()
 
     return Strings || []
   }

--- a/packages/ipfs-http-client/src/pubsub/publish.js
+++ b/packages/ipfs-http-client/src/pubsub/publish.js
@@ -3,19 +3,24 @@
 const { Buffer } = require('buffer')
 const encodeBuffer = require('../lib/encode-buffer-uri-component')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (topic, data, options = {}) => {
     data = Buffer.from(data)
 
-    const searchParams = new URLSearchParams(options)
-    searchParams.set('arg', topic)
+    const searchParams = toUrlSearchParams({
+      arg: [
+        topic
+      ],
+      ...options
+    })
 
-    const res = await (await api.post(`pubsub/pub?${searchParams}&arg=${encodeBuffer(data)}`, {
+    const res = await api.post(`pubsub/pub?${searchParams}&arg=${encodeBuffer(data)}`, {
       timeout: options.timeout,
       signal: options.signal
-    })).text()
+    })
 
-    return res
+    await res.text()
   }
 })

--- a/packages/ipfs-http-client/src/refs/index.js
+++ b/packages/ipfs-http-client/src/refs/index.js
@@ -4,23 +4,21 @@ const { Buffer } = require('buffer')
 const CID = require('cids')
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure((api, options) => {
   const refs = async function * (args, options = {}) {
-    const searchParams = new URLSearchParams(options)
-
     if (!Array.isArray(args)) {
       args = [args]
-    }
-
-    for (const arg of args) {
-      searchParams.append('arg', `${Buffer.isBuffer(arg) ? new CID(arg) : arg}`)
     }
 
     const res = await api.post('refs', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams,
+      searchParams: toUrlSearchParams({
+        arg: args.map(arg => `${Buffer.isBuffer(arg) ? new CID(arg) : arg}`),
+        ...options
+      }),
       transform: toCamel
     })
 

--- a/packages/ipfs-http-client/src/refs/local.js
+++ b/packages/ipfs-http-client/src/refs/local.js
@@ -2,13 +2,15 @@
 
 const toCamel = require('../lib/object-to-camel')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * refsLocal (options = {}) {
     const res = await api.post('refs/local', {
       timeout: options.timeout,
       signal: options.signal,
-      transform: toCamel
+      transform: toCamel,
+      searchParams: toUrlSearchParams(options)
     })
 
     yield * res.ndjson()

--- a/packages/ipfs-http-client/src/repo/gc.js
+++ b/packages/ipfs-http-client/src/repo/gc.js
@@ -2,13 +2,14 @@
 
 const CID = require('cids')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * gc (options = {}) {
     const res = await api.post('repo/gc', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options,
+      searchParams: toUrlSearchParams(options),
       transform: (res) => {
         return {
           err: res.Error ? new Error(res.Error) : null,

--- a/packages/ipfs-http-client/src/repo/stat.js
+++ b/packages/ipfs-http-client/src/repo/stat.js
@@ -2,21 +2,23 @@
 
 const { BigNumber } = require('bignumber.js')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
-    const res = await (await api.post('repo/stat', {
+    const res = await api.post('repo/stat', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
-    })).json()
+      searchParams: toUrlSearchParams(options)
+    })
+    const data = await res.json()
 
     return {
-      numObjects: new BigNumber(res.NumObjects),
-      repoSize: new BigNumber(res.RepoSize),
-      repoPath: res.RepoPath,
-      version: res.Version,
-      storageMax: new BigNumber(res.StorageMax)
+      numObjects: new BigNumber(data.NumObjects),
+      repoSize: new BigNumber(data.RepoSize),
+      repoPath: data.RepoPath,
+      version: data.Version,
+      storageMax: new BigNumber(data.StorageMax)
     }
   }
 })

--- a/packages/ipfs-http-client/src/repo/version.js
+++ b/packages/ipfs-http-client/src/repo/version.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await (await api.post('repo/version', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })).json()
 
     return res.Version

--- a/packages/ipfs-http-client/src/resolve.js
+++ b/packages/ipfs-http-client/src/resolve.js
@@ -1,16 +1,19 @@
 'use strict'
 
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (path, options = {}) => {
-    options.arg = path
-    const rsp = await api.post('resolve', {
+    const res = await api.post('resolve', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams({
+        arg: path,
+        ...options
+      })
     })
-    const data = await rsp.json()
-    return data.Path
+    const { Path } = await res.json()
+    return Path
   }
 })

--- a/packages/ipfs-http-client/src/stats/bw.js
+++ b/packages/ipfs-http-client/src/stats/bw.js
@@ -2,13 +2,14 @@
 
 const { BigNumber } = require('bignumber.js')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async function * bw (options = {}) {
     const res = await api.post('stats/bw', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options,
+      searchParams: toUrlSearchParams(options),
       transform: (stats) => ({
         totalIn: new BigNumber(stats.TotalIn),
         totalOut: new BigNumber(stats.TotalOut),

--- a/packages/ipfs-http-client/src/stop.js
+++ b/packages/ipfs-http-client/src/stop.js
@@ -1,13 +1,16 @@
 'use strict'
 
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
-    return (await api.post('shutdown', {
+    const res = await api.post('shutdown', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
-    })).text()
+      searchParams: toUrlSearchParams(options)
+    })
+
+    await res.text()
   }
 })

--- a/packages/ipfs-http-client/src/swarm/addrs.js
+++ b/packages/ipfs-http-client/src/swarm/addrs.js
@@ -2,18 +2,20 @@
 
 const multiaddr = require('multiaddr')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
-    const res = await (await api.post('swarm/addrs', {
+    const res = await api.post('swarm/addrs', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
-    })).json()
+      searchParams: toUrlSearchParams(options)
+    })
+    const { Addrs } = await res.json()
 
-    return Object.keys(res.Addrs).map(id => ({
+    return Object.keys(Addrs).map(id => ({
       id,
-      addrs: (res.Addrs[id] || []).map(a => multiaddr(a))
+      addrs: (Addrs[id] || []).map(a => multiaddr(a))
     }))
   }
 })

--- a/packages/ipfs-http-client/src/swarm/connect.js
+++ b/packages/ipfs-http-client/src/swarm/connect.js
@@ -1,20 +1,22 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (addrs, options = {}) => {
     addrs = Array.isArray(addrs) ? addrs : [addrs]
 
-    const searchParams = new URLSearchParams(options)
-    addrs.forEach(addr => searchParams.append('arg', addr))
-
-    const res = await (await api.post('swarm/connect', {
+    const res = await api.post('swarm/connect', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
-    })).json()
+      searchParams: toUrlSearchParams({
+        arg: addrs.map(addr => `${addr}`),
+        ...options
+      })
+    })
+    const { Strings } = await res.json()
 
-    return res.Strings || []
+    return Strings || []
   }
 })

--- a/packages/ipfs-http-client/src/swarm/disconnect.js
+++ b/packages/ipfs-http-client/src/swarm/disconnect.js
@@ -1,20 +1,22 @@
 'use strict'
 
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (addrs, options = {}) => {
     addrs = Array.isArray(addrs) ? addrs : [addrs]
 
-    const searchParams = new URLSearchParams(options)
-    addrs.forEach(addr => searchParams.append('arg', `${addr}`))
-
-    const res = await (await api.post('swarm/disconnect', {
+    const res = await api.post('swarm/disconnect', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams
-    })).json()
+      searchParams: toUrlSearchParams({
+        arg: addrs.map(addr => `${addr}`),
+        ...options
+      })
+    })
+    const { Strings } = await res.json()
 
-    return res.Strings || []
+    return Strings || []
   }
 })

--- a/packages/ipfs-http-client/src/swarm/localAddrs.js
+++ b/packages/ipfs-http-client/src/swarm/localAddrs.js
@@ -2,15 +2,17 @@
 
 const multiaddr = require('multiaddr')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
-    const res = await (await api.post('swarm/addrs/local', {
+    const res = await api.post('swarm/addrs/local', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
-    })).json()
+      searchParams: toUrlSearchParams(options)
+    })
+    const { Strings } = await res.json()
 
-    return (res.Strings || []).map(a => multiaddr(a))
+    return (Strings || []).map(a => multiaddr(a))
   }
 })

--- a/packages/ipfs-http-client/src/swarm/peers.js
+++ b/packages/ipfs-http-client/src/swarm/peers.js
@@ -2,13 +2,14 @@
 
 const multiaddr = require('multiaddr')
 const configure = require('../lib/configure')
+const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
     const res = await (await api.post('swarm/peers', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
+      searchParams: toUrlSearchParams(options)
     })).json()
 
     return (res.Peers || []).map(peer => {

--- a/packages/ipfs-http-client/src/update.js
+++ b/packages/ipfs-http-client/src/update.js
@@ -1,13 +1,16 @@
 'use strict'
 
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
-    return (await api.post('update', {
+    const res = await api.post('update', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options
-    })).text()
+      searchParams: toUrlSearchParams(options)
+    })
+
+    await res.text()
   }
 })

--- a/packages/ipfs-http-client/src/version.js
+++ b/packages/ipfs-http-client/src/version.js
@@ -2,15 +2,17 @@
 
 const toCamel = require('./lib/object-to-camel')
 const configure = require('./lib/configure')
+const toUrlSearchParams = require('./lib/to-url-search-params')
 
 module.exports = configure(api => {
   return async (options = {}) => {
-    const res = await (await api.post('version', {
+    const res = await api.post('version', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: options.searchParams
-    })).json()
+      searchParams: toUrlSearchParams(options)
+    })
+    const data = await res.json()
 
-    return toCamel(res)
+    return toCamel(data)
   }
 })

--- a/packages/ipfs-http-client/test/dag.spec.js
+++ b/packages/ipfs-http-client/test/dag.spec.js
@@ -48,7 +48,7 @@ describe('.dag', function () {
     expect(result.value).to.deep.equal(cbor)
   })
 
-  it('should callback with error when missing DAG resolver for multicodec from requested CID', async () => {
+  it('should error when missing DAG resolver for multicodec from requested CID', async () => {
     const block = await ipfs.block.put(Buffer.from([0, 1, 2, 3]), {
       cid: new CID('z8mWaJ1dZ9fH5EetPuRsj8jj26pXsgpsr')
     })


### PR DESCRIPTION
Refactors how we pass url params to the API, all args are now normalised in one place.  If a timeout is passed it is passed on to the server as a url search param.

N.b. this does mean that timeouts are set in the client and on the server so it's not always clear which will expire first, though one will expire.

We do our best to ensure the errors are the same, though when the API is streaming there's no way to tell if the request completed successfully or if the timeout occurred as the timeout message arrives in http trailers.

Also fixes a problem we have, where the README [says](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/README.md#additional-options) we support passing `searchParams` as an additional option:

```javascript
await ipfs.id({
  searchParams: {
    foo: 'bar'
  }
})
```

yet this ends up getting sent as:

```
POST /api/v0/id?search-params==%5Bobject+Object%5D
```