### PR TITLE
fix: fix ipfs config show

### DIFF
--- a/docs/core-api/CONFIG.md
+++ b/docs/core-api/CONFIG.md
@@ -26,7 +26,7 @@
   - [Returns](#returns-4)
   - [Example](#example-4)
 
-## `ipfs.config.get([key,] [options])`
+## `ipfs.config.get(key, [options])`
 
 > Returns the currently being used config. If the daemon is off, it returns the stored config.
 
@@ -34,7 +34,7 @@
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| key | `String` | The key of the value that should be fetched from the config file. If no key is passed, then the whole config will be returned.  |
+| key | `String` | The key of the value that should be fetched from the config file. An `undefined` or empty `string` value will return the full config object.  |
 
 ### Options
 

--- a/packages/interface-ipfs-core/src/config/get.js
+++ b/packages/interface-ipfs-core/src/config/get.js
@@ -45,7 +45,7 @@ module.exports = (common, options) => {
       expect(config).to.be.an('object')
     })
 
-    it.only('should retrieve the whole config with options', async () => {
+    it('should retrieve the whole config with options', async () => {
       const config = await ipfs.config.get('', { signal: null })
 
       expect(config).to.be.an('object')

--- a/packages/interface-ipfs-core/src/config/get.js
+++ b/packages/interface-ipfs-core/src/config/get.js
@@ -7,7 +7,7 @@ const testTimeout = require('../utils/test-timeout')
 /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
  * @param {Factory} common
- * @param {Object} options
+ * @param {object} options
  */
 module.exports = (common, options) => {
   const describe = getDescribe(options)
@@ -29,6 +29,24 @@ module.exports = (common, options) => {
 
     it('should retrieve the whole config', async () => {
       const config = await ipfs.config.get()
+
+      expect(config).to.be.an('object')
+    })
+
+    it('should retrieve the whole config with empty string', async () => {
+      const config = await ipfs.config.get('')
+
+      expect(config).to.be.an('object')
+    })
+
+    it('should retrieve the whole config with undefined', async () => {
+      const config = await ipfs.config.get(undefined)
+
+      expect(config).to.be.an('object')
+    })
+
+    it('should retrieve the whole config with options', async () => {
+      const config = await ipfs.config.get('', { timeout: 0 })
 
       expect(config).to.be.an('object')
     })

--- a/packages/interface-ipfs-core/src/config/get.js
+++ b/packages/interface-ipfs-core/src/config/get.js
@@ -45,8 +45,8 @@ module.exports = (common, options) => {
       expect(config).to.be.an('object')
     })
 
-    it('should retrieve the whole config with options', async () => {
-      const config = await ipfs.config.get('', { timeout: 0 })
+    it.only('should retrieve the whole config with options', async () => {
+      const config = await ipfs.config.get('', { signal: null })
 
       expect(config).to.be.an('object')
     })

--- a/packages/ipfs/src/cli/commands/config/show.js
+++ b/packages/ipfs/src/cli/commands/config/show.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   async handler ({ ctx: { ipfs, print }, timeout }) {
-    const config = await ipfs.config.get({
+    const config = await ipfs.config.get('', {
       timeout
     })
     print(JSON.stringify(config, null, 4))


### PR DESCRIPTION
This PR makes `ipfs config show` work again and `config.get` first arg required.

Also this makes ipfsd-ctl work again.