### PR TITLE
fix: remove client-side timeout from http rpc calls

### DIFF
--- a/packages/interface-ipfs-core/src/refs.js
+++ b/packages/interface-ipfs-core/src/refs.js
@@ -323,8 +323,7 @@ function getRefsTests () {
     'should print nothing for non-existent hashes': {
       path: () => 'QmYmW4HiZhotsoSqnv2o1oSssvkRM8b9RweBoH7ao5nki2',
       params: { timeout: 2000 },
-      expected: [],
-      expectTimeout: true
+      expected: ['']
     }
   }
 }

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -62,6 +62,7 @@
     "@ipld/dag-pb": "^2.1.3",
     "@multiformats/murmur3": "^1.0.1",
     "abort-controller": "^3.0.0",
+    "any-signal": "^2.1.2",
     "array-shuffle": "^2.0.0",
     "blockstore-datastore-adapter": "^1.0.0",
     "datastore-core": "^5.0.1",
@@ -126,6 +127,7 @@
     "parse-duration": "^1.0.0",
     "peer-id": "^0.15.1",
     "streaming-iterables": "^6.0.0",
+    "timeout-abort-controller": "^1.1.1",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/ipfs-http-client/src/add-all.js
+++ b/packages/ipfs-http-client/src/add-all.js
@@ -43,7 +43,6 @@ module.exports = configure((api) => {
         ...options,
         progress: Boolean(progressFn)
       }),
-      timeout: options.timeout,
       onUploadProgress,
       signal,
       headers,

