### PR TITLE
feat: persist peerstore

### DIFF
--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -63,6 +63,10 @@ module.exports = () => {
     },
     metrics: {
       enabled: true
+    },
+    peerStore: {
+      persistence: true,
+      threshold: 1
     }
   }
 }

--- a/packages/ipfs/src/core/runtime/libp2p-nodejs.js
+++ b/packages/ipfs/src/core/runtime/libp2p-nodejs.js
@@ -66,6 +66,9 @@ module.exports = () => {
     },
     metrics: {
       enabled: true
+    },
+    peerStore: {
+      persistence: true
     }
   }
 }


### PR DESCRIPTION
This PR enables the [PeerStore persistence](https://github.com/libp2p/js-libp2p/tree/master/src/peer-store#data-persistence) by default in the libp2p runtime configurations.

The configuration details can be seen via [libp2p/js-libp2p/doc/CONFIGURATION.md#configuring-peerstore](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#configuring-peerstore). According to the instructions there, we set the browser `threshold` to 1.

Regarding benchmarks, I did a small experiment while we do not have testground support to test proper networking scenarios. The conclusions are available in [libp2p/js-libp2p#582#issuecomment-637404704](https://github.com/libp2p/js-libp2p/issues/582#issuecomment-637404704). The current results are more significant for node in our current state, but I hope that we can leverage this to also improve browser results with the rendezvous and circuit relay instead of the star servers. It is important pointing out that the results should be better on a real network scenario, since the latencies for connections and exchanging known peers will be bigger than a bunch of nodes in my machine.