### PR TITLE
test: make refs tests iteration order independent

### DIFF
--- a/packages/interface-ipfs-core/src/refs.js
+++ b/packages/interface-ipfs-core/src/refs.js
@@ -199,19 +199,19 @@ function getRefsTests () {
     },
 
     'should get refs with recursive and unique option': {
-      params: { format: '<linkname>', recursive: true, unique: true },
+      params: { format: '<dst>', recursive: true, unique: true },
       expected: [
-        'animals',
-        'land',
-        'african.txt',
-        'americas.txt',
-        'australian.txt',
-        'sea',
-        'atlantic.txt',
-        'indian.txt',
-        'fruits',
-        'tropical.txt',
-        'mushroom.txt'
+        'QmRfqT4uTUgFXhWbfBZm6eZxi2FQ8pqYK5tcWRyTZ7RcgY',
+        'QmUXzZKa3xhTauLektUiK4GiogHskuz1c57CnnoP4TgYJD',
+        'QmVX54jfjB8eRxLVxyQSod6b1FyDh7mR4mQie9j97i2Qk3',
+        'QmWEuXAjUGyndgr4MKqMBgzMW36XgPgvitt2jsXgtuc7JE',
+        'QmYEJ7qQNZUvBnv4SZ3rEbksagaan3sGvnUq948vSG8Z34',
+        'QmYLvZrFn8KE2bcJ9UFhthScBVbbcXEgkJnnCBeKWYkpuQ',
+        'Qma5z9bmwPcrWLJxX6Vj6BrcybaFg84c2riNbUKrSVf8h1',
+        'QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa',
+        'QmdHVR8M4zAdGctnTYq4fyPZjTwwzdcBpGWAfMAhAVfT9n',
+        'Qmf6MrqT2oAve9diagLTMCYFPEcSx7fnUdW3xAjhXm32vo',
+        'QmfP6D9bRV4FEYDL4EHZtZG58kDwDfnzmyjuyK5d1pvzbM'
       ]
     },
 

--- a/packages/interface-ipfs-core/src/refs.js
+++ b/packages/interface-ipfs-core/src/refs.js
@@ -64,8 +64,9 @@ module.exports = (common, options) => {
 
         const refs = await all(ipfs.refs(p, params))
 
+        // Sort the refs not to lock-in the iteration order
         // Check there was no error and the refs match what was expected
-        expect(refs.map(r => r.ref)).to.eql(expected)
+        expect(refs.map(r => r.ref).sort()).to.eql(expected.sort())
       })
     }
 


### PR DESCRIPTION
Proposing here a change which will make the `refs.js` tests dag node iteration order independent by sorting the expected and actual refs list. In the soon-to-be polished rust-ipfs refs implementation the refs are iterated breadth-first. Looking at the js-ipfs implementation I am not 100% sure but looks like the implementation is recursive depth-first (I could be wrong).

The iteration orders differ on almost half of the tests, but only big difference is with the test modified on the second commit: recursive+unique test with formatting `<linkname>` where a document has two names and breadth-first and depth-first offer the different names as a result.

The proposed changes are similar to what is already done for the dag-cbor nodes (sorted).