### PR TITLE
feat: turn on delegate nodes by default

### DIFF
--- a/packages/ipfs/src/core/components/config.js
+++ b/packages/ipfs/src/core/components/config.js
@@ -103,6 +103,7 @@ const profiles = {
       config.Addresses.API = defaultConfig.Addresses.API
       config.Addresses.Gateway = defaultConfig.Addresses.Gateway
       config.Addresses.Swarm = defaultConfig.Addresses.Swarm
+      config.Addresses.Delegates = defaultConfig.Addresses.Delegates
       config.Bootstrap = defaultConfig.Bootstrap
       config.Discovery.MDNS.Enabled = defaultConfig.Discovery.MDNS.Enabled
       config.Discovery.webRTCStar.Enabled = defaultConfig.Discovery.webRTCStar.Enabled

--- a/packages/ipfs/src/core/components/config.js
+++ b/packages/ipfs/src/core/components/config.js
@@ -87,6 +87,7 @@ const profiles = {
       config.Addresses.API = defaultConfig.Addresses.API ? '/ip4/127.0.0.1/tcp/0' : ''
       config.Addresses.Gateway = defaultConfig.Addresses.Gateway ? '/ip4/127.0.0.1/tcp/0' : ''
       config.Addresses.Swarm = defaultConfig.Addresses.Swarm.length ? ['/ip4/127.0.0.1/tcp/0'] : []
+      config.Addresses.Delegates = []
       config.Bootstrap = []
       config.Discovery.MDNS.Enabled = false
       config.Discovery.webRTCStar.Enabled = false

--- a/packages/ipfs/src/core/runtime/config-browser.js
+++ b/packages/ipfs/src/core/runtime/config-browser.js
@@ -6,7 +6,12 @@ module.exports = () => ({
     ],
     API: '',
     Gateway: '',
-    Delegates: []
+    Delegates: [
+      '/dns4/node0.delegate.ipfs.io/tcp/443/https',
+      '/dns4/node1.delegate.ipfs.io/tcp/443/https',
+      '/dns4/node2.delegate.ipfs.io/tcp/443/https',
+      '/dns4/node3.delegate.ipfs.io/tcp/443/https'
+    ]
   },
   Discovery: {
     MDNS: {

--- a/packages/ipfs/src/core/runtime/config-nodejs.js
+++ b/packages/ipfs/src/core/runtime/config-nodejs.js
@@ -8,7 +8,12 @@ module.exports = () => ({
     ],
     API: '/ip4/127.0.0.1/tcp/5002',
     Gateway: '/ip4/127.0.0.1/tcp/9090',
-    Delegates: []
+    Delegates: [
+      '/dns4/node0.delegate.ipfs.io/tcp/443/https',
+      '/dns4/node1.delegate.ipfs.io/tcp/443/https',
+      '/dns4/node2.delegate.ipfs.io/tcp/443/https',
+      '/dns4/node3.delegate.ipfs.io/tcp/443/https'
+    ]
   },
   Discovery: {
     MDNS: {


### PR DESCRIPTION
To help find content and peers on the network, turn on delegate nodes by default.

Disables delegate nodes while using the `test` config profile.