### PR TITLE
feat: add interface and http client versions to version output

### DIFF
--- a/docs/core-api/MISCELLANEOUS.md
+++ b/docs/core-api/MISCELLANEOUS.md
@@ -92,7 +92,7 @@ An optional object which may have the following keys:
 
 | Type | Description |
 | -------- | -------- |
-| `Promise<Object>` | An object with the version of the implementation, the commit and the Repo |
+| `Promise<Object>` | An object with the version of the implementation, the commit and the Repo. `js-ipfs` instances will also return the version of `interface-ipfs-core` and `ipfs-http-client` supported by this node |
 
 ### Example
 

--- a/packages/interface-ipfs-core/src/miscellaneous/version.js
+++ b/packages/interface-ipfs-core/src/miscellaneous/version.js
@@ -34,5 +34,15 @@ module.exports = (common, options) => {
       expect(result).to.have.a.property('commit')
       expect(result).to.have.a.property('repo')
     })
+
+    it('should include the ipfs-http-client version', async () => {
+      const result = await ipfs.version()
+      expect(result).to.have.a.property('ipfs-http-client')
+    })
+
+    it('should include the interface-ipfs-core version', async () => {
+      const result = await ipfs.version()
+      expect(result).to.have.a.property('interface-ipfs-core')
+    })
   })
 }

--- a/packages/ipfs-http-client/test/interface.spec.js
+++ b/packages/ipfs-http-client/test/interface.spec.js
@@ -482,7 +482,18 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
-  tests.miscellaneous(commonFactory)
+  tests.miscellaneous(commonFactory, {
+    skip: [
+      {
+        name: 'should include the ipfs-http-client version',
+        reason: 'TODO not implemented in go-ipfs yet'
+      },
+      {
+        name: 'should include the interface-ipfs-core version',
+        reason: 'TODO not implemented in go-ipfs yet'
+      }
+    ]
+  })
 
   tests.name(factory(
     {

--- a/packages/ipfs/src/cli/commands/version.js
+++ b/packages/ipfs/src/cli/commands/version.js
@@ -42,7 +42,7 @@ module.exports = {
     })
 
     const withCommit = all || commit
-    const parsedVersion = `${data.version}${withCommit ? `-${data.commit}` : ''}`
+    const parsedVersion = `${data.version}${withCommit && data.commit ? `-${data.commit}` : ''}`
 
     if (repo) {
       // go-ipfs prints only the number, even without the --number flag.
@@ -51,9 +51,15 @@ module.exports = {
       print(parsedVersion)
     } else if (all) {
       print(`js-ipfs version: ${parsedVersion}`)
+      print(`interface-ipfs-core version: ${data['interface-ipfs-core']}`)
+      print(`ipfs-http-client version: ${data['ipfs-http-client']}`)
       print(`Repo version: ${data.repo}`)
       print(`System version: ${os.arch()}/${os.platform()}`)
       print(`Node.js version: ${process.version}`)
+
+      if (data.commit) {
+        print(`Commit: ${data.commit}`)
+      }
     } else {
       print(`js-ipfs version: ${parsedVersion}`)
     }

--- a/packages/ipfs/src/core/components/version.js
+++ b/packages/ipfs/src/core/components/version.js
@@ -3,7 +3,6 @@
 const pkg = require('../../../package.json')
 const { withTimeoutOption } = require('../utils')
 
-// TODO add the commit hash of the current ipfs version to the response.
 module.exports = ({ repo }) => {
   return withTimeoutOption(async function version (options) {
     const repoVersion = await repo.version.get(options)
@@ -11,7 +10,9 @@ module.exports = ({ repo }) => {
     return {
       version: pkg.version,
       repo: repoVersion,
-      commit: ''
+      commit: pkg.gitHead || '', // is defined in published versions,
+      'interface-ipfs-core': pkg.devDependencies['interface-ipfs-core'],
+      'ipfs-http-client': pkg.dependencies['ipfs-http-client']
     }
   })
 }

--- a/packages/ipfs/src/http/api/resources/version.js
+++ b/packages/ipfs/src/http/api/resources/version.js
@@ -37,7 +37,9 @@ module.exports = {
     return h.response({
       Version: version.version,
       Commit: version.commit,
-      Repo: version.repo
+      Repo: version.repo,
+      'ipfs-http-client': version['ipfs-http-client'],
+      'interface-ipfs-core': version['interface-ipfs-core']
     })
   }
 }


### PR DESCRIPTION
Adds `interface-ipfs-core` and `ipfs-http-client` versions to the output of the `ipfs version` command, also the git commit id if it's available.

Closes #2878