### PR TITLE
fix: libp2p now requires encryption module

### DIFF
--- a/examples/circuit-relaying/README.md
+++ b/examples/circuit-relaying/README.md
@@ -64,21 +64,21 @@ A circuit relay address is a [multiaddress](https://multiformats.io/multiaddr/) 
 
 Circuit relay addresses are very flexible and can describe many different aspects of how to esablish the relayed connection. In its simplest form, it looks something like this:
 
-- `/p2p-circuit/ipfs/QmPeer`
+- `/p2p-circuit/p2p/QmPeer`
 
 If we want to be specific as to which transport we want to use to establish the relay, we can encode that in the address as well:
 
-- `/ip4/127.0.0.1/tcp/65000/ipfs/QmRelay/p2p-circuit/ipfs/QmPeer`
+- `/ip4/127.0.0.1/tcp/65000/p2p/QmRelay/p2p-circuit/ipfs/QmPeer`
 
 This tells us that we want to use `QmRelay` located at address 127.0.0.1 and port 65000.
 
-- `/ip4/127.0.0.1/tcp/65000/ipfs/QmRelay/p2p-circuit/ip4/127.0.0.1/tcp/8080/ws/ipfs/QmPeer`
+- `/ip4/127.0.0.1/tcp/65000/p2p/QmRelay/p2p-circuit/ip4/127.0.0.1/tcp/8080/ws/ipfs/QmPeer`
 
 We can take it a step further and encode the same information for the destination peer. In this case, we have it located at 127.0.0.1 on port 8080 and using a Web sockets transport!
 
-- `/ip4/127.0.0.1/tcp/65000/ipfs/QmRelay/p2p-circuit`
+- `/ip4/127.0.0.1/tcp/65000/p2p/QmRelay/p2p-circuit`
 
-If a node is configured with this address, it will use the specified host (`/ip4/127.0.0.1/tcp/65000/ipfs/QmRelay`) as a relay and it will be reachable over this relay.
+If a node is configured with this address, it will use the specified host (`/ip4/127.0.0.1/tcp/65000/p2p/QmRelay`) as a relay and it will be reachable over this relay.
   - There could multiple addresses of this sort specified in the config, in which case the node will be reachable over all of them.
   - This is useful if, for example, the node is behind a firewall but wants to be reachable from the outside over a specific relay.
 
@@ -227,36 +227,36 @@ $ ipfs id
         "ID": "QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
         "PublicKey": "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC84qPFzqajCfnvaJunqt48S1LIBRthXV60q5QClL+dUfOOU/m7v1ZcpNhvFFUN6tVCDaoT5AxEv0czxZiVx/njl6FVIc6tE1J+HWpc8cbAXNY6QbbyzKl/rjp7V8/QClE0JqgjIk84wnWGTwFhOEt0hnpu2XFt9iHaenSfg3EAa8K9MlbxmbawuxNLJJf7VZXkJrUNl6WOglAVU8Sqc4QaahCLVK5Dzo98zDBq1KDBxMbUgH0LTqzr6i+saxkEHZmBKO+mMVT3LzOUx1DQR4pLAw1qgoJstsIZEaJ2XLh975IiI7OKqWYH7+3NyNK2sldJK/4Zko4rH3irmnkAxLcFAgMBAAE=",
         "Addresses": [
-                "/ip4/127.0.0.1/tcp/4001/ipfs/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
-                "/ip4/192.168.1.132/tcp/4001/ipfs/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
-                "/ip6/::1/tcp/4001/ipfs/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
-                "/ip4/186.4.18.182/tcp/13285/ipfs/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
-                "/ip4/186.4.18.182/tcp/13285/ipfs/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF"
+                "/ip4/127.0.0.1/tcp/4001/p2p/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
+                "/ip4/192.168.1.132/tcp/4001/p2p/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
+                "/ip6/::1/tcp/4001/p2p/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
+                "/ip4/186.4.18.182/tcp/13285/p2p/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF",
+                "/ip4/186.4.18.182/tcp/13285/p2p/QmY73BLYav2gYc9PCEnjQqbfSGiqFv3aMsRXNyKFGtUoGF"
         ],
         "AgentVersion": "go-ipfs/0.4.14-dev/cb5bb7dd8",
         "ProtocolVersion": "ipfs/0.1.0"
 }
 ```
 
-We can then grab the resolved multiaddr from the `Addresses` array — `/ip4/127.0.0.1/tcp/4004/ws/ipfs/Qm...`. Let's note it down somewhere and move to the next step.
+We can then grab the resolved multiaddr from the `Addresses` array — `/ip4/127.0.0.1/tcp/4004/ws/p2p/Qm...`. Let's note it down somewhere and move to the next step.
 
 **js ipfs**
 
 ```console
 $ jsipfs daemon
 Initializing daemon...
