### PR TITLE
fix: skip gc tests over http on windows

### DIFF
--- a/packages/interface-ipfs-core/src/repo/gc.js
+++ b/packages/interface-ipfs-core/src/repo/gc.js
@@ -180,7 +180,7 @@ module.exports = (common, options) => {
       const obj = await new DAGNode(Buffer.from('fruit'), [{
         Name: 'p',
         Hash: dataCid,
-        TSize: addRes[0].size
+        Tsize: addRes[0].size
       }])
 
       // Put the object into IPFS

--- a/packages/ipfs-http-client/test/interface.spec.js
+++ b/packages/ipfs-http-client/test/interface.spec.js
@@ -567,7 +567,24 @@ describe('interface-ipfs-core tests', () => {
     ] : null
   })
 
-  tests.repo(commonFactory)
+  tests.repo(commonFactory, {
+    skip: isWindows ? [{
+      name: 'should run garbage collection',
+      reason: 'https://github.com/ipfs/go-ipfs/issues/7225'
+    }, {
+      name: 'should clean up unpinned data',
+      reason: 'https://github.com/ipfs/go-ipfs/issues/7225'
+    }, {
+      name: 'should clean up removed MFS files',
+      reason: 'https://github.com/ipfs/go-ipfs/issues/7225'
+    }, {
+      name: 'should clean up block only after unpinned and removed from MFS',
+      reason: 'https://github.com/ipfs/go-ipfs/issues/7225'
+    }, {
+      name: 'should clean up indirectly pinned data after recursive pin removal',
+      reason: 'https://github.com/ipfs/go-ipfs/issues/7225'
+    }] : null
+  })
 
   tests.stats(commonFactory)
 


### PR DESCRIPTION
A temporary measure until go-ipfs 0.5.0 is released

Refs: https://github.com/ipfs/go-ipfs/issues/7225