### PR TITLE
fix: unhandledpromiserejection in electron tests

### DIFF
--- a/packages/ipfs/src/core/ipns/publisher.js
+++ b/packages/ipfs/src/core/ipns/publisher.js
@@ -32,7 +32,7 @@ class IpnsPublisher {
   }
 
   // Accepts a keypair, as well as a value (ipfsPath), and publishes it out to the routing system
-  async publish (privKey, value) { // eslint-disable-line require-await
+  publish (privKey, value) {
     return this.publishWithEOL(privKey, value, defaultRecordLifetime)
   }
 


### PR DESCRIPTION
When this method is async (without any actual async work) the 'should fail to publish if does not receive private key' test experiences an UnhandledPromiseRejection in electron, though the test still passes.