### PR TITLE
chore: only prompt user to upgrade if not running an rc

### DIFF
--- a/packages/ipfs/src/cli/bin.js
+++ b/packages/ipfs/src/cli/bin.js
@@ -31,9 +31,11 @@ const { print, getIpfs, getRepoPath } = require('./utils')
 const debug = require('debug')('ipfs:cli')
 const cli = require('./')
 
-// Check if an update is available and notify
-const oneWeek = 1000 * 60 * 60 * 24 * 7
-updateNotifier({ pkg, updateCheckInterval: oneWeek }).notify()
+// If we're not running an rc, check if an update is available and notify
+if (!pkg.version.includes('-rc')) {
+  const oneWeek = 1000 * 60 * 60 * 24 * 7
+  updateNotifier({ pkg, updateCheckInterval: oneWeek }).notify()
+}
 
 async function main () {
   let exitCode = 0


### PR DESCRIPTION
We publish release candidates under the `next` tag and releases under the `current` tag - if we're running an rc, the update notifier can prompt the user to upgrade, even though they are actually running more recent code.

The change here is to only run the update notifier if the string `'-rc'` is not present in the version number..