### PR TITLE
fix: pass headers to request

### DIFF
--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -18,7 +18,7 @@
     "ipfs-pubsub-room": "^2.0.1"
   },
   "devDependencies": {
-    "aegir": "21.4.5",
+    "aegir": "^21.10.0",
     "execa": "^4.0.0",
     "ipfs-css": "^0.13.1",
     "ipfs-http-client": "^43.0.1",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -39,7 +39,7 @@
     "ipfs-block": "^0.8.1",
     "ipfs-unixfs": "^1.0.1",
     "ipfs-unixfs-importer": "^2.0.0",
-    "ipfs-utils": "^2.2.0",
+    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers",
     "ipld-dag-cbor": "^0.15.1",
     "ipld-dag-pb": "^0.18.3",
     "is-ipfs": "^1.0.0",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -39,7 +39,7 @@
     "ipfs-block": "^0.8.1",
     "ipfs-unixfs": "^1.0.1",
     "ipfs-unixfs-importer": "^2.0.0",
-    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers",
+    "ipfs-utils": "^2.2.2",
     "ipld-dag-cbor": "^0.15.1",
     "ipld-dag-pb": "^0.18.3",
     "is-ipfs": "^1.0.0",
@@ -58,7 +58,7 @@
     "temp-write": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "21.4.5",
+    "aegir": "^21.10.0",
     "ipfsd-ctl": "^3.0.0"
   },
   "contributors": [

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "buffer": "^5.4.2",
     "err-code": "^2.0.0",
-    "ipfs-utils": "^2.2.0"
+    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers"
   },
   "devDependencies": {
     "aegir": "21.4.5",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -30,10 +30,10 @@
   "dependencies": {
     "buffer": "^5.4.2",
     "err-code": "^2.0.0",
-    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers"
+    "ipfs-utils": "^2.2.2"
   },
   "devDependencies": {
-    "aegir": "21.4.5",
+    "aegir": "^21.10.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "delay": "^4.3.0",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -47,7 +47,7 @@
     "form-data": "^3.0.0",
     "ipfs-block": "^0.8.1",
     "ipfs-core-utils": "^0.2.0",
-    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers",
+    "ipfs-utils": "^2.2.2",
     "ipld-dag-cbor": "^0.15.1",
     "ipld-dag-pb": "^0.18.3",
     "ipld-raw": "^4.0.1",
@@ -67,7 +67,7 @@
     "stream-to-it": "^0.2.0"
   },
   "devDependencies": {
-    "aegir": "21.4.5",
+    "aegir": "^21.10.0",
     "browser-process-platform": "^0.1.1",
     "cross-env": "^7.0.0",
     "go-ipfs-dep": "0.4.23-3",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -47,7 +47,7 @@
     "form-data": "^3.0.0",
     "ipfs-block": "^0.8.1",
     "ipfs-core-utils": "^0.2.0",
-    "ipfs-utils": "^2.2.0",
+    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers",
     "ipld-dag-cbor": "^0.15.1",
     "ipld-dag-pb": "^0.18.3",
     "ipld-raw": "^4.0.1",

--- a/packages/ipfs-http-client/src/add.js
+++ b/packages/ipfs-http-client/src/add.js
@@ -19,7 +19,7 @@ module.exports = configure((api) => {
       timeout: options.timeout,
       signal: options.signal,
       ...(
-        await multipartRequest(input)
+        await multipartRequest(input, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/bitswap/stat.js
+++ b/packages/ipfs-http-client/src/bitswap/stat.js
@@ -10,7 +10,8 @@ module.exports = configure(api => {
     const res = await api.post('bitswap/stat', {
       searchParams: toUrlSearchParams(options),
       timeout: options.timeout,
-      signal: options.signal
+      signal: options.signal,
+      headers: options.headers
     })
 
     return toCoreInterface(await res.json())

--- a/packages/ipfs-http-client/src/bitswap/unwant.js
+++ b/packages/ipfs-http-client/src/bitswap/unwant.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: typeof cid === 'string' ? cid : new CID(cid).toString(),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/bitswap/wantlist.js
+++ b/packages/ipfs-http-client/src/bitswap/wantlist.js
@@ -13,7 +13,8 @@ module.exports = configure(api => {
     const res = await (await api.post('bitswap/wantlist', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })).json()
 
     return (res.Keys || []).map(k => new CID(k['/']))

--- a/packages/ipfs-http-client/src/block/get.js
+++ b/packages/ipfs-http-client/src/block/get.js
@@ -16,7 +16,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: cid.toString(),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return new Block(Buffer.from(await res.arrayBuffer()), cid)

--- a/packages/ipfs-http-client/src/block/put.js
+++ b/packages/ipfs-http-client/src/block/put.js
@@ -39,7 +39,7 @@ module.exports = configure(api => {
         signal: options.signal,
         searchParams: toUrlSearchParams(options),
         ...(
-          await multipartRequest(data)
+          await multipartRequest(data, options.headers)
         )
       })
       res = await response.json()

--- a/packages/ipfs-http-client/src/block/rm.js
+++ b/packages/ipfs-http-client/src/block/rm.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
         arg: cid.map(cid => new CID(cid).toString()),
         'stream-channels': true,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const removed of res.ndjson()) {

--- a/packages/ipfs-http-client/src/block/stat.js
+++ b/packages/ipfs-http-client/src/block/stat.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: new CID(cid).toString(),
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/bootstrap/add.js
+++ b/packages/ipfs-http-client/src/bootstrap/add.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: addr,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/bootstrap/list.js
+++ b/packages/ipfs-http-client/src/bootstrap/list.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('bootstrap/list', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/bootstrap/rm.js
+++ b/packages/ipfs-http-client/src/bootstrap/rm.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: addr,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/cat.js
+++ b/packages/ipfs-http-client/src/cat.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: typeof path === 'string' ? path : new CID(path).toString(),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     yield * res.iterator()

--- a/packages/ipfs-http-client/src/commands.js
+++ b/packages/ipfs-http-client/src/commands.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('commands', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/config/get.js
+++ b/packages/ipfs-http-client/src/config/get.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: key,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/config/profiles/apply.js
+++ b/packages/ipfs-http-client/src/config/profiles/apply.js
@@ -11,7 +11,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: profile,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/config/profiles/list.js
+++ b/packages/ipfs-http-client/src/config/profiles/list.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('config/profile/list', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     const data = await res.json()

--- a/packages/ipfs-http-client/src/config/replace.js
+++ b/packages/ipfs-http-client/src/config/replace.js
@@ -12,7 +12,7 @@ module.exports = configure(api => {
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       ...(
-        await multipartRequest(Buffer.from(JSON.stringify(config)))
+        await multipartRequest(Buffer.from(JSON.stringify(config)), options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/config/set.js
+++ b/packages/ipfs-http-client/src/config/set.js
@@ -29,7 +29,8 @@ module.exports = configure(api => {
     const res = await api.post('config', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(params)
+      searchParams: toUrlSearchParams(params),
+      headers: options.headers
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/dag/put.js
+++ b/packages/ipfs-http-client/src/dag/put.js
@@ -48,7 +48,7 @@ module.exports = configure(api => {
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       ...(
-        await multipartRequest(serialized)
+        await multipartRequest(serialized, options.headers)
       )
     })
     const data = await res.json()

--- a/packages/ipfs-http-client/src/dag/resolve.js
+++ b/packages/ipfs-http-client/src/dag/resolve.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: path ? [cid, path].join(path.startsWith('/') ? '' : '/') : `${cid}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     const data = await res.json()

--- a/packages/ipfs-http-client/src/dht/find-peer.js
+++ b/packages/ipfs-http-client/src/dht/find-peer.js
@@ -15,7 +15,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: `${Buffer.isBuffer(peerId) ? new CID(peerId) : peerId}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const data of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/find-provs.js
+++ b/packages/ipfs-http-client/src/dht/find-provs.js
@@ -14,7 +14,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: `${new CID(cid)}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/get.js
+++ b/packages/ipfs-http-client/src/dht/get.js
@@ -18,7 +18,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         key: encodeBufferURIComponent(key),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/provide.js
+++ b/packages/ipfs-http-client/src/dht/provide.js
@@ -16,7 +16,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: cids.map(cid => new CID(cid).toString()),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (let message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/put.js
+++ b/packages/ipfs-http-client/src/dht/put.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
           value
         ],
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (let message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/dht/query.js
+++ b/packages/ipfs-http-client/src/dht/query.js
@@ -14,7 +14,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: new CID(peerId),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (let message of res.ndjson()) {

--- a/packages/ipfs-http-client/src/diag/cmds.js
+++ b/packages/ipfs-http-client/src/diag/cmds.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('diag/cmds', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/diag/net.js
+++ b/packages/ipfs-http-client/src/diag/net.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('diag/net', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     return res.json()
   }

--- a/packages/ipfs-http-client/src/diag/sys.js
+++ b/packages/ipfs-http-client/src/diag/sys.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('diag/sys', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     return res.json()

--- a/packages/ipfs-http-client/src/dns.js
+++ b/packages/ipfs-http-client/src/dns.js
@@ -11,7 +11,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: domain,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/files/chmod.js
+++ b/packages/ipfs-http-client/src/files/chmod.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
         arg: path,
         mode,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/cp.js
+++ b/packages/ipfs-http-client/src/files/cp.js
@@ -15,7 +15,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: sources.map(src => CID.isCID(src) ? `/ipfs/${src}` : src),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/flush.js
+++ b/packages/ipfs-http-client/src/files/flush.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: path,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/files/ls.js
+++ b/packages/ipfs-http-client/src/files/ls.js
@@ -25,7 +25,8 @@ module.exports = configure(api => {
         l: options.long == null ? true : options.long,
         ...options,
         stream: true
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const result of res.ndjson()) {

--- a/packages/ipfs-http-client/src/files/mkdir.js
+++ b/packages/ipfs-http-client/src/files/mkdir.js
@@ -11,7 +11,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: path,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/mv.js
+++ b/packages/ipfs-http-client/src/files/mv.js
@@ -15,7 +15,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: sources.map(src => CID.isCID(src) ? `/ipfs/${src}` : src),
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/read.js
+++ b/packages/ipfs-http-client/src/files/read.js
@@ -14,7 +14,8 @@ module.exports = configure(api => {
         arg: path,
         count: options.count || options.length,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const chunk of toIterable(res.body)) {

--- a/packages/ipfs-http-client/src/files/rm.js
+++ b/packages/ipfs-http-client/src/files/rm.js
@@ -14,7 +14,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: sources,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/stat.js
+++ b/packages/ipfs-http-client/src/files/stat.js
@@ -18,7 +18,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: path,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/files/touch.js
+++ b/packages/ipfs-http-client/src/files/touch.js
@@ -11,7 +11,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: path,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/files/write.js
+++ b/packages/ipfs-http-client/src/files/write.js
@@ -23,7 +23,7 @@ module.exports = configure(api => {
           path: 'arg',
           mode: modeToString(options.mode),
           mtime: mtimeToObject(options.mtime)
-        })
+        }, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/get.js
+++ b/packages/ipfs-http-client/src/get.js
@@ -14,7 +14,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: `${Buffer.isBuffer(path) ? new CID(path) : path}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     const extractor = Tar.extract()

--- a/packages/ipfs-http-client/src/id.js
+++ b/packages/ipfs-http-client/src/id.js
@@ -10,7 +10,8 @@ module.exports = configure(api => {
     const res = await api.post('id', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/export.js
+++ b/packages/ipfs-http-client/src/key/export.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
         arg: name,
         password: password,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return res.text()

--- a/packages/ipfs-http-client/src/key/gen.js
+++ b/packages/ipfs-http-client/src/key/gen.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: name,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/import.js
+++ b/packages/ipfs-http-client/src/key/import.js
@@ -19,7 +19,8 @@ module.exports = configure(api => {
         pem,
         password,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/list.js
+++ b/packages/ipfs-http-client/src/key/list.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('key/list', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/key/rename.js
+++ b/packages/ipfs-http-client/src/key/rename.js
@@ -15,7 +15,8 @@ module.exports = configure(api => {
           newName
         ],
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/key/rm.js
+++ b/packages/ipfs-http-client/src/key/rm.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: name,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/lib/configure.js
+++ b/packages/ipfs-http-client/src/lib/configure.js
@@ -14,7 +14,9 @@ const Client = require('./core')
  */
 const configure = (fn) => {
   return (options) => {
-    return fn(new Client(options), options)
+    return fn({
+      post: (...args) => new Client(options).post(...args)
+    }, options)
   }
 }
 module.exports = configure

--- a/packages/ipfs-http-client/src/lib/configure.js
+++ b/packages/ipfs-http-client/src/lib/configure.js
@@ -14,9 +14,7 @@ const Client = require('./core')
  */
 const configure = (fn) => {
   return (options) => {
-    return fn({
-      post: (...args) => new Client(options).post(...args)
-    }, options)
+    return fn(new Client(options), options)
   }
 }
 module.exports = configure

--- a/packages/ipfs-http-client/src/lib/multipart-request.js
+++ b/packages/ipfs-http-client/src/lib/multipart-request.js
@@ -5,8 +5,9 @@ const toStream = require('./to-stream')
 const { nanoid } = require('nanoid')
 const modeToString = require('../lib/mode-to-string')
 const mtimeToObject = require('../lib/mtime-to-object')
+const merge = require('merge-options').bind({ ignoreUndefined: true })
 
-async function multipartRequest (source, boundary = `-----------------------------${nanoid()}`) {
+async function multipartRequest (source, headers = {}, boundary = `-----------------------------${nanoid()}`) {
   async function * streamFiles (source) {
     try {
       let index = 0
@@ -55,9 +56,9 @@ async function multipartRequest (source, boundary = `---------------------------
   }
 
   return {
-    headers: {
+    headers: merge(headers, {
       'Content-Type': `multipart/form-data; boundary=${boundary}`
-    },
+    }),
     body: await toStream(streamFiles(source))
   }
 }

--- a/packages/ipfs-http-client/src/log/level.js
+++ b/packages/ipfs-http-client/src/log/level.js
@@ -15,7 +15,8 @@ module.exports = configure(api => {
           level
         ],
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/log/ls.js
+++ b/packages/ipfs-http-client/src/log/ls.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('log/ls', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     const data = await res.json()

--- a/packages/ipfs-http-client/src/log/tail.js
+++ b/packages/ipfs-http-client/src/log/tail.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('log/tail', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     yield * res.ndjson()

--- a/packages/ipfs-http-client/src/ls.js
+++ b/packages/ipfs-http-client/src/ls.js
@@ -13,7 +13,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: `${Buffer.isBuffer(path) ? new CID(path) : path}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     for await (let result of res.ndjson()) {

--- a/packages/ipfs-http-client/src/mount.js
+++ b/packages/ipfs-http-client/src/mount.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('dns', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/publish.js
+++ b/packages/ipfs-http-client/src/name/publish.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: path,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/pubsub/cancel.js
+++ b/packages/ipfs-http-client/src/name/pubsub/cancel.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: name,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/pubsub/state.js
+++ b/packages/ipfs-http-client/src/name/pubsub/state.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('name/pubsub/state', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     return toCamel(await res.json())

--- a/packages/ipfs-http-client/src/name/pubsub/subs.js
+++ b/packages/ipfs-http-client/src/name/pubsub/subs.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('name/pubsub/subs', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/name/resolve.js
+++ b/packages/ipfs-http-client/src/name/resolve.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
         arg: path,
         ...options,
         stream: true
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const result of res.ndjson()) {

--- a/packages/ipfs-http-client/src/object/data.js
+++ b/packages/ipfs-http-client/src/object/data.js
@@ -13,7 +13,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.arrayBuffer()
 

--- a/packages/ipfs-http-client/src/object/get.js
+++ b/packages/ipfs-http-client/src/object/get.js
@@ -15,7 +15,8 @@ module.exports = configure(api => {
         arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
         dataEncoding: 'base64',
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/object/links.js
+++ b/packages/ipfs-http-client/src/object/links.js
@@ -14,7 +14,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/object/new.js
+++ b/packages/ipfs-http-client/src/object/new.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: template,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     const { Hash } = await res.json()

--- a/packages/ipfs-http-client/src/object/patch/add-link.js
+++ b/packages/ipfs-http-client/src/object/patch/add-link.js
@@ -17,7 +17,8 @@ module.exports = configure(api => {
           (dLink.Hash || dLink.cid || '').toString() || null
         ],
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     const { Hash } = await res.json()

--- a/packages/ipfs-http-client/src/object/patch/append-data.js
+++ b/packages/ipfs-http-client/src/object/patch/append-data.js
@@ -16,7 +16,7 @@ module.exports = configure(api => {
         ...options
       }),
       ...(
-        await multipartRequest(data)
+        await multipartRequest(data, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/object/patch/rm-link.js
+++ b/packages/ipfs-http-client/src/object/patch/rm-link.js
@@ -16,7 +16,8 @@ module.exports = configure(api => {
           dLink.Name || dLink.name || null
         ],
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     const { Hash } = await res.json()

--- a/packages/ipfs-http-client/src/object/patch/set-data.js
+++ b/packages/ipfs-http-client/src/object/patch/set-data.js
@@ -18,7 +18,7 @@ module.exports = configure(api => {
         ...options
       }),
       ...(
-        await multipartRequest(data)
+        await multipartRequest(data, options.headers)
       )
     })).json()
 

--- a/packages/ipfs-http-client/src/object/put.js
+++ b/packages/ipfs-http-client/src/object/put.js
@@ -49,7 +49,7 @@ module.exports = configure(api => {
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       ...(
-        await multipartRequest(buf)
+        await multipartRequest(buf, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/object/stat.js
+++ b/packages/ipfs-http-client/src/object/stat.js
@@ -15,7 +15,8 @@ module.exports = configure(api => {
         searchParams: toUrlSearchParams({
           arg: `${Buffer.isBuffer(cid) ? new CID(cid) : cid}`,
           ...options
-        })
+        }),
+        headers: options.headers
       })).json()
     } catch (err) {
       if (err.name === 'TimeoutError') {

--- a/packages/ipfs-http-client/src/pin/add.js
+++ b/packages/ipfs-http-client/src/pin/add.js
@@ -14,7 +14,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: paths.map(path => `${path}`),
         ...options
-      })
+      }),
+      headers: options.headers
     })).json()
 
     return (res.Pins || []).map(cid => ({ cid: new CID(cid) }))

--- a/packages/ipfs-http-client/src/pin/ls.js
+++ b/packages/ipfs-http-client/src/pin/ls.js
@@ -20,7 +20,8 @@ module.exports = configure(api => {
         arg: path.map(p => `${p}`),
         ...options,
         stream: true
-      })
+      }),
+      headers: options.headers
     })
 
     for await (const pin of res.ndjson()) {

--- a/packages/ipfs-http-client/src/pin/rm.js
+++ b/packages/ipfs-http-client/src/pin/rm.js
@@ -12,7 +12,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: `${path}`,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     const data = await res.json()

--- a/packages/ipfs-http-client/src/ping.js
+++ b/packages/ipfs-http-client/src/ping.js
@@ -13,6 +13,7 @@ module.exports = configure(api => {
         arg: `${peerId}`,
         ...options
       }),
+      headers: options.headers,
       transform: toCamel
     })
 

--- a/packages/ipfs-http-client/src/pubsub/ls.js
+++ b/packages/ipfs-http-client/src/pubsub/ls.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const { Strings } = await (await api.post('pubsub/ls', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })).json()
 
     return Strings || []

--- a/packages/ipfs-http-client/src/pubsub/peers.js
+++ b/packages/ipfs-http-client/src/pubsub/peers.js
@@ -16,7 +16,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: topic,
         ...options
-      })
+      }),
+      headers: options.headers
     })
 
     const { Strings } = await res.json()

--- a/packages/ipfs-http-client/src/pubsub/publish.js
+++ b/packages/ipfs-http-client/src/pubsub/publish.js
@@ -18,7 +18,8 @@ module.exports = configure(api => {
 
     const res = await api.post(`pubsub/pub?${searchParams}&arg=${encodeBuffer(data)}`, {
       timeout: options.timeout,
-      signal: options.signal
+      signal: options.signal,
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/pubsub/subscribe.js
+++ b/packages/ipfs-http-client/src/pubsub/subscribe.js
@@ -35,7 +35,8 @@ module.exports = configure((api, options) => {
         searchParams: toUrlSearchParams({
           arg: topic,
           ...options
-        })
+        }),
+        headers: options.headers
       })
     } catch (err) { // Initial subscribe fail, ensure we clean up
       subsTracker.unsubscribe(topic, handler)

--- a/packages/ipfs-http-client/src/refs/index.js
+++ b/packages/ipfs-http-client/src/refs/index.js
@@ -19,6 +19,7 @@ module.exports = configure((api, options) => {
         arg: args.map(arg => `${Buffer.isBuffer(arg) ? new CID(arg) : arg}`),
         ...options
       }),
+      headers: options.headers,
       transform: toCamel
     })
 

--- a/packages/ipfs-http-client/src/refs/local.js
+++ b/packages/ipfs-http-client/src/refs/local.js
@@ -10,7 +10,8 @@ module.exports = configure(api => {
       timeout: options.timeout,
       signal: options.signal,
       transform: toCamel,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     yield * res.ndjson()

--- a/packages/ipfs-http-client/src/repo/gc.js
+++ b/packages/ipfs-http-client/src/repo/gc.js
@@ -10,6 +10,7 @@ module.exports = configure(api => {
       timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
+      headers: options.headers,
       transform: (res) => {
         return {
           err: res.Error ? new Error(res.Error) : null,

--- a/packages/ipfs-http-client/src/repo/stat.js
+++ b/packages/ipfs-http-client/src/repo/stat.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('repo/stat', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/src/repo/version.js
+++ b/packages/ipfs-http-client/src/repo/version.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await (await api.post('repo/version', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })).json()
 
     return res.Version

--- a/packages/ipfs-http-client/src/resolve.js
+++ b/packages/ipfs-http-client/src/resolve.js
@@ -11,7 +11,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: path,
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const { Path } = await res.json()
     return Path

--- a/packages/ipfs-http-client/src/stats/bw.js
+++ b/packages/ipfs-http-client/src/stats/bw.js
@@ -10,6 +10,7 @@ module.exports = configure(api => {
       timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
+      headers: options.headers,
       transform: (stats) => ({
         totalIn: new BigNumber(stats.TotalIn),
         totalOut: new BigNumber(stats.TotalOut),

--- a/packages/ipfs-http-client/src/stop.js
+++ b/packages/ipfs-http-client/src/stop.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('shutdown', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/swarm/addrs.js
+++ b/packages/ipfs-http-client/src/swarm/addrs.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('swarm/addrs', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     const { Addrs } = await res.json()
 

--- a/packages/ipfs-http-client/src/swarm/connect.js
+++ b/packages/ipfs-http-client/src/swarm/connect.js
@@ -13,7 +13,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: addrs.map(addr => `${addr}`),
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const { Strings } = await res.json()
 

--- a/packages/ipfs-http-client/src/swarm/disconnect.js
+++ b/packages/ipfs-http-client/src/swarm/disconnect.js
@@ -13,7 +13,8 @@ module.exports = configure(api => {
       searchParams: toUrlSearchParams({
         arg: addrs.map(addr => `${addr}`),
         ...options
-      })
+      }),
+      headers: options.headers
     })
     const { Strings } = await res.json()
 

--- a/packages/ipfs-http-client/src/swarm/localAddrs.js
+++ b/packages/ipfs-http-client/src/swarm/localAddrs.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('swarm/addrs/local', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     const { Strings } = await res.json()
 

--- a/packages/ipfs-http-client/src/swarm/peers.js
+++ b/packages/ipfs-http-client/src/swarm/peers.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await (await api.post('swarm/peers', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })).json()
 
     return (res.Peers || []).map(peer => {

--- a/packages/ipfs-http-client/src/update.js
+++ b/packages/ipfs-http-client/src/update.js
@@ -8,7 +8,8 @@ module.exports = configure(api => {
     const res = await api.post('update', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
 
     await res.text()

--- a/packages/ipfs-http-client/src/version.js
+++ b/packages/ipfs-http-client/src/version.js
@@ -9,7 +9,8 @@ module.exports = configure(api => {
     const res = await api.post('version', {
       timeout: options.timeout,
       signal: options.signal,
-      searchParams: toUrlSearchParams(options)
+      searchParams: toUrlSearchParams(options),
+      headers: options.headers
     })
     const data = await res.json()
 

--- a/packages/ipfs-http-client/test/custom-headers.spec.js
+++ b/packages/ipfs-http-client/test/custom-headers.spec.js
@@ -5,94 +5,97 @@ const { isNode } = require('ipfs-utils/src/env')
 const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const ipfsClient = require('../src')
 
+function startServer (fn) {
+  let headersResolve
+  const headers = new Promise((resolve) => {
+    headersResolve = resolve
+  })
+
+  // spin up a test http server to inspect the requests made by the library
+  const server = require('http').createServer((req, res) => {
+    req.on('data', () => {})
+    req.on('end', () => {
+      res.writeHead(200)
+      res.write(JSON.stringify({}))
+      res.end()
+      server.close()
+
+      headersResolve(req.headers)
+    })
+  })
+
+  server.listen(6001, () => {
+    fn().then(() => {}, () => {})
+  })
+
+  return headers
+}
+
 describe('custom headers', function () {
   // do not test in browser
-  if (!isNode) { return }
+  if (!isNode) {
+    return
+  }
+
   let ipfs
-  // initialize ipfs with custom headers
-  before(() => {
-    ipfs = ipfsClient({
-      host: 'localhost',
-      port: 6001,
-      protocol: 'http',
-      headers: {
-        authorization: 'Bearer YOLO'
-      }
-    })
-  })
 
-  it('are supported in the client constructor', (done) => {
-    // spin up a test http server to inspect the requests made by the library
-    const server = require('http').createServer((req, res) => {
-      req.on('data', () => {})
-      req.on('end', () => {
-        res.writeHead(200)
-        res.write(JSON.stringify({}))
-        res.end()
-        // ensure custom headers are present
-        expect(req.headers.authorization).to.equal('Bearer YOLO')
-        server.close()
-        done()
+  describe('supported in the constructor', () => {
+    // initialize ipfs with custom headers
+    before(() => {
+      ipfs = ipfsClient({
+        host: 'localhost',
+        port: 6001,
+        protocol: 'http',
+        headers: {
+          authorization: 'Bearer YOLO'
+        }
       })
     })
 
-    server.listen(6001, () => {
-      // this call is used to test that headers are being sent.
-      ipfs.id()
-        .then(() => {}, done)
+    it('regular API calls', async () => {
+      const headers = await startServer(() => ipfs.id())
+
+      expect(headers.authorization).to.equal('Bearer YOLO')
+    })
+
+    it('multipart API calls', async () => {
+      const headers = await startServer(() => ipfs.files.write('/foo/bar', Buffer.from('derp'), {
+        create: true
+      }))
+
+      expect(headers.authorization).to.equal('Bearer YOLO')
     })
   })
 
-  it('are supported in API calls', (done) => {
-    // spin up a test http server to inspect the requests made by the library
-    const server = require('http').createServer((req, res) => {
-      req.on('data', () => {})
-      req.on('end', () => {
-        res.writeHead(200)
-        res.write(JSON.stringify({}))
-        res.end()
-        // ensure custom headers are present
-        expect(req.headers.authorization).to.equal('Bearer OLOY')
-        server.close()
-        done()
+  describe('supported as API call arguemnts', () => {
+    // initialize ipfs with custom headers
+    before(() => {
+      ipfs = ipfsClient({
+        host: 'localhost',
+        port: 6001,
+        protocol: 'http'
       })
     })
 
-    server.listen(6001, () => {
-      // this call is used to test that headers are being sent.
-      ipfs.id({
+    it('regular API calls', async () => {
+      const headers = await startServer(() => ipfs.id({
         headers: {
           authorization: 'Bearer OLOY'
         }
-      })
-        .then(() => {}, done)
-    })
-  })
+      }))
 
-  it('are supported in multipart API calls', (done) => {
-    // spin up a test http server to inspect the requests made by the library
-    const server = require('http').createServer((req, res) => {
-      req.on('data', () => {})
-      req.on('end', () => {
-        res.writeHead(200)
-        res.write(JSON.stringify({}))
-        res.end()
-        // ensure custom headers are present
-        expect(req.headers.authorization).to.equal('Bearer OYLO')
-        server.close()
-        done()
-      })
+      expect(headers.authorization).to.equal('Bearer OLOY')
     })
 
-    server.listen(6001, () => {
-      // this call is used to test that headers are being sent.
-      ipfs.files.write('/foo/bar', Buffer.from('derp'), {
+    it('multipart API calls', async () => {
+      const headers = await startServer(() => ipfs.files.write('/foo/bar', Buffer.from('derp'), {
         create: true,
         headers: {
-          authorization: 'Bearer OYLO'
+          authorization: 'Bearer OLOY'
         }
-      })
-        .then(() => {}, done)
+      }))
+
+      expect(headers.authorization).to.equal('Bearer OLOY')
     })
   })
 })

--- a/packages/ipfs-http-client/test/custom-headers.spec.js
+++ b/packages/ipfs-http-client/test/custom-headers.spec.js
@@ -16,12 +16,12 @@ describe('custom headers', function () {
       port: 6001,
       protocol: 'http',
       headers: {
-        authorization: 'Bearer ' + 'YOLO'
+        authorization: 'Bearer YOLO'
       }
     })
   })
 
-  it('are supported', (done) => {
+  it('are supported in the client constructor', (done) => {
     // spin up a test http server to inspect the requests made by the library
     const server = require('http').createServer((req, res) => {
       req.on('data', () => {})
@@ -30,19 +30,69 @@ describe('custom headers', function () {
         res.write(JSON.stringify({}))
         res.end()
         // ensure custom headers are present
-        expect(req.headers.authorization).to.equal('Bearer ' + 'YOLO')
+        expect(req.headers.authorization).to.equal('Bearer YOLO')
         server.close()
         done()
       })
     })
 
     server.listen(6001, () => {
-      ipfs.id((err, res) => {
-        if (err) {
-          throw err
-        }
-        // this call is used to test that headers are being sent.
+      // this call is used to test that headers are being sent.
+      ipfs.id()
+        .then(() => {}, done)
+    })
+  })
+
+  it('are supported in API calls', (done) => {
+    // spin up a test http server to inspect the requests made by the library
+    const server = require('http').createServer((req, res) => {
+      req.on('data', () => {})
+      req.on('end', () => {
+        res.writeHead(200)
+        res.write(JSON.stringify({}))
+        res.end()
+        // ensure custom headers are present
+        expect(req.headers.authorization).to.equal('Bearer OLOY')
+        server.close()
+        done()
       })
+    })
+
+    server.listen(6001, () => {
+      // this call is used to test that headers are being sent.
+      ipfs.id({
+        headers: {
+          authorization: 'Bearer OLOY'
+        }
+      })
+        .then(() => {}, done)
+    })
+  })
+
+  it('are supported in multipart API calls', (done) => {
+    // spin up a test http server to inspect the requests made by the library
+    const server = require('http').createServer((req, res) => {
+      req.on('data', () => {})
+      req.on('end', () => {
+        res.writeHead(200)
+        res.write(JSON.stringify({}))
+        res.end()
+        // ensure custom headers are present
+        expect(req.headers.authorization).to.equal('Bearer OYLO')
+        server.close()
+        done()
+      })
+    })
+
+    server.listen(6001, () => {
+      // this call is used to test that headers are being sent.
+      ipfs.files.write('/foo/bar', Buffer.from('derp'), {
+        create: true,
+        headers: {
+          authorization: 'Bearer OYLO'
+        }
+      })
+        .then(() => {}, done)
     })
   })
 })

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -106,7 +106,7 @@
     "ipfs-unixfs": "^1.0.1",
     "ipfs-unixfs-exporter": "^2.0.0",
     "ipfs-unixfs-importer": "^2.0.0",
-    "ipfs-utils": "^2.2.0",
+    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers",
     "ipld": "^0.25.0",
     "ipld-bitcoin": "^0.3.0",
     "ipld-dag-cbor": "^0.15.1",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -106,7 +106,7 @@
     "ipfs-unixfs": "^1.0.1",
     "ipfs-unixfs-exporter": "^2.0.0",
     "ipfs-unixfs-importer": "^2.0.0",
-    "ipfs-utils": "ipfs/js-ipfs-utils#fix/respect-headers",
+    "ipfs-utils": "^2.2.2",
     "ipld": "^0.25.0",
     "ipld-bitcoin": "^0.3.0",
     "ipld-dag-cbor": "^0.15.1",
@@ -176,7 +176,7 @@
     "yargs-promise": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "21.4.5",
+    "aegir": "^21.10.0",
     "base64url": "^3.0.1",
     "clear-module": "^4.0.0",
     "cross-env": "^7.0.0",


### PR DESCRIPTION
Somewhere along the line we stopped passing headers to the underlying
request library which means people can't use http auth etc to try to
secure their API servers.

Fixes #3017

Depends on:

- [x] https://github.com/ipfs/js-ipfs-utils/pull/41