### PR TITLE
chore: throw error no swarm on multiaddrs using websocket-star

### DIFF
--- a/packages/ipfs/src/core/components/start.js
+++ b/packages/ipfs/src/core/components/start.js
@@ -11,6 +11,8 @@ const Components = require('./')
 const createMfsPreload = require('../mfs-preload')
 const { withTimeoutOption } = require('../utils')
 
+const WEBSOCKET_STAR_PROTO_CODE = 479
+
 module.exports = ({
   apiManager,
   options: constructorOptions,
@@ -40,6 +42,12 @@ module.exports = ({
     if (config.Addresses && config.Addresses.Swarm) {
       config.Addresses.Swarm.forEach(addr => {
         let ma = multiaddr(addr)
+
+        // Temporary error for users migrating using websocket-star multiaddrs for listenning on libp2p
+        // websocket-star support was removed from ipfs and libp2p
+        if (ma.protoCodes().includes(WEBSOCKET_STAR_PROTO_CODE)) {
+          throw new Error('websocket-star swarm addresses are not supported. See https://github.com/ipfs/js-ipfs/issues/2779')
+        }
 
         // multiaddrs that go via a signalling server or other intermediary (e.g. stardust,
         // webrtc-star) can have the intermediary's peer ID in the address, so append our
@@ -133,7 +141,6 @@ module.exports = ({
     apiManager.update(api, () => undefined)
   } catch (err) {
     cancel()
-    startPromise.reject(err)
     throw err
   }
 

--- a/packages/ipfs/src/core/components/start.js
+++ b/packages/ipfs/src/core/components/start.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const log = require('debug')('ipfs:components:start')
 const Bitswap = require('ipfs-bitswap')
 const multiaddr = require('multiaddr')
 const get = require('dlv')
@@ -29,6 +30,8 @@ module.exports = ({
   repo
 }) => withTimeoutOption(async function start () {
   const startPromise = defer()
+  startPromise.promise.catch((err) => log(err))
+
   const { cancel } = apiManager.update({ start: () => startPromise.promise })
 
   try {

--- a/packages/ipfs/src/core/components/start.js
+++ b/packages/ipfs/src/core/components/start.js
@@ -4,6 +4,7 @@ const Bitswap = require('ipfs-bitswap')
 const multiaddr = require('multiaddr')
 const get = require('dlv')
 const defer = require('p-defer')
+const errCode = require('err-code')
 const IPNS = require('../ipns')
 const routingConfig = require('../ipns/routing/config')
 const { AlreadyInitializedError, NotEnabledError } = require('../errors')
@@ -46,7 +47,7 @@ module.exports = ({
         // Temporary error for users migrating using websocket-star multiaddrs for listenning on libp2p
         // websocket-star support was removed from ipfs and libp2p
         if (ma.protoCodes().includes(WEBSOCKET_STAR_PROTO_CODE)) {
-          throw new Error('websocket-star swarm addresses are not supported. See https://github.com/ipfs/js-ipfs/issues/2779')
+          throw errCode(new Error('websocket-star swarm addresses are not supported. See https://github.com/ipfs/js-ipfs/issues/2779'), 'ERR_WEBSOCKET_STAR_SWARM_ADDR_NOT_SUPPORTED')
         }
 
         // multiaddrs that go via a signalling server or other intermediary (e.g. stardust,
@@ -141,6 +142,7 @@ module.exports = ({
     apiManager.update(api, () => undefined)
   } catch (err) {
     cancel()
+    startPromise.reject(err)
     throw err
   }
 

--- a/packages/ipfs/test/core/create-node.spec.js
+++ b/packages/ipfs/test/core/create-node.spec.js
@@ -265,13 +265,6 @@ describe('create node', function () {
       preload: { enabled: false }
     })
 
-    try {
-      await node.start()
-    } catch (err) {
-      expect(err).to.exist()
-      return
-    }
-
-    throw new Error('should error when receiving websocket-star swarm addresses')
+    await expect(node.start()).to.eventually.be.rejected().with.property('code', 'ERR_WEBSOCKET_STAR_SWARM_ADDR_NOT_SUPPORTED')
   })
 })

--- a/packages/ipfs/test/core/create-node.spec.js
+++ b/packages/ipfs/test/core/create-node.spec.js
@@ -250,4 +250,28 @@ describe('create node', function () {
 
     await node.stop()
   })
+
+  it('should error when receiving websocket-star swarm addresses', async () => {
+    const node = await IPFS.create({
+      repo: tempRepo,
+      init: { bits: 512 },
+      start: false,
+      config: {
+        Addresses: {
+          Swarm: ['/ip4/127.0.0.1/tcp/13579/wss/p2p-websocket-star']
+        },
+        Bootstrap: []
+      },
+      preload: { enabled: false }
+    })
+
+    try {
+      await node.start()
+    } catch (err) {
+      expect(err).to.exist()
+      return
+    }
+
+    throw new Error('should error when receiving websocket-star swarm addresses')
+  })
 })


### PR DESCRIPTION
On `js-ipfs@0.41`, we removed the `websocket-star` module from the libp2p default configuration for browser nodes in `js-ipfs`. We removed it because this module was not refactored during https://github.com/ipfs/js-ipfs/issues/1670, since the libp2p goal is to [sunset the star protocols](https://github.com/libp2p/js-libp2p/issues/385) and we preferred to use the time refactoring `websocket-star` into improving the browser support.

In the refactor, the `webrtc-star` module was refactored so that browser users could discover other peers in the network. In addition, `circuit-relay` may be used for establishing connections between browser nodes using `websockets`.

However, this migration has not been smooth for `js-ipfs` users. Users previously using `websocket-star` swarm addresses, did not have enough visibility of this change, since the removal of `websocket-star` was transparent for them and on the default `js-ipfs` release and not technically a programmable breaking change. 

With the above in mind, once `js-ipfs` users updated they started getting errors from `js-libp2p` in scenarios where they were providing only `websocket-star` swarm addresses. When `js-libp2p` receives listening multiaddrs, it throws an error if it cannot use any to listen on the configured transports, which was the case here (For instance https://github.com/ipfs/js-ipfs/issues/2779).

In `js-libp2p`, we added an option to tolerate these errors [libp2p/js-libp2p#643](https://github.com/libp2p/js-libp2p/pull/643), which was also mentioned for some other cases earlier.

After syncing about this issue, we decided to temporarily throw an error when `js-ipfs` receives `websocket-star` multiaddrs. This aims to help users who still need to migrate to identify the problem faster.