### PR TITLE
fix: fixes browser script tag example

### DIFF
--- a/examples/browser-add-readable-stream/index.html
+++ b/examples/browser-add-readable-stream/index.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <pre id="output"></pre>
-    <script src="./node_modules/ipfs/dist/index.js"></script>
+    <script src="./node_modules/ipfs/dist/index.min.js"></script>
     <script src="index.js"></script>
   </body>
 </html>

--- a/examples/browser-add-readable-stream/package.json
+++ b/examples/browser-add-readable-stream/package.json
@@ -11,7 +11,7 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "test-ipfs-example": "^2.0.1"
   }
 }

--- a/examples/browser-browserify/package.json
+++ b/examples/browser-browserify/package.json
@@ -21,6 +21,6 @@
     "test-ipfs-example": "^2.0.1"
   },
   "browser": {
-    "ipfs": "ipfs/dist/index.js"
+    "ipfs": "ipfs/dist/index.min.js"
   }
 }

--- a/examples/browser-browserify/package.json
+++ b/examples/browser-browserify/package.json
@@ -17,7 +17,7 @@
     "concat-stream": "^2.0.0",
     "execa": "^4.0.0",
     "http-server": "^0.11.1",
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "test-ipfs-example": "^2.0.1"
   },
   "browser": {

--- a/examples/browser-create-react-app/package.json
+++ b/examples/browser-create-react-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "dot-prop": "^5.0.0",
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "ipfs-css": "^0.13.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/examples/browser-mfs/package.json
+++ b/examples/browser-mfs/package.json
@@ -20,7 +20,7 @@
     "webpack-cli": "^3.0.8"
   },
   "dependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "mime-sniffer": "~0.0.3"
   }
 }

--- a/examples/browser-parceljs/package.json
+++ b/examples/browser-parceljs/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ipfs": "^0.43.0"
+    "ipfs": "^0.43.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/examples/browser-readablestream/package.json
+++ b/examples/browser-readablestream/package.json
@@ -19,7 +19,7 @@
     "webpack": "^4.28.4"
   },
   "dependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "it-to-stream": "^0.1.1",
     "videostream": "^3.2.0"
   }

--- a/examples/browser-script-tag/index.html
+++ b/examples/browser-script-tag/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>IPFS in the Browser</title>
-  <script src="./node_modules/ipfs/dist/index.js"></script>
+  <script src="./node_modules/ipfs/dist/index.min.js"></script>
   <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', async () => {
       const node = await Ipfs.create({ repo: 'ipfs-' + Math.random() })
@@ -31,8 +31,9 @@
 
   <code style="display:block; white-space:pre-wrap; background-color:#d7d6d6">
     async function addFile () {
-      const filesAdded = await node.add('Hello world!')
-      filesAdded.forEach((file) => console.log('successfully stored', file.hash))
+      for await (const { cid } of node.add('Hello world!')) {
+        console.log('successfully stored', cid)
+      }
     }
 
     addFile()
@@ -42,8 +43,9 @@
 
   <code style="display:block; white-space:pre-wrap; background-color:#d7d6d6">
     async function catFile () {
-      const data = await node.cat('QmQzCQn4puG4qu8PVysxZmscmQ5vT1ZXpqo7f58Uh9QfyY')
-      console.log(data.toString())
+      for await (const data of node.cat('QmQzCQn4puG4qu8PVysxZmscmQ5vT1ZXpqo7f58Uh9QfyY')) {
+        console.log(data.toString())
+      }
     }
 
     catFile()

--- a/examples/browser-script-tag/package.json
+++ b/examples/browser-script-tag/package.json
@@ -15,6 +15,6 @@
     "test-ipfs-example": "^2.0.1"
   },
   "dependencies": {
-    "ipfs": "^0.43.0"
+    "ipfs": "^0.43.3"
   }
 }

--- a/examples/browser-video-streaming/index.html
+++ b/examples/browser-video-streaming/index.html
@@ -1,7 +1,7 @@
 <html>
   <body>
     <video id="video" controls></video>
-    <script src="./node_modules/ipfs/dist/index.js"></script>
+    <script src="./node_modules/ipfs/dist/index.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hlsjs-ipfs-loader@latest/dist/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="streaming.js"></script>

--- a/examples/browser-video-streaming/package.json
+++ b/examples/browser-video-streaming/package.json
@@ -15,6 +15,6 @@
     "test-ipfs-example": "^2.0.1"
   },
   "dependencies": {
-    "ipfs": "^0.43.0"
+    "ipfs": "^0.43.3"
   }
 }

--- a/examples/browser-vue/package.json
+++ b/examples/browser-vue/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.4",
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "vue": "^2.6.11"
   },
   "devDependencies": {

--- a/examples/browser-webpack/package.json
+++ b/examples/browser-webpack/package.json
@@ -24,7 +24,7 @@
     "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {
-    "ipfs": "^0.43.0"
+    "ipfs": "^0.43.3"
   },
   "browserslist": [
     ">1%",

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "execa": "^4.0.0",
     "ipfs-css": "^0.13.1",
-    "ipfs-http-client": "^43.0.1",
+    "ipfs-http-client": "^44.0.3",
     "parcel-bundler": "^1.12.4",
     "tachyons": "^4.9.1",
     "test-ipfs-example": "^2.0.1"

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -13,7 +13,7 @@
   "author": "Dmitriy Ryajov <dryajov@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "ipfs-pubsub-room": "^2.0.1"
   },
   "devDependencies": {

--- a/examples/custom-ipfs-repo/package.json
+++ b/examples/custom-ipfs-repo/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "datastore-fs": "^0.9.1",
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "ipfs-repo": "^2.0.1",
     "it-all": "^1.0.1"
   },

