### PR TITLE
refactor: replace ipfs.add in dag.get tests

### DIFF
--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -5,7 +5,6 @@ const dagPB = require('ipld-dag-pb')
 const DAGNode = dagPB.DAGNode
 const dagCBOR = require('ipld-dag-cbor')
 const Unixfs = require('ipfs-unixfs')
-const all = require('it-all')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
 /** @typedef { import("ipfsd-ctl/src/factory") } Factory */

--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -154,9 +154,11 @@ module.exports = (common, options) => {
     it('should get a node added as CIDv1 with a CIDv0', async () => {
       const input = Buffer.from(`TEST${Math.random()}`)
 
-      const res = await all(ipfs.add(input, { cidVersion: 1, rawLeaves: false }))
+      const inner = new Unixfs({ type: 'file', data: input })
+      const serialized = new DAGNode(inner.marshal()).serialize()
+      const res = await ipfs.block.put(serialized, { version: 1 })
 
-      const cidv1 = res[0].cid
+      const cidv1 = res.cid
       expect(cidv1.version).to.equal(1)
 
       const cidv0 = cidv1.toV0()


### PR DESCRIPTION
this is similar to other similar changes, we didn't start by implementing `ipfs.add` in `rust-ipfs`.

Related PR's: #2972, #2980, #2982, #2983