### PR TITLE
docs: fix weird whitespace character

### DIFF
--- a/docs/RELEASE_ISSUE_TEMPLATE.md
+++ b/docs/RELEASE_ISSUE_TEMPLATE.md
@@ -47,7 +47,7 @@
   - [ ] Publish a release candidate to npm
     ```sh
     # All successful builds of master update the `build/last-successful` branch
-    # which contains an `npm-shrinkwrap.json`.
+    # which contains an `npm-shrinkwrap.json`.
     # This command checks that branch out, installs it's dependencies using `npm ci`,
     # creates a release branch (e.g. release/v0.34.x), updates the minor prerelease
     # version (e.g. 0.33.1 -> 0.34.0-rc.0) and publishes it to npm.
@@ -60,7 +60,7 @@
     npx aegir update-release-branch-lockfiles release/v0.34.x
 
     # Then update the rc published on npm. This command pulls the specified
-    # release branch, installs it's dependencies `npm ci`, increments the  
+    # release branch, installs it's dependencies `npm ci`, increments the
     # prerelease version (e.g. 0.34.0-rc.0 -> 0.34.0-rc.1) and publishes it
     # to npm.
     npx aegir update-rc release/v0.34.x

--- a/docs/core-api/DAG.md
+++ b/docs/core-api/DAG.md
@@ -7,16 +7,21 @@
   - [Options](#options)
   - [Returns](#returns)
   - [Example](#example)
-- [`ipfs.dag.get(cid, [options])`](#ipfsdaggetcid-path-options)
+- [`ipfs.dag.get(cid, [options])`](#ipfsdaggetcid-options)
   - [Parameters](#parameters-1)
   - [Options](#options-1)
   - [Returns](#returns-1)
   - [Example](#example-1)
-- [`ipfs.dag.tree(cid, [options])`](#ipfsdagtreecid-path-options)
+- [`ipfs.dag.tree(cid, [options])`](#ipfsdagtreecid-options)
   - [Parameters](#parameters-2)
   - [Options](#options-2)
   - [Returns](#returns-2)
   - [Example](#example-2)
+- [`ipfs.dag.resolve(ipfsPath, [options])`](#ipfsdagresolveipfspath-options)
+  - [Parameters](#parameters-3)
+  - [Options](#options-3)
+  - [Returns](#returns-3)
+  - [Example](#example-3)
 
 _Explore the DAG API through interactive coding challenges in our ProtoSchool tutorials:_
 - _[P2P data links with content addressing](https://proto.school/#/basics/) (beginner)_

--- a/docs/core-api/FILES.md
+++ b/docs/core-api/FILES.md
@@ -9,6 +9,7 @@ _Explore the Mutable File System through interactive coding challenges in our [P
     - [Parameters](#parameters)
     - [Options](#options)
     - [Returns](#returns)
+    - [Example](#example)
     - [Notes](#notes)
       - [Chunking options](#chunking-options)
       - [Hash algorithms](#hash-algorithms)
@@ -18,69 +19,75 @@ _Explore the Mutable File System through interactive coding challenges in our [P
     - [Parameters](#parameters-1)
     - [Options](#options-1)
     - [Returns](#returns-1)
-    - [Example](#example)
+    - [Example](#example-1)
   - [`ipfs.get(ipfsPath, [options])`](#ipfsgetipfspath-options)
     - [Parameters](#parameters-2)
     - [Options](#options-2)
     - [Returns](#returns-2)
+    - [Example](#example-2)
   - [`ipfs.ls(ipfsPath)`](#ipfslsipfspath)
     - [Parameters](#parameters-3)
     - [Options](#options-3)
     - [Returns](#returns-3)
-    - [Example](#example-1)
+    - [Example](#example-3)
 - [The Mutable Files API](#the-mutable-files-api)
   - [`ipfs.files.chmod(path, mode, [options])`](#ipfsfileschmodpath-mode-options)
     - [Parameters](#parameters-4)
     - [Options](#options-4)
     - [Returns](#returns-4)
-    - [Example](#example-2)
+    - [Example](#example-4)
   - [`ipfs.files.cp(...from, to, [options])`](#ipfsfilescpfrom-to-options)
     - [Parameters](#parameters-5)
     - [Options](#options-5)
     - [Returns](#returns-5)
-    - [Example](#example-3)
+    - [Example](#example-5)
     - [Notes](#notes-1)
   - [`ipfs.files.mkdir(path, [options])`](#ipfsfilesmkdirpath-options)
     - [Parameters](#parameters-6)
     - [Options](#options-6)
     - [Returns](#returns-6)
-    - [Example](#example-4)
+    - [Example](#example-6)
   - [`ipfs.files.stat(path, [options])`](#ipfsfilesstatpath-options)
     - [Parameters](#parameters-7)
     - [Options](#options-7)
     - [Returns](#returns-7)
-    - [Example](#example-5)
+    - [Example](#example-7)
   - [`ipfs.files.touch(path, [options])`](#ipfsfilestouchpath-options)
     - [Parameters](#parameters-8)
     - [Options](#options-8)
     - [Returns](#returns-8)
-    - [Example](#example-6)
+    - [Example](#example-8)
   - [`ipfs.files.rm(...paths, [options])`](#ipfsfilesrmpaths-options)
     - [Parameters](#parameters-9)
     - [Options](#options-9)
-    - [Example](#example-7)
+    - [Returns](#returns-9)
+    - [Example](#example-9)
   - [`ipfs.files.read(path, [options])`](#ipfsfilesreadpath-options)
     - [Parameters](#parameters-10)
     - [Options](#options-10)
-    - [Returns](#returns-9)
+    - [Returns](#returns-10)
+    - [Example](#example-10)
   - [`ipfs.files.write(path, content, [options])`](#ipfsfileswritepath-content-options)
     - [Parameters](#parameters-11)
     - [Options](#options-11)
-    - [Returns](#returns-10)
+    - [Returns](#returns-11)
+    - [Example](#example-11)
   - [`ipfs.files.mv(...from, to, [options])`](#ipfsfilesmvfrom-to-options)
     - [Parameters](#parameters-12)
     - [Options](#options-12)
-    - [Returns](#returns-11)
-    - [Example](#example-8)
+    - [Returns](#returns-12)
+    - [Example](#example-12)
+    - [Notes](#notes-2)
   - [`ipfs.files.flush(path, [options])`](#ipfsfilesflushpath-options)
     - [Parameters](#parameters-13)
     - [Options](#options-13)
-    - [Returns](#returns-12)
+    - [Returns](#returns-13)
+    - [Example](#example-13)
   - [`ipfs.files.ls(path, [options])`](#ipfsfileslspath-options)
     - [Parameters](#parameters-14)
     - [Options](#options-14)
-    - [Returns](#returns-13)
-    - [Example](#example-9)
+    - [Returns](#returns-14)
+    - [Example](#example-14)
 
 ## The Regular API
 The regular, top-level API for add, cat, get and ls Files on IPFS
@@ -186,7 +193,7 @@ Each yielded object is of the form:
 }
 ```
 