-Swarm listening on /p2p-circuit/ipfs/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
-Swarm listening on /p2p-circuit/ip4/0.0.0.0/tcp/4002/ipfs/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
-Swarm listening on /p2p-circuit/ip4/127.0.0.1/tcp/4003/ws/ipfs/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
-Swarm listening on /ip4/127.0.0.1/tcp/4003/ws/ipfs/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
-Swarm listening on /ip4/127.0.0.1/tcp/4002/ipfs/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
-Swarm listening on /ip4/192.168.1.132/tcp/4002/ipfs/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
+Swarm listening on /p2p-circuit/p2p/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
+Swarm listening on /p2p-circuit/ip4/0.0.0.0/tcp/4002/p2p/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
+Swarm listening on /p2p-circuit/ip4/127.0.0.1/tcp/4003/ws/p2p/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
+Swarm listening on /ip4/127.0.0.1/tcp/4003/ws/p2p/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
+Swarm listening on /ip4/127.0.0.1/tcp/4002/p2p/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
+Swarm listening on /ip4/192.168.1.132/tcp/4002/p2p/QmfQj8YwDdy1uP2DpZBa7k38rSGPvhHiC52cdAGWBqoVpq
 API is listening on: /ip4/127.0.0.1/tcp/5002
 Gateway (readonly) is listening on: /ip4/127.0.0.1/tcp/9090
 Daemon is ready
 ```
 
-Look out for an address similar to `/ip4/127.0.0.1/tcp/4003/ws/ipfs/Qm...`. Note it down somewhere, and let's move on to the next step.
+Look out for an address similar to `/ip4/127.0.0.1/tcp/4003/ws/p2p/Qm...`. Note it down somewhere, and let's move on to the next step.
 
 ### 2. Configure and run the bundled example
 
@@ -333,7 +333,7 @@ const ipfs = await IPFS.create({
 
 - We connected the browser nodes to an external node over its websocket transport using the `/ip4/127.0.0.1/tcp/4003/ws/ipfs/...` multiaddr. That external node happens to be a `HOP` node, meaning that it can relay connections for our browsers (and other nodes) allowing them to connect
 
-- And finally we connected the two browser nodes using the `/p2p-circuit/ipfs/...` multiaddr. Take a look at the code below in [src/app.js](src/app.js#L103...L108) - lines 103-108
+- And finally we connected the two browser nodes using the `/p2p-circuit/p2p/...` multiaddr. Take a look at the code below in [src/app.js](src/app.js#L103...L108) - lines 103-108
 
 ```js
 try {

--- a/examples/circuit-relaying/index.html
+++ b/examples/circuit-relaying/index.html
@@ -34,7 +34,7 @@
           <ul id="peers"></ul>
         </div>
         <div class="box peers-box">
-          <label>Peers Connected:</label>
+          <label>Swarm Peers:</label>
           <ul id="peers-addrs"></ul>
         </div>
         <div>

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -14,6 +14,7 @@
   "author": "Dmitriy Ryajov <dryajov@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "delay": "^4.3.0",
     "ipfs": "^0.46.0",
     "ipfs-pubsub-room": "^2.0.1"
   },

