### PR TITLE
chore: upgrade ipld-raw

### DIFF
--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -51,7 +51,7 @@
     "ipld-block": "^0.9.1",
     "ipld-dag-cbor": "^0.15.2",
     "ipld-dag-pb": "^0.18.5",
-    "ipld-raw": "^4.0.1",
+    "ipld-raw": "^5.0.0",
     "iso-url": "^0.4.7",
     "it-tar": "^1.2.2",
     "it-to-buffer": "^1.0.0",

--- a/packages/ipfs-http-client/src/dag/get.js
+++ b/packages/ipfs-http-client/src/dag/get.js
@@ -32,6 +32,10 @@ module.exports = configure((api, options) => {
       )
     }
 
+    if (block.cid.codec === 'raw' && !resolved.remPath) {
+      resolved.remPath = '/'
+    }
+
     return dagResolver.resolve(block.data, resolved.remPath)
   }
 })

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -108,7 +108,7 @@
     "ipld-dag-pb": "^0.18.5",
     "ipld-ethereum": "^4.0.0",
     "ipld-git": "^0.5.0",
-    "ipld-raw": "^4.0.1",
+    "ipld-raw": "^5.0.0",
     "ipld-zcash": "^0.4.0",
     "ipns": "^0.7.1",
     "is-domain-name": "^1.0.1",


### PR DESCRIPTION
Resolve now throws if the path is not '/'.