### PR TITLE
fix: do not list raw nodes in a dag as directories

### DIFF
--- a/packages/ipfs/src/cli/commands/files/chmod.js
+++ b/packages/ipfs/src/cli/commands/files/chmod.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const {
-  asBoolean,
-  asOctal
+  asBoolean
 } = require('../../utils')
 const parseDuration = require('parse-duration').default
 
@@ -17,8 +16,7 @@ module.exports = {
       describe: 'The MFS path to change the mode of'
     },
     mode: {
-      type: 'int',
-      coerce: asOctal,
+      type: 'string',
       describe: 'The mode to use'
     },
     recursive: {

--- a/packages/ipfs/src/core/utils.js
+++ b/packages/ipfs/src/core/utils.js
@@ -155,13 +155,14 @@ const mapFile = (file, options) => {
     name: file.name,
     depth: file.path.split('/').length,
     size: 0,
-    type: 'dir'
+    type: 'file'
   }
 
   if (file.unixfs) {
+    output.type = file.unixfs.type === 'directory' ? 'dir' : 'file'
+
     if (file.unixfs.type === 'file') {
       output.size = file.unixfs.fileSize()
-      output.type = 'file'
 
       if (options.includeContent) {
         output.content = file.content()

--- a/packages/ipfs/src/http/api/resources/files-regular.js
+++ b/packages/ipfs/src/http/api/resources/files-regular.js
@@ -405,8 +405,11 @@ exports.ls = {
         Hash: cidToString(link.cid, { base: cidBase }),
         Size: link.size,
         Type: toTypeCode(link.type),
-        Depth: link.depth,
-        Mode: link.mode.toString(8).padStart(4, '0')
+        Depth: link.depth
+      }
+
+      if (link.mode != null) {
+        output.Mode = link.mode.toString(8).padStart(4, '0')
       }
 
       if (link.mtime) {

--- a/packages/ipfs/src/http/api/resources/files/chmod.js
+++ b/packages/ipfs/src/http/api/resources/files/chmod.js
@@ -56,6 +56,7 @@ const mfsChmod = {
         timeout
       }
     } = request
+
     await ipfs.files.chmod(path, mode, {
       recursive,
       hashAlg,

--- a/packages/ipfs/test/cli/files/chmod.js
+++ b/packages/ipfs/test/cli/files/chmod.js
@@ -32,7 +32,18 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8),
+      mode,
+      defaultOptions
+    ])
+  })
+
+  it('should update the mode for a file with a string', async () => {
+    await cli(`files chmod +x ${path}`, { ipfs })
+
+    expect(ipfs.files.chmod.callCount).to.equal(1)
+    expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
+      path,
+      '+x',
       defaultOptions
     ])
   })
@@ -43,7 +54,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         recursive: true
       }
@@ -56,7 +67,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         recursive: true
       }
@@ -69,7 +80,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         flush: false
       }
@@ -82,7 +93,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         flush: false
       }
@@ -95,7 +106,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         hashAlg: 'sha3-256'
       }
@@ -108,7 +119,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         hashAlg: 'sha3-256'
       }
@@ -121,7 +132,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         shardSplitThreshold: 10
       }
@@ -134,7 +145,7 @@ describe('chmod', () => {
     expect(ipfs.files.chmod.callCount).to.equal(1)
     expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
       path,
-      parseInt(mode, 8), {
+      mode, {
         ...defaultOptions,
         timeout: 1000
       }

--- a/packages/ipfs/test/http-api/inject/files.js
+++ b/packages/ipfs/test/http-api/inject/files.js
@@ -370,6 +370,33 @@ describe('/files', () => {
       })
     })
 
+    it('should list directory contents without unixfs v1.5 fields', async () => {
+      ipfs.ls.withArgs(`${cid}`, defaultOptions).returns([{
+        name: 'link',
+        cid,
+        size: 10,
+        type: 'file',
+        depth: 1
+      }])
+
+      const res = await http({
+        method: 'POST',
+        url: `/api/v0/ls?arg=${cid}`
+      }, { ipfs })
+
+      expect(res).to.have.property('statusCode', 200)
+      expect(res).to.have.deep.nested.property('result.Objects[0]', {
+        Hash: `${cid}`,
+        Links: [{
+          Depth: 1,
+          Hash: cid.toString(),
+          Name: 'link',
+          Size: 10,
+          Type: 2
+        }]
+      })
+    })
+
     it('should list directory contents recursively', async () => {
       ipfs.ls.withArgs(`${cid}`, {
         ...defaultOptions,

--- a/packages/ipfs/test/http-api/inject/mfs/chmod.js
+++ b/packages/ipfs/test/http-api/inject/mfs/chmod.js
@@ -43,6 +43,16 @@ describe('/files/chmod', () => {
     expect(ipfs.files.chmod.calledWith(path, mode, defaultOptions)).to.be.true()
   })
 
+  it('should update the mode for a file as a string', async () => {
+    await http({
+      method: 'POST',
+      url: `/api/v0/files/chmod?arg=${path}&mode=-x`
+    }, { ipfs })
+
+    expect(ipfs.files.chmod.callCount).to.equal(1)
+    expect(ipfs.files.chmod.calledWith(path, '-x', defaultOptions)).to.be.true()
+  })
+
   it('should update the mode recursively', async () => {
     await http({
       method: 'POST',


### PR DESCRIPTION
`ipfs ls QMfoo` was listing raw nodes as directories when present in a DAG.

Also does not try to parse chmod strings as octals to allow `+x` etc on the command line the same as the programmatic API