--- a/examples/custom-libp2p/package.json
+++ b/examples/custom-libp2p/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "libp2p": "^0.27.7",
     "libp2p-bootstrap": "^0.10.3",
     "libp2p-kad-dht": "^0.18.7",

--- a/examples/exchange-files-in-browser/package.json
+++ b/examples/exchange-files-in-browser/package.json
@@ -22,6 +22,6 @@
     "test-ipfs-example": "^2.0.1"
   },
   "browser": {
-    "ipfs": "ipfs/dist"
+    "ipfs": "ipfs/dist/index.min.js"
   }
 }

--- a/examples/exchange-files-in-browser/package.json
+++ b/examples/exchange-files-in-browser/package.json
@@ -16,7 +16,7 @@
     "ipfs-http-client": "^43.0.1"
   },
   "dependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "it-all": "^1.0.1",
     "it-last": "^1.0.1",
     "test-ipfs-example": "^2.0.1"

--- a/examples/explore-ethereum-blockchain/package.json
+++ b/examples/explore-ethereum-blockchain/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "ipfs": "^0.43.3",
-    "ipfs-http-client": "^43.0.1",
+    "ipfs-http-client": "^44.0.3",
     "test-ipfs-example": "^2.0.1"
   }
 }

--- a/examples/explore-ethereum-blockchain/package.json
+++ b/examples/explore-ethereum-blockchain/package.json
@@ -9,7 +9,7 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "ipfs-http-client": "^43.0.1",
     "test-ipfs-example": "^2.0.1"
   }

--- a/examples/ipfs-101/package.json
+++ b/examples/ipfs-101/package.json
@@ -9,7 +9,7 @@
   "author": "David Dias <daviddias@ipfs.io>",
   "license": "MIT",
   "dependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "it-all": "^1.0.1"
   },
   "devDependencies": {

--- a/examples/run-in-electron/package.json
+++ b/examples/run-in-electron/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "electron": "^6.0.0",
     "electron-rebuild": "^1.8.4",
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "test-ipfs-example": "^2.0.1"
   },
   "greenkeeper": {

--- a/examples/running-multiple-nodes/package.json
+++ b/examples/running-multiple-nodes/package.json
@@ -12,6 +12,6 @@
     "test-ipfs-example": "^2.0.1"
   },
   "dependencies": {
-    "ipfs": "^0.43.0"
+    "ipfs": "^0.43.3"
   }
 }

--- a/examples/test-ipfs-example/utils.js
+++ b/examples/test-ipfs-example/utils.js
@@ -66,7 +66,7 @@ async function startServer (dir) {
     if (fs.existsSync(f)) {
       console.info('Found bare file', f)
 
-      const distFile = path.resolve(process.cwd(), 'node_modules/ipfs/dist/index.js')
+      const distFile = path.resolve(process.cwd(), 'node_modules/ipfs/dist/index.min.js')
 
       console.info('Looking for IPFS dist file at', distFile)
 
@@ -78,6 +78,7 @@ async function startServer (dir) {
           cwd: path.resolve(dir, '../../packages/ipfs'),
           env: {
             ...process.env,
+            NODE_ENV: 'production', // otherwise we only produce index.js and not index.min.js
             CI: true // needed for some "clever" build tools
           },
           all: true

--- a/examples/traverse-ipld-graphs/package.json
+++ b/examples/traverse-ipld-graphs/package.json
@@ -12,7 +12,7 @@
     "test-ipfs-example": "^2.0.1"
   },
   "dependencies": {
-    "ipfs": "^0.43.0",
+    "ipfs": "^0.43.3",
     "ipld-block": "^0.9.1"
   }
 }

--- a/packages/interface-ipfs-core/src/dht/find-peer.js
+++ b/packages/interface-ipfs-core/src/dht/find-peer.js
@@ -30,7 +30,7 @@ module.exports = (common, options) => {
     it('should respect timeout option when finding a peer on the DHT', async () => {
       const nodeBId = await nodeB.id()
 
-      await testTimeout(() => nodeA.dht.findPeer(nodeBId, {
+      await testTimeout(() => nodeA.dht.findPeer(nodeBId.id, {
         timeout: 1
       }))
     })

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -255,9 +255,6 @@ To always request the latest version, use one of the following examples:
 ```html
 <!-- loading the minified version using jsDelivr -->
 <script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.min.js"></script>
-
-<!-- loading the human-readable (not minified) version jsDelivr -->
-<script src="https://cdn.jsdelivr.net/npm/ipfs-http-client/dist/index.js"></script>
 ```
 
 For maximum security you may also decide to:

--- a/packages/ipfs/README.md
+++ b/packages/ipfs/README.md
@@ -81,7 +81,7 @@ You can load IPFS right in your browser by adding the following to your page usi
 <script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
 
 <!-- loading the human-readable (not minified) version jsDelivr -->
-<script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
 ```
 
 Inserting one of the above lines will make an `Ipfs` object available in the global namespace:


### PR DESCRIPTION
Updates example syntax to new api, also removes references to `dist/index.js` in favour of `dist/index.min.js`.

fixes #3027