### PR TITLE
docs: updates docs link to non-beta site

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We've come a long way, but this project is still in Alpha, lots of development i
 * Read the [Core API docs](https://github.com/ipfs/js-ipfs/tree/master/docs/core-api) to see what you can do with an IPFS node
 * Visit https://dweb-primer.ipfs.io to learn about IPFS and the concepts that underpin it
 * Head over to https://proto.school to take interactive tutorials that cover core IPFS APIs
-* Check out https://docs-beta.ipfs.io for tips, how-tos and more
+* Check out https://docs.ipfs.io for tips, how-tos and more
 
 ## Lead Maintainer <!-- omit in toc -->
 

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -35,7 +35,7 @@
 * Read the [Core API docs](https://github.com/ipfs/js-ipfs/tree/master/docs/core-api) to see what you can do with an IPFS node
 * Visit https://dweb-primer.ipfs.io to learn about IPFS and the concepts that underpin it
 * Head over to https://proto.school to take interactive tutorials that cover core IPFS APIs
-* Check out https://docs-beta.ipfs.io for tips, how-tos and more
+* Check out https://docs.ipfs.io for tips, how-tos and more
 
 ## Lead Maintainer
 

--- a/packages/ipfs/README.md
+++ b/packages/ipfs/README.md
@@ -37,7 +37,7 @@ We've come a long way, but this project is still in Alpha, lots of development i
 * Read the [Core API docs](https://github.com/ipfs/js-ipfs/tree/master/docs/core-api) to see what you can do with an IPFS node
 * Visit https://dweb-primer.ipfs.io to learn about IPFS and the concepts that underpin it
 * Head over to https://proto.school to take interactive tutorials that cover core IPFS APIs
-* Check out https://docs-beta.ipfs.io for tips, how-tos and more
+* Check out https://docs.ipfs.io for tips, how-tos and more
 
 ## Lead Maintainer <!-- omit in toc -->
 


### PR DESCRIPTION
The legacy IPFS Docs site has been deprecated, so links to `docs-beta.ipfs.io` will auto-redirect to `docs.ipfs.io`. This PR doesn't change much from the user's perspective, but it makes things a bit tidier.