### PR TITLE
fix(docs): update webrtc instructions for node in faq

### DIFF
--- a/packages/ipfs/docs/FAQ.md
+++ b/packages/ipfs/docs/FAQ.md
@@ -89,6 +89,11 @@ const node = await IPFS.create({
       transport: [WebRTCStar]
     },
     config: {
+      peerDiscovery: {
+        [WebRTCStar.tag]: {
+          enabled: true
+        }
+      },
       transport: {
         WebRTCStar: {
           wrtc

--- a/packages/ipfs/docs/FAQ.md
+++ b/packages/ipfs/docs/FAQ.md
@@ -71,12 +71,10 @@ To add WebRTC support in a IPFS node instance, do:
 
 ```JavaScript
 const wrtc = require('wrtc') // or require('electron-webrtc')()
-const WStar = require('libp2p-webrtc-star')
-const wstar = new WStar({ wrtc })
+const WebRTCStar = require('libp2p-webrtc-star')
 
 const node = await IPFS.create({
   repo: 'your-repo-path',
-  // start: false,
   config: {
     Addresses: {
       Swarm: [
@@ -88,8 +86,14 @@ const node = await IPFS.create({
   },
   libp2p: {
     modules: {
-      transport: [wstar],
-      peerDiscovery: [wstar.discovery]
+      transport: [WebRTCStar]
+    },
+    config: {
+      transport: {
+        WebRTCStar: {
+          wrtc
+        }
+      }
     }
   }
 })


### PR DESCRIPTION
They were out of date and cause confusing errors to be thrown.