### PR TITLE
fix: reflect actual return value of `files.write`

### DIFF
--- a/docs/core-api/FILES.md
+++ b/docs/core-api/FILES.md
@@ -807,7 +807,12 @@ An optional object which may have the following keys:
 
 | Type | Description |
 | -------- | -------- |
-| `Promise<void>` | If action is successfully completed. Otherwise an error will be thrown |
+| `Promise<Object>` | If action is successfully completed. Otherwise an error will be thrown |
+
+The returned object has the following keys:
+
+- `cid` a [CID][cid] instance
+- `size` is an integer with the file size in Bytes
 
 #### Example
 


### PR DESCRIPTION
As far as I can tell documentation is incorrect here given this is what write returns

https://github.com/ipfs/js-ipfs/blob/b2dc47c18a0c5b307a8c9da4bf6fe0100096228f/packages/ipfs/src/core/components/files/write.js#L222-L225