### PR TITLE
fix: use datastore-level in the browser again

### DIFF
--- a/examples/custom-ipfs-repo/package.json
+++ b/examples/custom-ipfs-repo/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "datastore-fs": "^1.1.0",
     "ipfs": "^0.46.0",
-    "ipfs-repo": "^3.0.0",
+    "ipfs-repo": "ipfs/js-ipfs-repo#feat/use-datastore-level-in-browser",
     "it-all": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/ipfs/.aegir.js
+++ b/packages/ipfs/.aegir.js
@@ -15,7 +15,7 @@ let sigServerB
 let ipfsdServer
 
 module.exports = {
-  bundlesize: { maxSize: '446kB' },
+  bundlesize: { maxSize: '460kB' },
   karma: {
     files: [{
       pattern: 'node_modules/interface-ipfs-core/test/fixtures/**/*',

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -96,7 +96,7 @@
     "ipfs-core-utils": "^0.2.3",
     "ipfs-http-client": "^44.2.0",
     "ipfs-http-response": "^0.5.0",
-    "ipfs-repo": "^3.0.0",
+    "ipfs-repo": "ipfs/js-ipfs-repo#feat/use-datastore-level-in-browser",
     "ipfs-unixfs": "^1.0.3",
     "ipfs-unixfs-exporter": "^2.0.2",
     "ipfs-unixfs-importer": "^2.0.2",


### PR DESCRIPTION
`level-js` seems to handle datastore mutations during queries better which we need for datastore migrations.

Revisit once https://github.com/ipfs/js-datastore-idb/issues/6 is resolved.