### PR TITLE
feat: add config.getAll

### DIFF
--- a/docs/core-api/CONFIG.md
+++ b/docs/core-api/CONFIG.md
@@ -1,7 +1,11 @@
 # Config API <!-- omit in toc -->
 
-- [`ipfs.config.get([key,] [options])`](#ipfsconfiggetkey-options)
+- [`ipfs.config.get(key, [options])`](#ipfsconfiggetkey-options)
   - [Parameters](#parameters)
+  - [Options](#options)
+  - [Returns](#returns)
+  - [Example](#example)
+- [`ipfs.config.getAll([options])`](#ipfsconfiggetkey-options)
   - [Options](#options)
   - [Returns](#returns)
   - [Example](#example)
@@ -26,7 +30,7 @@
   - [Returns](#returns-4)
   - [Example](#example-4)
 
-## `ipfs.config.get([key,] [options])`
+## `ipfs.config.get(key, [options])`
 
 > Returns the currently being used config. If the daemon is off, it returns the stored config.
 
@@ -34,7 +38,7 @@
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| key | `String` | The key of the value that should be fetched from the config file. If no key is passed, then the whole config will be returned.  |
+| key | `String` | The key of the value that should be fetched from the config file.  |
 
 ### Options
 
@@ -59,6 +63,35 @@ console.log(config)
 ```
 
 A great source of [examples][] can be found in the tests for this API.
+
+## `ipfs.config.getAll([options])`
+
+> Returns the full config been used. If the daemon is off, it returns the stored config.
+
+### Options
+
+An optional object which may have the following keys:
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| timeout | `Number` | `undefined` | A timeout in ms |
+| signal | [AbortSignal][] | `undefined` |  Can be used to cancel any long running requests started as a result of this call |
+
+### Returns
+
+| Type | Description |
+| -------- | -------- |
+| `Promise<Object>` | An object containing the configuration of the IPFS node |
+
+### Example
+
+```JavaScript
+const config = await ipfs.config.getAll()
+console.log(config)
+```
+
+A great source of [examples][] can be found in the tests for this API.
+
 
 ## `ipfs.config.set(key, value, [options])`
 

--- a/packages/interface-ipfs-core/src/config/get.js
+++ b/packages/interface-ipfs-core/src/config/get.js
@@ -27,10 +27,8 @@ module.exports = (common, options) => {
       }))
     })
 
-    it('should retrieve the whole config', async () => {
-      const config = await ipfs.config.get()
-
-      expect(config).to.be.an('object')
+    it('should fail with error', async () => {
+      await expect(ipfs.config.get()).to.eventually.rejectedWith('key argument is required')
     })
 
     it('should retrieve a value through a key', async () => {
@@ -49,6 +47,33 @@ module.exports = (common, options) => {
 
     it('should fail on non existent key', () => {
       return expect(ipfs.config.get('Bananas')).to.eventually.be.rejected()
+    })
+  })
+
+  describe('.config.getAll', function () {
+    this.timeout(30 * 1000)
+    let ipfs
+
+    before(async () => { ipfs = (await common.spawn()).api })
+
+    after(() => common.clean())
+
+    it('should respect timeout option when getting config values', () => {
+      return testTimeout(() => ipfs.config.getAll({
+        timeout: 1
+      }))
+    })
+
+    it('should retrieve the whole config', async () => {
+      const config = await ipfs.config.getAll()
+
+      expect(config).to.be.an('object')
+    })
+
+    it('should retrieve the whole config with options', async () => {
+      const config = await ipfs.config.getAll({ signal: undefined })
+
+      expect(config).to.be.an('object')
     })
   })
 }

--- a/packages/interface-ipfs-core/src/config/profiles/apply.js
+++ b/packages/interface-ipfs-core/src/config/profiles/apply.js
@@ -33,12 +33,12 @@ module.exports = (common, options) => {
       const diff = await ipfs.config.profiles.apply('lowpower')
       expect(diff.original.Swarm.ConnMgr.LowWater).to.not.equal(diff.updated.Swarm.ConnMgr.LowWater)
 
-      const newConfig = await ipfs.config.get()
+      const newConfig = await ipfs.config.getAll()
       expect(newConfig.Swarm.ConnMgr.LowWater).to.equal(diff.updated.Swarm.ConnMgr.LowWater)
     })
 
     it('should strip private key from diff output', async () => {
-      const originalConfig = await ipfs.config.get()
+      const originalConfig = await ipfs.config.getAll()
       const diff = await ipfs.config.profiles.apply('default-networking', { dryRun: true })
 
       // should have stripped private key from diff output
@@ -48,11 +48,11 @@ module.exports = (common, options) => {
     })
 
     it('should not apply a config profile in dry-run mode', async () => {
-      const originalConfig = await ipfs.config.get()
+      const originalConfig = await ipfs.config.getAll()
 
       await ipfs.config.profiles.apply('server', { dryRun: true })
 
-      const updatedConfig = await ipfs.config.get()
+      const updatedConfig = await ipfs.config.getAll()
 
       expect(updatedConfig).to.deep.equal(originalConfig)
     })

--- a/packages/interface-ipfs-core/src/config/replace.js
+++ b/packages/interface-ipfs-core/src/config/replace.js
@@ -36,14 +36,14 @@ module.exports = (common, options) => {
     it('should replace the whole config', async () => {
       await ipfs.config.replace(config)
 
-      const _config = await ipfs.config.get()
+      const _config = await ipfs.config.getAll()
       expect(_config).to.deep.equal(config)
     })
 
     it('should replace to empty config', async () => {
       await ipfs.config.replace({})
 
-      const _config = await ipfs.config.get()
+      const _config = await ipfs.config.getAll()
       expect(_config).to.deep.equal({})
     })
   })

--- a/packages/ipfs-http-client/src/config/getAll.js
+++ b/packages/ipfs-http-client/src/config/getAll.js
@@ -4,22 +4,17 @@ const configure = require('../lib/configure')
 const toUrlSearchParams = require('../lib/to-url-search-params')
 
 module.exports = configure(api => {
-  return async (key, options = {}) => {
-    if (!key) {
-      throw new Error('key argument is required')
-    }
-
-    const res = await api.post('config', {
+  return async (options = {}) => {
+    const res = await api.post('config/show', {
       timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
-        arg: key,
         ...options
       }),
       headers: options.headers
     })
     const data = await res.json()
 
-    return data.Value
+    return data
   }
 })

--- a/packages/ipfs-http-client/src/config/index.js
+++ b/packages/ipfs-http-client/src/config/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 module.exports = config => ({
+  getAll: require('./getAll')(config),
   get: require('./get')(config),
   set: require('./set')(config),
   replace: require('./replace')(config),

--- a/packages/ipfs/src/cli/commands/config/show.js
+++ b/packages/ipfs/src/cli/commands/config/show.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   async handler ({ ctx: { ipfs, print }, timeout }) {
-    const config = await ipfs.config.get({
+    const config = await ipfs.config.getAll({
       timeout
     })
     print(JSON.stringify(config, null, 4))

--- a/packages/ipfs/src/core/components/bootstrap/add.js
+++ b/packages/ipfs/src/core/components/bootstrap/add.js
@@ -12,7 +12,7 @@ module.exports = ({ repo }) => {
       throw new Error(`${multiaddr} is not a valid Multiaddr`)
     }
 
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
     if (options.default) {
       config.Bootstrap = defaultConfig().Bootstrap
     } else if (multiaddr && config.Bootstrap.indexOf(multiaddr) === -1) {

--- a/packages/ipfs/src/core/components/bootstrap/rm.js
+++ b/packages/ipfs/src/core/components/bootstrap/rm.js
@@ -12,7 +12,7 @@ module.exports = ({ repo }) => {
     }
 
     let res = []
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
 
     if (options.all) {
       res = config.Bootstrap || []

--- a/packages/ipfs/src/core/components/config.js
+++ b/packages/ipfs/src/core/components/config.js
@@ -6,10 +6,10 @@ const log = require('debug')('ipfs:core:config')
 
 module.exports = ({ repo }) => {
   return {
+    getAll: withTimeoutOption(repo.config.getAll),
     get: withTimeoutOption((key, options) => {
-      if (!options && key && typeof key === 'object') {
-        options = key
-        key = undefined
+      if (!key) {
+        return Promise.reject(new Error('key argument is required'))
       }
 
       return repo.config.get(key, options)

--- a/packages/ipfs/src/core/components/init.js
+++ b/packages/ipfs/src/core/components/init.js
@@ -227,7 +227,7 @@ async function initNewRepo (repo, { privateKey, emptyRepo, bits, profiles, confi
 }
 
 async function initExistingRepo (repo, { config: newConfig, profiles, pass }) {
-  let config = await repo.config.get()
+  let config = await repo.config.getAll()
 
   if (newConfig || profiles) {
     if (profiles) {

--- a/packages/ipfs/src/core/components/start.js
+++ b/packages/ipfs/src/core/components/start.js
@@ -34,7 +34,7 @@ module.exports = ({
       await repo.open()
     }
 
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
     const addrs = []
 
     if (config.Addresses && config.Addresses.Swarm) {

--- a/packages/ipfs/src/http/api/resources/config.js
+++ b/packages/ipfs/src/http/api/resources/config.js
@@ -99,7 +99,7 @@ exports.getOrSet = {
 
     let originalConfig
     try {
-      originalConfig = await ipfs.config.get(undefined, {
+      originalConfig = await ipfs.config.getAll({
         signal,
         timeout
       })
@@ -172,7 +172,7 @@ exports.get = {
 
     let config
     try {
-      config = await ipfs.config.get(undefined, {
+      config = await ipfs.config.getAll({
         signal,
         timeout
       })
@@ -215,7 +215,7 @@ exports.show = {
 
     let config
     try {
-      config = await ipfs.config.get(undefined, {
+      config = await ipfs.config.getAll({
         signal,
         timeout
       })

--- a/packages/ipfs/src/http/index.js
+++ b/packages/ipfs/src/http/index.js
@@ -54,7 +54,7 @@ class HttpApi {
 
     const ipfs = this._ipfs
 
-    const config = await ipfs.config.get()
+    const config = await ipfs.config.getAll()
     config.Addresses = config.Addresses || {}
 
     const apiAddrs = config.Addresses.API

--- a/packages/ipfs/test/cli/config.js
+++ b/packages/ipfs/test/cli/config.js
@@ -14,6 +14,7 @@ describe('config', () => {
     ipfs = {
       config: {
         set: sinon.stub(),
+        getAll: sinon.stub(),
         get: sinon.stub(),
         replace: sinon.stub(),
         profiles: {
@@ -87,7 +88,7 @@ describe('config', () => {
 
   describe('show', function () {
     it('returns the full config', async () => {
-      ipfs.config.get.withArgs({
+      ipfs.config.getAll.withArgs({
         timeout: undefined
       }).returns({ foo: 'bar' })
       const out = await cli('config show', { ipfs })
@@ -95,7 +96,7 @@ describe('config', () => {
     })
 
     it('returns the full config with a timeout', async () => {
-      ipfs.config.get.withArgs({
+      ipfs.config.getAll.withArgs({
         timeout: 1000
       }).returns({ foo: 'bar' })
       const out = await cli('config show --timeout=1s', { ipfs })

--- a/packages/ipfs/test/core/create-node.spec.js
+++ b/packages/ipfs/test/core/create-node.spec.js
@@ -34,7 +34,7 @@ describe('create node', function () {
       preload: { enabled: false }
     })
 
-    const config = await node.config.get()
+    const config = await node.config.getAll()
     expect(config.Identity).to.exist()
     await node.stop()
   })
@@ -53,7 +53,7 @@ describe('create node', function () {
       preload: { enabled: false }
     })
 
-    const config = await node.config.get()
+    const config = await node.config.getAll()
     expect(config.Identity).to.exist()
     await node.stop()
   })
@@ -104,7 +104,7 @@ describe('create node', function () {
       preload: { enabled: false }
     })
 
-    const config = await node.config.get()
+    const config = await node.config.getAll()
     expect(config.Identity).to.exist()
     expect(config.Identity.PrivKey.length).is.below(1024)
     await node.stop()
@@ -152,7 +152,7 @@ describe('create node', function () {
       preload: { enabled: false }
     })
 
-    const config = await node.config.get()
+    const config = await node.config.getAll()
     expect(config.Addresses.Swarm).to.eql(['/ip4/127.0.0.1/tcp/9977'])
     expect(config.Bootstrap).to.eql([])
     await node.stop()

--- a/packages/ipfs/test/core/init.spec.js
+++ b/packages/ipfs/test/core/init.spec.js
@@ -38,7 +38,7 @@ describe('init', function () {
     const res = await repo.exists()
     expect(res).to.equal(true)
 
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
 
     expect(config.Identity).to.exist()
     expect(config.Keychain).to.exist()
@@ -49,14 +49,14 @@ describe('init', function () {
 
     await ipfs.init({ bits: 1024, pass: nanoid() })
 
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
     expect(config.Identity.PrivKey.length).is.above(256)
   })
 
   it('should allow a pregenerated key to be used', async () => {
     await ipfs.init({ privateKey })
 
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
     expect(config.Identity.PeerID).is.equal('QmRsooYQasV5f5r834NSpdUtmejdQcpxXkK6qsozZWEihC')
   })
 
@@ -79,14 +79,14 @@ describe('init', function () {
   it('should apply one profile', async () => {
     await ipfs.init({ bits: 512, profiles: ['test'] })
 
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
     expect(config.Bootstrap).to.be.empty()
   })
 
   it('should apply multiple profiles', async () => {
     await ipfs.init({ bits: 512, profiles: ['test', 'local-discovery'] })
 
-    const config = await repo.config.get()
+    const config = await repo.config.getAll()
     expect(config.Bootstrap).to.be.empty()
     expect(config.Discovery.MDNS.Enabled).to.be.true()
   })

--- a/packages/ipfs/test/http-api/inject/config.js
+++ b/packages/ipfs/test/http-api/inject/config.js
@@ -23,6 +23,7 @@ describe('/config', () => {
   beforeEach(() => {
     ipfs = {
       config: {
+        getAll: sinon.stub(),
         get: sinon.stub(),
         replace: sinon.stub(),
         profiles: {
@@ -58,7 +59,7 @@ describe('/config', () => {
   })
 
   it('returns value for request with valid arg', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       API: {
         HTTPHeaders: 'value'
       }
@@ -75,7 +76,7 @@ describe('/config', () => {
   })
 
   it('returns value for request as subcommand', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       API: {
         HTTPHeaders: 'value'
       }
@@ -92,7 +93,7 @@ describe('/config', () => {
   })
 
   it('updates value for request with both args', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       Datastore: {
         Path: 'not-kitten'
       }
@@ -114,7 +115,7 @@ describe('/config', () => {
   })
 
   it('returns 400 value for request with both args and JSON flag with invalid JSON argument', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       Datastore: {
         Path: 'not-kitten'
       }
@@ -132,7 +133,7 @@ describe('/config', () => {
   })
 
   it('updates value for request with both args and JSON flag with valid JSON argument', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       Datastore: {
         Path: 'not-kitten'
       }
@@ -156,7 +157,7 @@ describe('/config', () => {
   })
 
   it('updates null json value', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       Datastore: {
         Path: 'not-kitten'
       }
@@ -178,7 +179,7 @@ describe('/config', () => {
   })
 
   it('updates value for request with both args and bool flag and true argument', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       Datastore: {
         Path: 'not-kitten'
       }
@@ -200,7 +201,7 @@ describe('/config', () => {
   })
 
   it('updates value for request with both args and bool flag and false argument', async () => {
-    ipfs.config.get.withArgs(undefined, defaultOptions).returns({
+    ipfs.config.getAll.withArgs(defaultOptions).returns({
       Datastore: {
         Path: 'not-kitten'
       }
@@ -224,7 +225,7 @@ describe('/config', () => {
   it('accepts a timeout', async () => {
     const key = 'Datastore.Path'
     const value = 'value'
-    ipfs.config.get.withArgs(undefined, {
+    ipfs.config.getAll.withArgs({
       ...defaultOptions,
       timeout: 1000
     }).returns({
@@ -262,7 +263,7 @@ describe('/config', () => {
         }
       }
 
-      ipfs.config.get.withArgs(undefined, defaultOptions).returns(config)
+      ipfs.config.getAll.withArgs(defaultOptions).returns(config)
 
       const res = await http({
         method: 'POST',
@@ -280,7 +281,7 @@ describe('/config', () => {
         }
       }
 
-      ipfs.config.get.withArgs(undefined, {
+      ipfs.config.getAll.withArgs({
         ...defaultOptions,
         timeout: 1000
       }).returns(config)


### PR DESCRIPTION
This PR adds `ipfs.config.getAll(options?: Object)` and makes `key` in `ipfs.config.get(key: string, options?: object)` required.