### PR TITLE
chore: use ipfs npm registry in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export PATH=/c/PROGRA~1/Git/usr/bin:/c/PROGRA~1/Git/mingw64/libexec/git-core:$PATH ; fi
   # only run jobs in packages that have changed since master in PR builds
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export RUN_SINCE='--since master' ; fi
+  # use IPFS npm to install
+  - npm config set registry https://registry.js.ipfs.io
 
 script: npm run test:node -- $RUN_SINCE -- -- --timeout 10000 --bail
 


### PR DESCRIPTION
Have added a step to set npm registry in the travis build process to solve #2997.

Another way to do this would have been maintaining a `.npmrc` file in the root directory, but that would have lead to installs happening during development also to use ipfs npm registry which I feel is more than the scope defined.
