### PR TITLE
fix: typeof bug when passing timeout to dag.get

### DIFF
--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -147,6 +147,11 @@ module.exports = (common, options) => {
       expect(result.value.equals(cidPb)).to.be.true()
     })
 
+    it('should get with options and no path', async function () {
+      const result = await ipfs.dag.get(cidCbor, { localResolve: true })
+      expect(result.value).to.deep.equal(nodeCbor)
+    })
+
     it('should get a node added as CIDv0 with a CIDv1', async () => {
       const input = Buffer.from(`TEST${Math.random()}`)
 

--- a/packages/ipfs-http-client/src/dag/get.js
+++ b/packages/ipfs-http-client/src/dag/get.js
@@ -16,7 +16,7 @@ module.exports = configure((api, options) => {
   const dagResolve = require('./resolve')(options)
 
   return async (cid, path, options = {}) => {
-    if (typeof path === 'object') {
+    if (path && typeof path === 'object') {
       options = path
       path = null
     }


### PR DESCRIPTION
Passing `options` without a `path` to dag.get will throw an error.
```
ipfs.dag.get(cidPath, { timeout: 2000 })

TypeError: Cannot read property 'timeout' of null
```

Cause by the lovely JS issue of `typeof null === 'object'`.

Co-authored-by: Kia Rahimian <kia@tintmail.com>