### PR TITLE
chore: test datastore-idb with transactions

### DIFF
--- a/examples/custom-ipfs-repo/package.json
+++ b/examples/custom-ipfs-repo/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "datastore-fs": "^1.1.0",
     "ipfs": "^0.46.0",
-    "ipfs-repo": "^3.0.0",
+    "ipfs-repo": "ipfs/js-ipfs-repo#test/use-datastore-idb-with-tx",
     "it-all": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -96,7 +96,7 @@
     "ipfs-core-utils": "^0.2.3",
     "ipfs-http-client": "^44.2.0",
     "ipfs-http-response": "^0.5.0",
-    "ipfs-repo": "^3.0.0",
+    "ipfs-repo": "ipfs/js-ipfs-repo#test/use-datastore-idb-with-tx",
     "ipfs-unixfs": "^1.0.3",
     "ipfs-unixfs-exporter": "^2.0.2",
     "ipfs-unixfs-importer": "^2.0.2",


### PR DESCRIPTION
Use repo branch with datastore-idb with transactions so we can test integration. Not for merging.