--- a/packages/ipfs-http-client/src/bitswap/stat.js
+++ b/packages/ipfs-http-client/src/bitswap/stat.js
@@ -16,7 +16,6 @@ module.exports = configure(api => {
   async function stat (options = {}) {
     const res = await api.post('bitswap/stat', {
       searchParams: toUrlSearchParams(options),
-      timeout: options.timeout,
       signal: options.signal,
       headers: options.headers
     })

--- a/packages/ipfs-http-client/src/bitswap/unwant.js
+++ b/packages/ipfs-http-client/src/bitswap/unwant.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function unwant (cid, options = {}) {
     const res = await api.post('bitswap/unwant', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: cid.toString(),

--- a/packages/ipfs-http-client/src/bitswap/wantlist-for-peer.js
+++ b/packages/ipfs-http-client/src/bitswap/wantlist-for-peer.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function wantlistForPeer (peerId, options = {}) {
     const res = await (await api.post('bitswap/wantlist', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         ...options,

--- a/packages/ipfs-http-client/src/bitswap/wantlist.js
+++ b/packages/ipfs-http-client/src/bitswap/wantlist.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function wantlist (options = {}) {
     const res = await (await api.post('bitswap/wantlist', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/block/get.js
+++ b/packages/ipfs-http-client/src/block/get.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function get (cid, options = {}) {
     const res = await api.post('block/get', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: cid.toString(),

--- a/packages/ipfs-http-client/src/block/put.js
+++ b/packages/ipfs-http-client/src/block/put.js
@@ -24,7 +24,6 @@ module.exports = configure(api => {
     let res
     try {
       const response = await api.post('block/put', {
-        timeout: options.timeout,
         signal: signal,
         searchParams: toUrlSearchParams(options),
         ...(

--- a/packages/ipfs-http-client/src/block/rm.js
+++ b/packages/ipfs-http-client/src/block/rm.js
@@ -20,7 +20,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('block/rm', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: cid.map(cid => cid.toString()),

--- a/packages/ipfs-http-client/src/block/stat.js
+++ b/packages/ipfs-http-client/src/block/stat.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function stat (cid, options = {}) {
     const res = await api.post('block/stat', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: cid.toString(),

--- a/packages/ipfs-http-client/src/bootstrap/add.js
+++ b/packages/ipfs-http-client/src/bootstrap/add.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function add (addr, options = {}) {
     const res = await api.post('bootstrap/add', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: addr,

--- a/packages/ipfs-http-client/src/bootstrap/clear.js
+++ b/packages/ipfs-http-client/src/bootstrap/clear.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function clear (options = {}) {
     const res = await api.post('bootstrap/rm', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         ...options,

--- a/packages/ipfs-http-client/src/bootstrap/list.js
+++ b/packages/ipfs-http-client/src/bootstrap/list.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function list (options = {}) {
     const res = await api.post('bootstrap/list', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/bootstrap/reset.js
+++ b/packages/ipfs-http-client/src/bootstrap/reset.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function reset (options = {}) {
     const res = await api.post('bootstrap/add', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         ...options,

--- a/packages/ipfs-http-client/src/bootstrap/rm.js
+++ b/packages/ipfs-http-client/src/bootstrap/rm.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function rm (addr, options = {}) {
     const res = await api.post('bootstrap/rm', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: addr,

--- a/packages/ipfs-http-client/src/cat.js
+++ b/packages/ipfs-http-client/src/cat.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function * cat (path, options = {}) {
     const res = await api.post('cat', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path.toString(),

--- a/packages/ipfs-http-client/src/commands.js
+++ b/packages/ipfs-http-client/src/commands.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   const commands = async (options = {}) => {
     const res = await api.post('commands', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/config/get.js
+++ b/packages/ipfs-http-client/src/config/get.js
@@ -18,7 +18,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('config', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: key,

--- a/packages/ipfs-http-client/src/config/getAll.js
+++ b/packages/ipfs-http-client/src/config/getAll.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   const getAll = async (options = {}) => {
     const res = await api.post('config/show', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         ...options

--- a/packages/ipfs-http-client/src/config/profiles/apply.js
+++ b/packages/ipfs-http-client/src/config/profiles/apply.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function apply (profile, options = {}) {
     const res = await api.post('config/profile/apply', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: profile,

--- a/packages/ipfs-http-client/src/config/profiles/list.js
+++ b/packages/ipfs-http-client/src/config/profiles/list.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function list (options = {}) {
     const res = await api.post('config/profile/list', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/config/replace.js
+++ b/packages/ipfs-http-client/src/config/replace.js
@@ -22,7 +22,6 @@ module.exports = configure(api => {
     const signal = abortSignal(controller.signal, options.signal)
 
     const res = await api.post('config/replace', {
-      timeout: options.timeout,
       signal,
       searchParams: toUrlSearchParams(options),
       ...(

--- a/packages/ipfs-http-client/src/config/set.js
+++ b/packages/ipfs-http-client/src/config/set.js
@@ -23,7 +23,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('config', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(params),
       headers: options.headers

--- a/packages/ipfs-http-client/src/dag/export.js
+++ b/packages/ipfs-http-client/src/dag/export.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function * dagExport (root, options = {}) {
     const res = await api.post('dag/export', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: root.toString()

--- a/packages/ipfs-http-client/src/dag/import.js
+++ b/packages/ipfs-http-client/src/dag/import.js
@@ -22,7 +22,6 @@ module.exports = configure(api => {
     const { headers, body } = await multipartRequest(source, controller, options.headers)
 
     const res = await api.post('dag/import', {
-      timeout: options.timeout,
       signal,
       headers,
       body,

--- a/packages/ipfs-http-client/src/dag/resolve.js
+++ b/packages/ipfs-http-client/src/dag/resolve.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   const resolve = async (ipfsPath, options = {}) => {
     const res = await api.post('dag/resolve', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: `${ipfsPath}${options.path ? `/${options.path}`.replace(/\/[/]+/g, '/') : ''}`,

--- a/packages/ipfs-http-client/src/dht/find-peer.js
+++ b/packages/ipfs-http-client/src/dht/find-peer.js
@@ -16,7 +16,6 @@ module.exports = configure(api => {
    */
   async function findPeer (peerId, options = {}) {
     const res = await api.post('dht/findpeer', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: peerId,

--- a/packages/ipfs-http-client/src/dht/find-provs.js
+++ b/packages/ipfs-http-client/src/dht/find-provs.js
@@ -16,7 +16,6 @@ module.exports = configure(api => {
    */
   async function * findProvs (cid, options = {}) {
     const res = await api.post('dht/findprovs', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: cid.toString(),

--- a/packages/ipfs-http-client/src/dht/get.js
+++ b/packages/ipfs-http-client/src/dht/get.js
@@ -17,7 +17,6 @@ module.exports = configure(api => {
    */
   async function get (key, options = {}) {
     const res = await api.post('dht/get', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: key instanceof Uint8Array ? uint8ArrayToString(key) : key,

--- a/packages/ipfs-http-client/src/dht/provide.js
+++ b/packages/ipfs-http-client/src/dht/provide.js
@@ -20,7 +20,6 @@ module.exports = configure(api => {
     const cidArr = Array.isArray(cids) ? cids : [cids]
 
     const res = await api.post('dht/provide', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: cidArr.map(cid => cid.toString()),

--- a/packages/ipfs-http-client/src/dht/put.js
+++ b/packages/ipfs-http-client/src/dht/put.js
@@ -24,7 +24,6 @@ module.exports = configure(api => {
     const signal = abortSignal(controller.signal, options.signal)
 
     const res = await api.post('dht/put', {
-      timeout: options.timeout,
       signal,
       searchParams: toUrlSearchParams({
         arg: uint8ArrayToString(key),

--- a/packages/ipfs-http-client/src/dht/query.js
+++ b/packages/ipfs-http-client/src/dht/query.js
@@ -16,7 +16,6 @@ module.exports = configure(api => {
    */
   async function * query (peerId, options = {}) {
     const res = await api.post('dht/query', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: peerId.toString(),

--- a/packages/ipfs-http-client/src/diag/cmds.js
+++ b/packages/ipfs-http-client/src/diag/cmds.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function cmds (options = {}) {
     const res = await api.post('diag/cmds', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/diag/net.js
+++ b/packages/ipfs-http-client/src/diag/net.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function net (options = {}) {
     const res = await api.post('diag/net', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/diag/sys.js
+++ b/packages/ipfs-http-client/src/diag/sys.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function sys (options = {}) {
     const res = await api.post('diag/sys', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/dns.js
+++ b/packages/ipfs-http-client/src/dns.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   const dns = async (domain, options = {}) => {
     const res = await api.post('dns', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: domain,

--- a/packages/ipfs-http-client/src/files/chmod.js
+++ b/packages/ipfs-http-client/src/files/chmod.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function chmod (path, mode, options = {}) {
     const res = await api.post('files/chmod', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/files/cp.js
+++ b/packages/ipfs-http-client/src/files/cp.js
@@ -18,7 +18,6 @@ module.exports = configure(api => {
     const sourceArr = Array.isArray(sources) ? sources : [sources]
 
     const res = await api.post('files/cp', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: sourceArr.concat(destination).map(src => src instanceof CID ? `/ipfs/${src}` : src),

--- a/packages/ipfs-http-client/src/files/flush.js
+++ b/packages/ipfs-http-client/src/files/flush.js
@@ -19,7 +19,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('files/flush', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/files/ls.js
+++ b/packages/ipfs-http-client/src/files/ls.js
@@ -19,7 +19,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('files/ls', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path instanceof CID ? `/ipfs/${path}` : path,

--- a/packages/ipfs-http-client/src/files/mkdir.js
+++ b/packages/ipfs-http-client/src/files/mkdir.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function mkdir (path, options = {}) {
     const res = await api.post('files/mkdir', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/files/mv.js
+++ b/packages/ipfs-http-client/src/files/mv.js
@@ -18,7 +18,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('files/mv', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: sources.concat(destination),

--- a/packages/ipfs-http-client/src/files/read.js
+++ b/packages/ipfs-http-client/src/files/read.js
@@ -16,7 +16,6 @@ module.exports = configure(api => {
    */
   async function * read (path, options = {}) {
     const res = await api.post('files/read', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/files/rm.js
+++ b/packages/ipfs-http-client/src/files/rm.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function rm (path, options = {}) {
     const res = await api.post('files/rm', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/files/stat.js
+++ b/packages/ipfs-http-client/src/files/stat.js
@@ -23,7 +23,6 @@ module.exports = configure(api => {
     options = options || {}
 
     const res = await api.post('files/stat', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/files/touch.js
+++ b/packages/ipfs-http-client/src/files/touch.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function touch (path, options = {}) {
     const res = await api.post('files/touch', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/files/write.js
+++ b/packages/ipfs-http-client/src/files/write.js
@@ -23,7 +23,6 @@ module.exports = configure(api => {
     const signal = abortSignal(controller.signal, options.signal)
 
     const res = await api.post('files/write', {
-      timeout: options.timeout,
       signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/get.js
+++ b/packages/ipfs-http-client/src/get.js
@@ -26,7 +26,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('get', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(opts),
       headers: options.headers

--- a/packages/ipfs-http-client/src/id.js
+++ b/packages/ipfs-http-client/src/id.js
@@ -16,7 +16,6 @@ module.exports = configure(api => {
    */
   async function id (options = {}) {
     const res = await api.post('id', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: options.peerId ? options.peerId.toString() : undefined,

--- a/packages/ipfs-http-client/src/key/gen.js
+++ b/packages/ipfs-http-client/src/key/gen.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function gen (name, options = { type: 'rsa', size: 2048 }) {
     const res = await api.post('key/gen', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: name,

--- a/packages/ipfs-http-client/src/key/import.js
+++ b/packages/ipfs-http-client/src/key/import.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function importKey (name, pem, password, options = {}) {
     const res = await api.post('key/import', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: name,

--- a/packages/ipfs-http-client/src/key/list.js
+++ b/packages/ipfs-http-client/src/key/list.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function list (options = {}) {
     const res = await api.post('key/list', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/key/rename.js
+++ b/packages/ipfs-http-client/src/key/rename.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function rename (oldName, newName, options = {}) {
     const res = await api.post('key/rename', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: [

--- a/packages/ipfs-http-client/src/key/rm.js
+++ b/packages/ipfs-http-client/src/key/rm.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function rm (name, options = {}) {
     const res = await api.post('key/rm', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: name,

--- a/packages/ipfs-http-client/src/lib/core.js
+++ b/packages/ipfs-http-client/src/lib/core.js
@@ -99,14 +99,21 @@ const errorHandler = async (response) => {
   /** @type {Error} */
   let error = new HTTP.HTTPError(response)
 
-  // This is what go-ipfs returns where there's a timeout
-  if (msg && msg.includes('context deadline exceeded')) {
-    error = new HTTP.TimeoutError('Request timed out')
+  if (msg) {
+    // This is what rs-ipfs returns where there's a timeout
+    if (msg.includes('deadline has elapsed')) {
+      error = new HTTP.TimeoutError()
+    }
+
+    // This is what go-ipfs returns where there's a timeout
+    if (msg && msg.includes('context deadline exceeded')) {
+      error = new HTTP.TimeoutError()
+    }
   }
 
   // This also gets returned
   if (msg && msg.includes('request timed out')) {
-    error = new HTTP.TimeoutError('Request timed out')
+    error = new HTTP.TimeoutError()
   }
 
   // If we managed to extract a message from the response, use it
@@ -143,7 +150,7 @@ class Client extends HTTP {
     const opts = normalizeOptions(options)
 
     super({
-      timeout: parseTimeout(opts.timeout || 0) || 60000 * 20,
+      timeout: parseTimeout(opts.timeout || 0) || undefined,
       headers: opts.headers,
       base: `${opts.url}`,
       handleError: errorHandler,

--- a/packages/ipfs-http-client/src/log/level.js
+++ b/packages/ipfs-http-client/src/log/level.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function level (subsystem, level, options = {}) {
     const res = await api.post('log/level', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: [

--- a/packages/ipfs-http-client/src/log/ls.js
+++ b/packages/ipfs-http-client/src/log/ls.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function ls (options = {}) {
     const res = await api.post('log/ls', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/log/tail.js
+++ b/packages/ipfs-http-client/src/log/tail.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function * tail (options = {}) {
     const res = await api.post('log/tail', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/ls.js
+++ b/packages/ipfs-http-client/src/ls.js
@@ -60,7 +60,6 @@ module.exports = configure((api, opts) => {
     }
 
     const res = await api.post('ls', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: pathStr,

--- a/packages/ipfs-http-client/src/mount.js
+++ b/packages/ipfs-http-client/src/mount.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function mount (options = {}) {
     const res = await api.post('dns', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/name/publish.js
+++ b/packages/ipfs-http-client/src/name/publish.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function publish (path, options = {}) {
     const res = await api.post('name/publish', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: `${path}`,

--- a/packages/ipfs-http-client/src/name/pubsub/cancel.js
+++ b/packages/ipfs-http-client/src/name/pubsub/cancel.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function cancel (name, options = {}) {
     const res = await api.post('name/pubsub/cancel', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: name,

--- a/packages/ipfs-http-client/src/name/pubsub/state.js
+++ b/packages/ipfs-http-client/src/name/pubsub/state.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function state (options = {}) {
     const res = await api.post('name/pubsub/state', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/name/pubsub/subs.js
+++ b/packages/ipfs-http-client/src/name/pubsub/subs.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function subs (options = {}) {
     const res = await api.post('name/pubsub/subs', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/name/resolve.js
+++ b/packages/ipfs-http-client/src/name/resolve.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function * resolve (path, options = {}) {
     const res = await api.post('name/resolve', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/object/data.js
+++ b/packages/ipfs-http-client/src/object/data.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function data (cid, options = {}) {
     const res = await api.post('object/data', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: `${cid instanceof Uint8Array ? CID.decode(cid) : cid}`,

--- a/packages/ipfs-http-client/src/object/get.js
+++ b/packages/ipfs-http-client/src/object/get.js
@@ -16,7 +16,6 @@ module.exports = configure(api => {
    */
   async function get (cid, options = {}) {
     const res = await api.post('object/get', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: `${cid instanceof Uint8Array ? CID.decode(cid) : cid}`,

--- a/packages/ipfs-http-client/src/object/links.js
+++ b/packages/ipfs-http-client/src/object/links.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function links (cid, options = {}) {
     const res = await api.post('object/links', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: `${cid instanceof Uint8Array ? CID.decode(cid) : cid}`,

--- a/packages/ipfs-http-client/src/object/new.js
+++ b/packages/ipfs-http-client/src/object/new.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function newObject (options = {}) {
     const res = await api.post('object/new', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: options.template,

--- a/packages/ipfs-http-client/src/object/patch/add-link.js
+++ b/packages/ipfs-http-client/src/object/patch/add-link.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function addLink (cid, dLink, options = {}) {
     const res = await api.post('object/patch/add-link', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: [

--- a/packages/ipfs-http-client/src/object/patch/append-data.js
+++ b/packages/ipfs-http-client/src/object/patch/append-data.js
@@ -22,7 +22,6 @@ module.exports = configure(api => {
     const signal = abortSignal(controller.signal, options.signal)
 
     const res = await api.post('object/patch/append-data', {
-      timeout: options.timeout,
       signal,
       searchParams: toUrlSearchParams({
         arg: `${cid}`,

--- a/packages/ipfs-http-client/src/object/patch/rm-link.js
+++ b/packages/ipfs-http-client/src/object/patch/rm-link.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function rmLink (cid, dLink, options = {}) {
     const res = await api.post('object/patch/rm-link', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: [

--- a/packages/ipfs-http-client/src/object/patch/set-data.js
+++ b/packages/ipfs-http-client/src/object/patch/set-data.js
@@ -22,7 +22,6 @@ module.exports = configure(api => {
     const signal = abortSignal(controller.signal, options.signal)
 
     const res = await api.post('object/patch/set-data', {
-      timeout: options.timeout,
       signal,
       searchParams: toUrlSearchParams({
         arg: [

--- a/packages/ipfs-http-client/src/object/stat.js
+++ b/packages/ipfs-http-client/src/object/stat.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function stat (cid, options = {}) {
     const res = await api.post('object/stat', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: `${cid}`,

--- a/packages/ipfs-http-client/src/pin/add-all.js
+++ b/packages/ipfs-http-client/src/pin/add-all.js
@@ -17,7 +17,6 @@ module.exports = configure(api => {
   async function * addAll (source, options = {}) {
     for await (const { path, recursive, metadata } of normaliseInput(source)) {
       const res = await api.post('pin/add', {
-        timeout: options.timeout,
         signal: options.signal,
         searchParams: toUrlSearchParams({
           ...options,

--- a/packages/ipfs-http-client/src/pin/ls.js
+++ b/packages/ipfs-http-client/src/pin/ls.js
@@ -41,7 +41,6 @@ module.exports = configure(api => {
     }
 
     const res = await api.post('pin/ls', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         ...options,

--- a/packages/ipfs-http-client/src/pin/remote/service.js
+++ b/packages/ipfs-http-client/src/pin/remote/service.js
@@ -95,7 +95,6 @@ Service.prototype.add = async function add (name, options) {
  */
 Service.prototype.rm = async function rm (name, options = {}) {
   await this.client.post('pin/remote/service/rm', {
-    timeout: options.timeout,
     signal: options.signal,
     headers: options.headers,
     searchParams: toUrlSearchParams({

--- a/packages/ipfs-http-client/src/pin/rm-all.js
+++ b/packages/ipfs-http-client/src/pin/rm-all.js
@@ -22,7 +22,6 @@ module.exports = configure(api => {
       if (recursive != null) searchParams.set('recursive', String(recursive))
 
       const res = await api.post('pin/rm', {
-        timeout: options.timeout,
         signal: options.signal,
         headers: options.headers,
         searchParams: toUrlSearchParams({

--- a/packages/ipfs-http-client/src/ping.js
+++ b/packages/ipfs-http-client/src/ping.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function * ping (peerId, options = {}) {
     const res = await api.post('ping', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: `${peerId}`,

--- a/packages/ipfs-http-client/src/pubsub/ls.js
+++ b/packages/ipfs-http-client/src/pubsub/ls.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function ls (options = {}) {
     const { Strings } = await (await api.post('pubsub/ls', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/pubsub/peers.js
+++ b/packages/ipfs-http-client/src/pubsub/peers.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function peers (topic, options = {}) {
     const res = await api.post('pubsub/peers', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: topic,

--- a/packages/ipfs-http-client/src/pubsub/publish.js
+++ b/packages/ipfs-http-client/src/pubsub/publish.js
@@ -26,7 +26,6 @@ module.exports = configure(api => {
     const signal = abortSignal(controller.signal, options.signal)
 
     const res = await api.post('pubsub/pub', {
-      timeout: options.timeout,
       signal,
       searchParams,
       ...(

--- a/packages/ipfs-http-client/src/pubsub/subscribe.js
+++ b/packages/ipfs-http-client/src/pubsub/subscribe.js
@@ -42,7 +42,6 @@ module.exports = (options, subsTracker) => {
 
       // Do this async to not block Firefox
       api.post('pubsub/sub', {
-        timeout: options.timeout,
         signal: options.signal,
         searchParams: toUrlSearchParams({
           arg: topic,

--- a/packages/ipfs-http-client/src/refs/index.js
+++ b/packages/ipfs-http-client/src/refs/index.js
@@ -19,7 +19,6 @@ module.exports = configure((api, opts) => {
     const argsArr = Array.isArray(args) ? args : [args]
 
     const res = await api.post('refs', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: argsArr.map(arg => `${arg instanceof Uint8Array ? CID.decode(arg) : arg}`),

--- a/packages/ipfs-http-client/src/refs/local.js
+++ b/packages/ipfs-http-client/src/refs/local.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function * refsLocal (options = {}) {
     const res = await api.post('refs/local', {
-      timeout: options.timeout,
       signal: options.signal,
       transform: toCamel,
       searchParams: toUrlSearchParams(options),

--- a/packages/ipfs-http-client/src/repo/gc.js
+++ b/packages/ipfs-http-client/src/repo/gc.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function * gc (options = {}) {
     const res = await api.post('repo/gc', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers,

--- a/packages/ipfs-http-client/src/repo/stat.js
+++ b/packages/ipfs-http-client/src/repo/stat.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function stat (options = {}) {
     const res = await api.post('repo/stat', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/repo/version.js
+++ b/packages/ipfs-http-client/src/repo/version.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function version (options = {}) {
     const res = await (await api.post('repo/version', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/resolve.js
+++ b/packages/ipfs-http-client/src/resolve.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function resolve (path, options = {}) {
     const res = await api.post('resolve', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,

--- a/packages/ipfs-http-client/src/stats/bw.js
+++ b/packages/ipfs-http-client/src/stats/bw.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function * bw (options = {}) {
     const res = await api.post('stats/bw', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers,

--- a/packages/ipfs-http-client/src/stop.js
+++ b/packages/ipfs-http-client/src/stop.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function stop (options = {}) {
     const res = await api.post('shutdown', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/swarm/addrs.js
+++ b/packages/ipfs-http-client/src/swarm/addrs.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function addrs (options = {}) {
     const res = await api.post('swarm/addrs', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/swarm/connect.js
+++ b/packages/ipfs-http-client/src/swarm/connect.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function connect (addr, options = {}) {
     const res = await api.post('swarm/connect', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: addr,

--- a/packages/ipfs-http-client/src/swarm/disconnect.js
+++ b/packages/ipfs-http-client/src/swarm/disconnect.js
@@ -14,7 +14,6 @@ module.exports = configure(api => {
    */
   async function disconnect (addr, options = {}) {
     const res = await api.post('swarm/disconnect', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: addr,

--- a/packages/ipfs-http-client/src/swarm/localAddrs.js
+++ b/packages/ipfs-http-client/src/swarm/localAddrs.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function localAddrs (options = {}) {
     const res = await api.post('swarm/addrs/local', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/swarm/peers.js
+++ b/packages/ipfs-http-client/src/swarm/peers.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function peers (options = {}) {
     const res = await api.post('swarm/peers', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers

--- a/packages/ipfs-http-client/src/version.js
+++ b/packages/ipfs-http-client/src/version.js
@@ -15,7 +15,6 @@ module.exports = configure(api => {
    */
   async function version (options = {}) {
     const res = await api.post('version', {
-      timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers


### PR DESCRIPTION
Do not set up a client-side timeout, instead rely on the server-side version.

The global timeout is still respected, users can use an AbortSignal to do timeouts on a per-call basis if desired.

fixes: #3161