-#### Example
+#### Example
 
 ```js
 const files = [{
@@ -380,7 +387,7 @@ Each yielded object is of the form:
 
 Here, each `path` corresponds to the name of a file, and `content` is an async iterable with the file contents.
 
-#### Example
+#### Example
 
 ```JavaScript
 const BufferList = require('bl/BufferList')
@@ -713,7 +720,7 @@ An optional object which may have the following keys:
 | timeout | `Number` | `undefined` | A timeout in ms |
 | signal | [AbortSignal][] | `undefined` |  Can be used to cancel any long running requests started as a result of this call |
 
-#### Returns
+#### Returns
 
 | Type | Description |
 | -------- | -------- |
@@ -759,7 +766,7 @@ An optional object which may have the following keys:
 | -------- | -------- |
 | `AsyncIterable<Buffer>` | An async iterable that yields [`Buffer`][b] objects with the contents of `path` |
 
-#### Example
+#### Example
 
 ```JavaScript
 const chunks = []
@@ -809,7 +816,7 @@ An optional object which may have the following keys:
 | -------- | -------- |
 | `Promise<void>` | If action is successfully completed. Otherwise an error will be thrown |
 
-#### Example
+#### Example
 
 ```JavaScript
 await ipfs.files.write('/hello-world', Buffer.from('Hello, world!'))
@@ -855,7 +862,7 @@ await ipfs.files.mv('/src-dir', '/dst-dir')
 await ipfs.files.mv('/src-file1', '/src-file2', '/dst-dir')
 ```
 
-#### Notes
+#### Notes
 
 If `from` has multiple values then `to` must be a directory.
 
@@ -894,7 +901,7 @@ An optional object which may have the following keys:
 | -------- | -------- |
 | `Promise<CID>` | The CID of the path that has been flushed |
 
-#### Example
+#### Example
 
 ```JavaScript
 const cid = await ipfs.files.flush('/')

