### PR TITLE
add webpack-cli as dev dependency

### DIFF
--- a/examples/browser-webpack/package.json
+++ b/examples/browser-webpack/package.json
@@ -21,6 +21,7 @@
     "react-hot-loader": "^4.8.8",
     "test-ipfs-example": "^2.0.1",
     "webpack": "^4.28.4",
+    "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {


### PR DESCRIPTION
It's needed for webpack now apparently. Without it, the user will get a message like this on first `npm run build`:
```txt
$ npm run build                                                                      
> example-browser-webpack@ build /path/to/browser-webpack                 
> webpack                                                                           
                                                                                    
One CLI for webpack must be installed. These are recommended choices, delivered as s
eparate packages:                                                                   
 - webpack-cli (https://github.com/webpack/webpack-cli)                             
   The original webpack full-featured CLI.                                          
We will use "npm" to install the CLI via "npm install -D".                          
Do you want to install 'webpack-cli' (yes/no):
```