### PR TITLE
Updated globSource example with options

### DIFF
--- a/docs/core-api/FILES.md
+++ b/docs/core-api/FILES.md
@@ -247,7 +247,19 @@ const { globSource } = IPFS
 
 const ipfs = await IPFS.create()
 
-for await (const file of ipfs.add(globSource('./docs', { recursive: true }))) {
+//options specific to globSource
+const globSourceOptions = {
+  recursive: true
+};
+
+//example options to pass to IPFS
+const addOptions = {
+  pin: true,
+  wrapWithDirectory: true,
+  timeout: 10000
+};
+
+for await (const file of ipfs.add(globSource('./docs', globSourceOptions), addOptions)) {
   console.log(file)
 }
 


### PR DESCRIPTION
Previously, before globSource, all options were passed in to ipfs.addFromFs together as one options object. With globSource, `recursive` and `hidden` are now separated out from the options that are traditionally passed into IPFS and are now passed in specifically to globSource.

This PR updates the example for adding files with ipfs.add and globSource to reflect that there should be two separate options objects when using globSource to add from the fileSystem and also wanting to pass in additional options to IPFS.