### PR TITLE
fix: typeof bug when passing timeout to dag.get

### DIFF
--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -204,5 +204,19 @@ module.exports = (common, options) => {
       const result = await ipfs.dag.get(cid)
       expect(result.value).to.deep.equal(buf)
     })
+
+    it('should be able to pass a timeout without a path', async () => {
+      const cid = 'bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu'
+
+      let error
+      try {
+        const result = await ipfs.dag.get(cid, { timeout: 200 })
+      } catch (e) {
+        error = e
+      }
+
+      expect(error.name).to.eql('TimeoutError')
+    })
+
   })
 }

--- a/packages/ipfs-http-client/src/dag/get.js
+++ b/packages/ipfs-http-client/src/dag/get.js
@@ -18,7 +18,7 @@ module.exports = configure((api, options) => {
   return async (cid, path, options = {}) => {
     if (typeof path === 'object') {
       options = path
-      path = null
+      path = undefined
     }
 
     const resolved = await dagResolve(cid, path, options)


### PR DESCRIPTION
Passing `options` without a `path` to dag.get will throw an error.
```
ipfs.dag.get(cidPath, { timeout: 2000 })

TypeError: Cannot read property 'timeout' of null
```

Cause by the lovely JS issue of `typeof null === 'object'`.