### PR TITLE
feat: add size-only flag to cli repo stat command

### DIFF
--- a/packages/ipfs/src/cli/commands/repo/stat.js
+++ b/packages/ipfs/src/cli/commands/repo/stat.js
@@ -14,13 +14,18 @@ module.exports = {
       alias: 'H',
       default: false
     },
+    sizeOnly: {
+      type: 'boolean',
+      alias: 's',
+      default: false
+    },
     timeout: {
       type: 'string',
       coerce: parseDuration
     }
   },
 
-  async handler ({ ctx: { ipfs, print }, human, timeout }) {
+  async handler ({ ctx: { ipfs, print }, human, sizeOnly, timeout }) {
     const stats = await ipfs.repo.stat({
       timeout
     })
@@ -31,11 +36,16 @@ module.exports = {
       stats.storageMax = prettyBytes(stats.storageMax.toNumber()).toUpperCase()
     }
 
-    print(
-`NumObjects: ${stats.numObjects}
-RepoSize: ${stats.repoSize}
+    if (sizeOnly) {
+      print(
+        `RepoSize:   ${stats.repoSize}
+StorageMax: ${stats.storageMax}`)
+    } else {
+      print(`NumObjects: ${stats.numObjects}
+RepoSize:   ${stats.repoSize}
 StorageMax: ${stats.storageMax}
-RepoPath: ${stats.repoPath}
-Version: ${stats.version}`)
+RepoPath:   ${stats.repoPath}
+Version:    ${stats.version}`)
+    }
   }
 }

--- a/packages/ipfs/src/cli/commands/stats/repo.js
+++ b/packages/ipfs/src/cli/commands/stats/repo.js
@@ -1,30 +1,12 @@
 'use strict'
 
-const parseDuration = require('parse-duration').default
+// This is an alias for `repo stat`.
+const repoStats = require('../repo/stat.js')
 
 module.exports = {
-  command: 'repo',
+  ...repoStats,
 
-  describe: 'Get stats for the currently used repo',
-
-  builder: {
-    human: {
-      type: 'boolean',
-      default: false
-    },
-    timeout: {
-      type: 'string',
-      coerce: parseDuration
-    }
-  },
-
-  async handler ({ ctx: { ipfs, print } }, human, timeout) {
-    const stats = await ipfs.stats.repo({ human, timeout })
-    print(`repo status
-  number of objects: ${stats.numObjects}
-  repo size: ${stats.repoSize}
-  repo path: ${stats.repoPath}
-  version: ${stats.version}
-  maximum storage: ${stats.storageMax}`)
-  }
+  // The command needs to be renamed, else it would be `stats stat` instead of
+  // `stats repo`
+  command: 'repo'
 }

--- a/packages/ipfs/test/cli/repo.js
+++ b/packages/ipfs/test/cli/repo.js
@@ -35,11 +35,28 @@ describe('repo', () => {
       })
 
       const stats = await cli('repo stat', { ipfs })
-      expect(stats).to.match(/^NumObjects:\s\d+$/m)
-      expect(stats).to.match(/^RepoSize:\s\d+$/m)
-      expect(stats).to.match(/^StorageMax:\s\d+$/m)
+      expect(stats).to.match(/^NumObjects:\s+\d+$/m)
+      expect(stats).to.match(/^RepoSize:\s+\d+$/m)
+      expect(stats).to.match(/^StorageMax:\s+\d+$/m)
       expect(stats).to.match(/^RepoPath:\s.+$/m)
-      expect(stats).to.match(/^Version:\s\d+$/m)
+      expect(stats).to.match(/^Version:\s+\d+$/m)
+    })
+
+    it('get repo stats with just size', async () => {
+      ipfs.repo.stat.withArgs(defaultOptions).resolves({
+        numObjects: BigNumber(10),
+        repoSize: BigNumber(10),
+        storageMax: BigNumber(10),
+        repoPath: '/foo',
+        version: 5
+      })
+
+      const stats = await cli('repo stat -s', { ipfs })
+      expect(stats).to.not.match(/^NumObjects:$/m)
+      expect(stats).to.match(/^RepoSize:\s+\d+$/m)
+      expect(stats).to.match(/^StorageMax:\s+\d+$/m)
+      expect(stats).to.not.match(/^RepoPath:$/m)
+      expect(stats).to.not.match(/^Version:$/m)
     })
 
     it('get human readable repo stats', async () => {
@@ -52,11 +69,11 @@ describe('repo', () => {
       })
 
       const stats = await cli('repo stat --human', { ipfs })
-      expect(stats).to.match(/^NumObjects:\s\d+$/m)
+      expect(stats).to.match(/^NumObjects:\s+\d+$/m)
       expect(stats).to.match(/^RepoSize:\s+[\d.]+\s[PTGMK]?B$/gm)
       expect(stats).to.match(/^StorageMax:\s+[\d.]+\s[PTGMK]?B$/gm)
       expect(stats).to.match(/^RepoPath:\s.+$/m)
-      expect(stats).to.match(/^Version:\s\d+$/m)
+      expect(stats).to.match(/^Version:\s+\d+$/m)
     })
 
     it('get repo with timeout', async () => {
@@ -72,11 +89,11 @@ describe('repo', () => {
       })
 
       const stats = await cli('repo stat --timeout=1s', { ipfs })
-      expect(stats).to.match(/^NumObjects:\s\d+$/m)
-      expect(stats).to.match(/^RepoSize:\s\d+$/m)
-      expect(stats).to.match(/^StorageMax:\s\d+$/m)
+      expect(stats).to.match(/^NumObjects:\s+\d+$/m)
+      expect(stats).to.match(/^RepoSize:\s+\d+$/m)
+      expect(stats).to.match(/^StorageMax:\s+\d+$/m)
       expect(stats).to.match(/^RepoPath:\s.+$/m)
-      expect(stats).to.match(/^Version:\s\d+$/m)
+      expect(stats).to.match(/^Version:\s+\d+$/m)
     })
   })
 


### PR DESCRIPTION
Makes `stats repo` an alias for `repo stat` to make formatting the same across commmands in line with go-ipfs.

Also adds `-s` flag to both commands to print just the size info.