### PR TITLE
chore: upgrade go-ipfs-dep to 0.5.0

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "aegir": "21.4.5",
-    "ipfsd-ctl": "^3.0.0"
+    "ipfsd-ctl": "^4.1.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -72,7 +72,7 @@
     "cross-env": "^7.0.0",
     "go-ipfs-dep": "^0.5.0",
     "interface-ipfs-core": "^0.134.1",
-    "ipfsd-ctl": "^3.0.0",
+    "ipfsd-ctl": "^4.1.0",
     "it-all": "^1.0.1",
     "it-concat": "^1.0.0",
     "it-pipe": "^1.1.0",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -70,7 +70,7 @@
     "aegir": "21.4.5",
     "browser-process-platform": "^0.1.1",
     "cross-env": "^7.0.0",
-    "go-ipfs-dep": "0.4.23-3",
+    "go-ipfs-dep": "^0.5.0",
     "interface-ipfs-core": "^0.134.1",
     "ipfsd-ctl": "^3.0.0",
     "it-all": "^1.0.1",

--- a/packages/ipfs-http-client/test/utils/factory.js
+++ b/packages/ipfs-http-client/test/utils/factory.js
@@ -8,7 +8,12 @@ const commonOptions = {
   test: true,
   type: 'go',
   ipfsHttpModule: require('../../src'),
-  endpoint: 'http://localhost:48372'
+  endpoint: 'http://localhost:48372',
+  ipfsOptions: {
+    init: {
+      bits: 2048
+    }
+  }
 }
 
 const commonOverrides = {

--- a/packages/ipfs-http-client/test/utils/factory.js
+++ b/packages/ipfs-http-client/test/utils/factory.js
@@ -8,12 +8,7 @@ const commonOptions = {
   test: true,
   type: 'go',
   ipfsHttpModule: require('../../src'),
-  endpoint: 'http://localhost:48372',
-  ipfsOptions: {
-    init: {
-      bits: 2048
-    }
-  }
+  endpoint: 'http://localhost:48372'
 }
 
 const commonOverrides = {

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -186,7 +186,7 @@
     "go-ipfs-dep": "^0.5.0",
     "interface-ipfs-core": "^0.134.1",
     "ipfs-interop": "^1.0.1",
-    "ipfsd-ctl": "^3.0.0",
+    "ipfsd-ctl": "^4.1.0",
     "iso-random-stream": "^1.1.1",
     "it-first": "^1.0.1",
     "it-to-buffer": "^1.0.0",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -183,7 +183,7 @@
     "delay": "^4.3.0",
     "execa": "^4.0.0",
     "form-data": "^3.0.0",
-    "go-ipfs-dep": "0.4.23-3",
+    "go-ipfs-dep": "^0.5.0",
     "interface-ipfs-core": "^0.134.1",
     "ipfs-interop": "^1.0.1",
     "ipfsd-ctl": "^3.0.0",


### PR DESCRIPTION
Upgrades to the latest go-ipfs release

Depends on:

- [x] https://github.com/ipfs/js-ipfsd-ctl/pull/504