### PR TITLE
docs: remove Tech Lead section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ We've come a long way, but this project is still in Alpha, lots of development i
 * Head over to https://proto.school to take interactive tutorials that cover core IPFS APIs
 * Check out https://docs-beta.ipfs.io for tips, how-tos and more
 
-## Tech Lead <!-- omit in toc -->
-
-[David Dias](https://github.com/daviddias)
-
 ## Lead Maintainer <!-- omit in toc -->
 
 [Alex Potsides](http://github.com/achingbrain)

--- a/packages/ipfs/README.md
+++ b/packages/ipfs/README.md
@@ -39,10 +39,6 @@ We've come a long way, but this project is still in Alpha, lots of development i
 * Head over to https://proto.school to take interactive tutorials that cover core IPFS APIs
 * Check out https://docs-beta.ipfs.io for tips, how-tos and more
 
-## Tech Lead <!-- omit in toc -->
-
-[David Dias](https://github.com/daviddias)
-
 ## Lead Maintainer <!-- omit in toc -->
 
 [Alex Potsides](http://github.com/achingbrain)


### PR DESCRIPTION
I've been effectively not contributing as Tech Lead for a several months now, so not worth having my name there and mislead folks.

I see this is a natural transition, specially after all the great work from @alanshaw and @achingbrain as the [Lead Maintainers](https://github.com/ipfs/team-mgmt/blob/master/LEAD_MAINTAINER_PROTOCOL.md). You've made the project so much better, thank you for taking really great care of it, as you can imagine, it means a lot to me ❤️