### PR TITLE
chore: update libp2p runtime config

### DIFF
--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -39,7 +39,8 @@ module.exports = () => {
         bootstrap: {
           enabled: true
         },
-        [WebRTCStar.tag]: {
+        // [WebRTCStar.discovery.tag]
+        webRTCStar: {
           enabled: true
         }
       },

--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -35,8 +35,6 @@ module.exports = () => {
     config: {
       peerDiscovery: {
         autoDial: true,
-        // Optimization
-        // Requiring bootstrap inline in components/libp2p to reduce the cli execution time
         // [Bootstrap.tag] = 'bootstrap'
         bootstrap: {
           enabled: true

--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Bootstrap = require('libp2p-bootstrap')
 const WS = require('libp2p-websockets')
 const WebRTCStar = require('libp2p-webrtc-star')
 const Multiplex = require('libp2p-mplex')
@@ -36,7 +35,10 @@ module.exports = () => {
     config: {
       peerDiscovery: {
         autoDial: true,
-        [Bootstrap.tag]: {
+        // Optimization
+        // Requiring bootstrap inline in components/libp2p to speed up start-up time
+        // [Bootstrap.tag] = 'bootstrap'
+        bootstrap: {
           enabled: true
         },
         [WebRTCStar.tag]: {

--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -36,7 +36,7 @@ module.exports = () => {
       peerDiscovery: {
         autoDial: true,
         // Optimization
-        // Requiring bootstrap inline in components/libp2p to speed up start-up time
+        // Requiring bootstrap inline in components/libp2p to reduce the cli execution time
         // [Bootstrap.tag] = 'bootstrap'
         bootstrap: {
           enabled: true

--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Bootstrap = require('libp2p-bootstrap')
 const WS = require('libp2p-websockets')
 const WebRTCStar = require('libp2p-webrtc-star')
 const Multiplex = require('libp2p-mplex')
@@ -35,13 +36,10 @@ module.exports = () => {
     config: {
       peerDiscovery: {
         autoDial: true,
-        bootstrap: {
+        [Bootstrap.tag]: {
           enabled: true
         },
-        webRTCStar: {
-          enabled: true
-        },
-        websocketStar: {
+        [WebRTCStar.tag]: {
           enabled: true
         }
       },

--- a/packages/ipfs/src/core/runtime/libp2p-nodejs.js
+++ b/packages/ipfs/src/core/runtime/libp2p-nodejs.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Bootstrap = require('libp2p-bootstrap')
 const TCP = require('libp2p-tcp')
 const MulticastDNS = require('libp2p-mdns')
 const WS = require('libp2p-websockets')
@@ -38,13 +39,10 @@ module.exports = () => {
     config: {
       peerDiscovery: {
         autoDial: true,
-        mdns: {
+        [MulticastDNS.tag]: {
           enabled: true
         },
-        bootstrap: {
-          enabled: true
-        },
-        websocketStar: {
+        [Bootstrap.tag]: {
           enabled: true
         }
       },

--- a/packages/ipfs/src/core/runtime/libp2p-nodejs.js
+++ b/packages/ipfs/src/core/runtime/libp2p-nodejs.js
@@ -42,7 +42,7 @@ module.exports = () => {
           enabled: true
         },
         // Optimization
-        // Requiring bootstrap inline in components/libp2p to speed up start-up time
+        // Requiring bootstrap inline in components/libp2p to reduce the cli execution time
         // [Bootstrap.tag] = 'bootstrap'
         bootstrap: {
           enabled: true

--- a/packages/ipfs/src/core/runtime/libp2p-nodejs.js
+++ b/packages/ipfs/src/core/runtime/libp2p-nodejs.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Bootstrap = require('libp2p-bootstrap')
 const TCP = require('libp2p-tcp')
 const MulticastDNS = require('libp2p-mdns')
 const WS = require('libp2p-websockets')
@@ -42,7 +41,10 @@ module.exports = () => {
         [MulticastDNS.tag]: {
           enabled: true
         },
-        [Bootstrap.tag]: {
+        // Optimization
+        // Requiring bootstrap inline in components/libp2p to speed up start-up time
+        // [Bootstrap.tag] = 'bootstrap'
+        bootstrap: {
           enabled: true
         }
       },

--- a/packages/ipfs/test/core/libp2p.spec.js
+++ b/packages/ipfs/test/core/libp2p.spec.js
@@ -144,9 +144,6 @@ describe('libp2p customization', function () {
           },
           webRTCStar: {
             enabled: false
-          },
-          websocketStar: {
-            enabled: true
           }
         },
         pubsub: {


### PR DESCRIPTION
This PR removes the websocketStar discovery configuration, since it is not used anymore.

In addition, I have changed the discovery keys to use the modules tag from the module. This has created some confusion to libp2p users, and we would like people to use the tag instead of magic keys that might also be changed in the future: https://github.com/libp2p/js-libp2p/issues/664#issuecomment-642249349