--- a/examples/circuit-relaying/src/app.js
+++ b/examples/circuit-relaying/src/app.js
@@ -47,6 +47,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const sendMsg = helpers.sendMsg
   const updatePeers = helpers.updatePeers
   const updateAddrs = helpers.updateAddrs
+  const updateSwarmPeers = helpers.updateSwarmPeers
 
   const info = await ipfs.id()
   console.log('IPFS node ready with id ' + info.id)
@@ -54,7 +55,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   let room = createRoom(roomName)
 
   $peerId.innerHTML = `<li>${info.id}</li>`
-  updateAddrs(info.addresses)
 
   $send.addEventListener('click', () => {
     sendMsg(room)
@@ -95,13 +95,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   })
 
   $connect.addEventListener('click', async () => {
-    const peer = $peer.value
+    const peer = $peer.value.trim()
     $peer.value = ''
     try {
       await ipfs.swarm.connect(peer)
+      await updateAddrs(ipfs)
+      await updateSwarmPeers(ipfs)
     } catch (err) {
       return console.error(err)
     }
-    $pAddrs.innerHTML += `<li>${peer.trim()}</li>`
   })
 })

--- a/packages/ipfs/test/core/libp2p.spec.js
+++ b/packages/ipfs/test/core/libp2p.spec.js
@@ -7,6 +7,7 @@ const PeerId = require('peer-id')
 const Libp2p = require('libp2p')
 const EE = require('events')
 const libp2pComponent = require('../../src/core/components/libp2p')
+const Crypto = require('libp2p-secio')
 
 class DummyTransport {
   get [Symbol.toStringTag] () {
@@ -32,7 +33,7 @@ class DummyDiscovery extends EE {
   }
 }
 
-describe('libp2p customization', function () {
+describe.only('libp2p customization', function () {
   // Provide some extra time for ci since we're starting libp2p nodes in each test
   this.timeout(25 * 1000)
 
@@ -77,7 +78,7 @@ describe('libp2p customization', function () {
           libp2p: (opts) => {
             return new Libp2p({
               peerId: opts.peerId,
-              modules: { transport: [DummyTransport] },
+              modules: { transport: [DummyTransport], connEncryption: [ Crypto ] },
               config: { relay: { enabled: false } }
             })
           }
@@ -101,7 +102,7 @@ describe('libp2p customization', function () {
           libp2p: (opts) => {
             return new Libp2p({
               peerId: opts.peerId,
-              modules: { transport: [DummyTransport] },
+              modules: { transport: [DummyTransport], connEncryption: [ Crypto ] },
               config: { relay: { enabled: false } }
             })
           }

--- a/packages/ipfs/test/core/libp2p.spec.js
+++ b/packages/ipfs/test/core/libp2p.spec.js
@@ -33,7 +33,7 @@ class DummyDiscovery extends EE {
   }
 }
 
-describe.only('libp2p customization', function () {
+describe('libp2p customization', function () {
   // Provide some extra time for ci since we're starting libp2p nodes in each test
   this.timeout(25 * 1000)
 
@@ -78,7 +78,7 @@ describe.only('libp2p customization', function () {
           libp2p: (opts) => {
             return new Libp2p({
               peerId: opts.peerId,
-              modules: { transport: [DummyTransport], connEncryption: [ Crypto ] },
+              modules: { transport: [DummyTransport], connEncryption: [Crypto] },
               config: { relay: { enabled: false } }
             })
           }
@@ -102,7 +102,7 @@ describe.only('libp2p customization', function () {
           libp2p: (opts) => {
             return new Libp2p({
               peerId: opts.peerId,
-              modules: { transport: [DummyTransport], connEncryption: [ Crypto ] },
+              modules: { transport: [DummyTransport], connEncryption: [Crypto] },
               config: { relay: { enabled: false } }
             })
           }


### PR DESCRIPTION
Since the `v0.28.1` patch release, libp2p requires a connection encryption module to be passed in config, otherwise it throws.

See: https://github.com/libp2p/js-libp2p/pull/665