### PR TITLE
docs: ready to test in less time

### DIFF
--- a/examples/browser-browserify/README.md
+++ b/examples/browser-browserify/README.md
@@ -2,22 +2,12 @@
 
 In this example, you will find a boilerplate you can use to guide yourself into bundling js-ipfs with [browserify](http://browserify.org/), so that you can use it in your own web app!
 
-## Before you start
-
-First clone this repo, install dependencies in the project root and build the project.
-
-```console
-$ git clone https://github.com/ipfs/js-ipfs.git
-$ cd js-ipfs
-$ npm install
-$ npm run build
-```
-
-## Running the example
-
-In this directory run:
+## Clone repo and run the example
 
 ```bash
+> git clone https://github.com/ipfs/js-ipfs.git
+> cd js-ipfs/examples/browser-browserify
+> npm install
 > npm start
 ```
 


### PR DESCRIPTION
This is an improvement to a previous PR (#3084 ). It is ment to avoid building all the project just to run an example. Following the old instructions, after the cloning is finished, it took me 20 minutes before I can run the example. With this modification, I can run the example just 2 minutes after the cloning is finished.