### PR TITLE
fix: still load dag-pb, dag-cbor and raw when specifying custom formats

### DIFF
--- a/packages/ipfs/src/core/runtime/ipld-nodejs.js
+++ b/packages/ipfs/src/core/runtime/ipld-nodejs.js
@@ -4,6 +4,15 @@ const multicodec = require('multicodec')
 
 // All known (non-default) IPLD formats
 const IpldFormats = {
+  get [multicodec.DAG_PB] () {
+    return require('ipld-dag-pb')
+  },
+  get [multicodec.DAG_CBOR] () {
+    return require('ipld-dag-cbor')
+  },
+  get [multicodec.RAW] () {
+    return require('ipld-raw')
+  },
   get [multicodec.BITCOIN_BLOCK] () {
     return require('ipld-bitcoin')
   },

--- a/packages/ipfs/test/core/ipld.spec.js
+++ b/packages/ipfs/test/core/ipld.spec.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
+const factory = require('../utils/factory')
+const ipldDagPb = require('ipld-dag-pb')
+
+describe('ipld', function () {
+  this.timeout(10 * 1000)
+  const df = factory()
+
+  after(() => df.clean())
+
+  it('should allow formats to be specified without overwriting others', async () => {
+    const ipfs = (await df.spawn({
+      type: 'proc',
+      ipfsOptions: {
+        ipld: {
+          formats: [
+            require('ipld-dag-pb')
+          ]
+        }
+      }
+    })).api
+
+    const dagCborNode = {
+      hello: 'world'
+    }
+    const cid1 = await ipfs.dag.put(dagCborNode, {
+      format: 'dag-cbor',
+      hashAlg: 'sha2-256'
+    })
+
+    const dagPbNode = new ipldDagPb.DAGNode(Buffer.alloc(0), [], 0)
+    const cid2 = await ipfs.dag.put(dagPbNode, {
+      format: 'dag-pb',
+      hashAlg: 'sha2-256'
+    })
+
+    await expect(ipfs.dag.get(cid1)).to.eventually.have.property('value').that.deep.equals(dagCborNode)
+    await expect(ipfs.dag.get(cid2)).to.eventually.have.property('value').that.deep.equals(dagPbNode)
+  })
+})


### PR DESCRIPTION
If we specify a `formats` array as part of the ipld options in in-proc nodes, it replaces the default list of dag-pb, dag-cbor and raw.

This change allows the `loadFormat` function to still resolve those formats even if the user has passed a `format` array that does not contain them.

Fixes #3129