### PR TITLE
chore: remove second greaterThanZero check from block.rm test

### DIFF
--- a/packages/interface-ipfs-core/src/block/rm.js
+++ b/packages/interface-ipfs-core/src/block/rm.js
@@ -39,7 +39,6 @@ module.exports = (common, options) => {
 
       // did we actually remove the block?
       const localRefsAfterRemove = await all(ipfs.refs.local())
-      expect(localRefsAfterRemove).to.have.property('length').that.is.greaterThan(0)
       expect(localRefsAfterRemove.find(ref => ref.ref === cid.toString())).to.not.be.ok()
     })
 


### PR DESCRIPTION
This PR removes the `expect(localRefsAfterRemove).to.have.property('length').that.is.greaterThan(0)` from line 42. The rationale here is that the `rs-ipfs` nodes start with a completely empty blockstore. Once only block added is removed, then it drops back to one again.

This was imo the least obtrusive move I could make with the tests, the alternative could be to seed a cid2 within the test to ensure it was always `greaterThanZero`