### PR TITLE
chore: update ipfs-bitswap

### DIFF
--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -92,7 +92,7 @@
     "hapi-pino": "^6.1.0",
     "hashlru": "^2.3.0",
     "interface-datastore": "^0.8.0",
-    "ipfs-bitswap": "^0.27.1",
+    "ipfs-bitswap": "^0.28.0",
     "ipfs-block": "^0.8.1",
     "ipfs-block-service": "^0.16.0",
     "ipfs-http-client": "^42.0.0",


### PR DESCRIPTION
This PR updates ipfs-bitswap to `0.28` after [ipfs/js-ipfs-bitswap#204](https://github.com/ipfs/js-ipfs-bitswap/pull/204/)