### PR TITLE
feat(ipfs): add libp2p-noise as fallback support for libp2p-secio

### DIFF
--- a/packages/ipfs/package-list.json
+++ b/packages/ipfs/package-list.json
@@ -45,6 +45,7 @@
     ["libp2p/js-libp2p-kad-dht", "libp2p-kad-dht"],
     ["libp2p/js-libp2p-mdns", "libp2p-mdns"],
     ["libp2p/js-libp2p-bootstrap", "libp2p-bootstrap"],
+    ["NodeFactoryIo/js-libp2p-noise", "libp2p-noise"],
     ["libp2p/js-libp2p-secio", "libp2p-secio"],
     ["libp2p/js-libp2p-tcp", "libp2p-tcp"],
     ["libp2p/js-libp2p-webrtc-star", "libp2p-webrtc-star"],

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -138,6 +138,7 @@
     "libp2p-kad-dht": "^0.19.5",
     "libp2p-mdns": "^0.14.1",
     "libp2p-mplex": "^0.9.3",
+    "libp2p-noise": "^1.1.0",
     "libp2p-record": "^0.7.3",
     "libp2p-secio": "^0.12.2",
     "libp2p-tcp": "^0.14.5",

--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -4,6 +4,7 @@ const WS = require('libp2p-websockets')
 const WebRTCStar = require('libp2p-webrtc-star')
 const Multiplex = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
+const { NOISE } = require('libp2p-noise')
 const KadDHT = require('libp2p-kad-dht')
 const GossipSub = require('libp2p-gossipsub')
 const ipnsUtils = require('../ipns/routing/utils')
@@ -24,7 +25,8 @@ module.exports = () => {
         Multiplex
       ],
       connEncryption: [
-        SECIO
+        SECIO,
+        NOISE
       ],
       peerDiscovery: [],
       dht: KadDHT,

--- a/packages/ipfs/src/core/runtime/libp2p-nodejs.js
+++ b/packages/ipfs/src/core/runtime/libp2p-nodejs.js
@@ -7,6 +7,7 @@ const KadDHT = require('libp2p-kad-dht')
 const GossipSub = require('libp2p-gossipsub')
 const Multiplex = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
+const { NOISE } = require('libp2p-noise')
 const ipnsUtils = require('../ipns/routing/utils')
 
 module.exports = () => {
@@ -25,7 +26,8 @@ module.exports = () => {
         Multiplex
       ],
       connEncryption: [
-        SECIO
+        SECIO,
+        NOISE
       ],
       peerDiscovery: [
         MulticastDNS


### PR DESCRIPTION
The target release of this is in conjunction with the go-ipfs 0.6 release (scheduled for June with an RC in in May).

* This adds support for the Noise security transport, but does not change the default from Secio
* A future release should prioritize Noise once the network has had time to Upgrade

### Rollout Plan
- Add support for Noise
- [Time allotted for network to upgrade]
- Prioritize Noise over Secio
- [Time allotted for network to upgrade]
- Remove support for Secio

required by https://github.com/libp2p/js-libp2p/issues/615