### PR TITLE
refactor: changing another ipfs.add to importer

### DIFF
--- a/packages/interface-ipfs-core/src/pin/add.js
+++ b/packages/interface-ipfs-core/src/pin/add.js
@@ -6,6 +6,7 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const all = require('it-all')
 const testTimeout = require('../utils/test-timeout')
 const CID = require('cids')
+const importer = require('ipfs-unixfs-importer')
 
 /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
@@ -23,7 +24,7 @@ module.exports = (common, options) => {
     before(async () => {
       ipfs = (await common.spawn()).api
       await Promise.all(fixtures.files.map(file => {
-        return all(ipfs.add(file.data, { pin: false }))
+        return all(importer(file.data, ipfs.block, { pin: false }))
       }))
     })
 

--- a/packages/interface-ipfs-core/src/pin/add.js
+++ b/packages/interface-ipfs-core/src/pin/add.js
@@ -24,7 +24,7 @@ module.exports = (common, options) => {
     before(async () => {
       ipfs = (await common.spawn()).api
       await Promise.all(fixtures.files.map(file => {
-        return all(importer(file.data, ipfs.block, { pin: false }))
+        return all(importer([{ content: file.data }], ipfs.block, { pin: false }))
       }))
     })
 


### PR DESCRIPTION
This [WIP] PR modifies the `pin/*.js` tests to use `importer` instead of `ipfs.add`. This will be developed in tandem with https://github.com/rs-ipfs/rust-ipfs/pull/152

- [x] pin.add
- [ ] pin.rm
- [ ] pin.ls