--- a/docs/core-api/OBJECT.md
+++ b/docs/core-api/OBJECT.md
@@ -41,6 +41,7 @@
   - [Options](#options-7)
   - [Returns](#returns-7)
   - [Example](#example-7)
+  - [Notes](#notes-1)
 - [`ipfs.object.patch.appendData(cid, data, [options])`](#ipfsobjectpatchappenddatacid-data-options)
   - [Parameters](#parameters-8)
   - [Options](#options-8)
@@ -405,7 +406,7 @@ const cid = await ipfs.object.patch.rmLink(node, {
 
 A great source of [examples][] can be found in the tests for this API.
 
-### Notes
+### Notes
 
 `link` is the link to be removed on the node that is identified by the `multihash`, can be passed as:
 

--- a/packages/ipfs-core-utils/README.md
+++ b/packages/ipfs-core-utils/README.md
@@ -14,7 +14,7 @@
 
 [Alex Potsides](https://github.com/achingbrain)
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents <!-- omit in toc -->
 
 - [Install](#install)
 - [Contribute](#contribute)

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -309,9 +309,9 @@ To always request the latest version, use one of the following examples:
 
 For maximum security you may also decide to:
 
-* reference a specific version of IPFS API (to prevent unexpected breaking changes when a newer latest version is published)
-* [generate a SRI hash](https://www.srihash.org/) of that version and use it to ensure integrity. Learn more also at the [jsdelivr website](https://www.jsdelivr.com/using-sri-with-dynamic-files)
-* set the [CORS settings attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) to make anonymous requests to CDN
+* reference a specific version of IPFS API (to prevent unexpected breaking changes when a newer latest version is published)
+* [generate a SRI hash](https://www.srihash.org/) of that version and use it to ensure integrity. Learn more also at the [jsdelivr website](https://www.jsdelivr.com/using-sri-with-dynamic-files)
+* set the [CORS settings attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) to make anonymous requests to CDN
 
 Example:
 
@@ -335,7 +335,7 @@ const ipfs = window.IpfsHttpClient()
 
 ### CORS
 
-In a web browser IPFS HTTP client (either browserified or CDN-based) might encounter an error saying that the origin is not allowed. This would be a CORS ("Cross Origin Resource Sharing") failure: IPFS servers are designed to reject requests from unknown domains by default. You can whitelist the domain that you are calling from by changing your ipfs config like this:
+In a web browser IPFS HTTP client (either browserified or CDN-based) might encounter an error saying that the origin is not allowed. This would be a CORS ("Cross Origin Resource Sharing") failure: IPFS servers are designed to reject requests from unknown domains by default. You can whitelist the domain that you are calling from by changing your ipfs config like this:
 
 ```console
 $ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin  '["http://example.com"]'

--- a/packages/ipfs/docs/CLI.md
+++ b/packages/ipfs/docs/CLI.md
@@ -1,6 +1,6 @@
 # IPFS CLI <!-- omit in toc -->
 
-## Table of contents <!-- omit in toc -->
+## Table of contents <!-- omit in toc -->
 
 - [Overview](#overview)
 - [Configuration](#configuration)

--- a/packages/ipfs/docs/DAEMON.md
+++ b/packages/ipfs/docs/DAEMON.md
@@ -3,7 +3,7 @@
 
 > How to run a long-lived IPFS process
 
-## Table of contents <!-- omit in toc -->
+## Table of contents <!-- omit in toc -->
 
 - [CLI](#cli)
 - [Programmatic](#programmatic)

--- a/packages/ipfs/docs/DEVELOPMENT.md
+++ b/packages/ipfs/docs/DEVELOPMENT.md
@@ -54,7 +54,7 @@
 # run the interop tests with the default go-IPFS
 > npm run test:interop
 
-# run the interop tests with a different go-IPFS
+# run the interop tests with a different go-IPFS
 > IPFS_EXEC_GO=/path/to/ipfs npm run test:interop
 ```
 


### PR DESCRIPTION
VSCode seems to insert this weird whitespace character that isn't a space but looks like a space and then messes up all the formatting in markdown files.