### PR TITLE
fix: fix react example

### DIFF
--- a/examples/browser-create-react-app/src/hooks/use-ipfs-factory.js
+++ b/examples/browser-create-react-app/src/hooks/use-ipfs-factory.js
@@ -13,7 +13,7 @@ let ipfs = null
  * so use-ipfs calls can grab it from there rather than expecting
  * it to be passed in.
  */
-export default function useIpfsFactory ({ commands }) {
+export default function useIpfsFactory () {
   const [isIpfsReady, setIpfsReady] = useState(Boolean(ipfs))
   const [ipfsInitError, setIpfsInitError] = useState(null)
 
@@ -21,6 +21,27 @@ export default function useIpfsFactory ({ commands }) {
     // The fn to useEffect should not return anything other than a cleanup fn,
     // So it cannot be marked async, which causes it to return a promise,
     // Hence we delegate to a async fn rather than making the param an async fn.
+    async function startIpfs () {
+      if (ipfs) {
+        console.log('IPFS already started')
+      } else if (window.ipfs && window.ipfs.enable) {
+        console.log('Found window.ipfs')
+        ipfs = await window.ipfs.enable({ commands: ['id'] })
+      } else {
+        try {
+          console.time('IPFS Started')
+          ipfs = await Ipfs.create()
+          console.timeEnd('IPFS Started')
+        } catch (error) {
+          console.error('IPFS init error:', error)
+          ipfs = null
+          setIpfsInitError(error)
+        }
+      }
+
+      setIpfsReady(Boolean(ipfs))
+    }
+
     startIpfs()
     return function cleanup () {
       if (ipfs && ipfs.stop) {
@@ -31,27 +52,6 @@ export default function useIpfsFactory ({ commands }) {
       }
     }
   }, [])
-
-  async function startIpfs () {
-    if (ipfs) {
-      console.log('IPFS already started')
-    } else if (window.ipfs && window.ipfs.enable) {
-      console.log('Found window.ipfs')
-      ipfs = await window.ipfs.enable({ commands })
-    } else {
-      try {
-        console.time('IPFS Started')
-        ipfs = await Ipfs.create()
-        console.timeEnd('IPFS Started')
-      } catch (error) {
-        console.error('IPFS init error:', error)
-        ipfs = null
-        setIpfsInitError(error)
-      }
-    }
-
-    setIpfsReady(Boolean(ipfs))
-  }
 
   return { ipfs, isIpfsReady, ipfsInitError }
 }

--- a/examples/browser-create-react-app/src/hooks/use-ipfs-factory.js
+++ b/examples/browser-create-react-app/src/hooks/use-ipfs-factory.js
@@ -30,7 +30,7 @@ export default function useIpfsFactory ({ commands }) {
         setIpfsReady(false)
       }
     }
-  })
+  }, [])
 
   async function startIpfs () {
     if (ipfs) {


### PR DESCRIPTION
use-ipfs-factory useEffect was been execute in a loop because in did had the dependencies set to empty

closes #2978