### PR TITLE
fix: use post for preloading

### DIFF
--- a/packages/ipfs/src/core/runtime/preload-browser.js
+++ b/packages/ipfs/src/core/runtime/preload-browser.js
@@ -17,7 +17,7 @@ module.exports = function preload (url, options) {
   options = options || {}
 
   return httpQueue.add(async () => {
-    const res = await HTTP.get(url, { signal: options.signal })
+    const res = await HTTP.post(url, { signal: options.signal })
     const reader = res.body.getReader()
 
     try {

--- a/packages/ipfs/src/core/runtime/preload-nodejs.js
+++ b/packages/ipfs/src/core/runtime/preload-nodejs.js
@@ -10,7 +10,7 @@ module.exports = async function preload (url, options) {
   log(url)
   options = options || {}
 
-  const res = await HTTP.get(url, { signal: options.signal })
+  const res = await HTTP.post(url, { signal: options.signal })
 
   for await (const _ of res.body) { // eslint-disable-line no-unused-vars
     // Read to completion but do not cache


### PR DESCRIPTION
As we don't accept get requests via the http api any more