### PR TITLE
fix: require command for key and pin subcommands

### DIFF
--- a/packages/ipfs/src/cli/commands/key.js
+++ b/packages/ipfs/src/cli/commands/key.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'key',
+  command: 'key <command>',
 
   description: 'Manage your keys',
 

--- a/packages/ipfs/src/cli/commands/pin.js
+++ b/packages/ipfs/src/cli/commands/pin.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'pin',
+  command: 'pin <command>',
 
   description: 'Pin and unpin objects to local storage.',
 


### PR DESCRIPTION
Without specifying that we require a sub-sub command, these commands
exit with a non-zero code and no output when you just run the subcommand

E.g:

```console
$ jsipfs key
$ echo $?
0
```

Now becomes

```console
$ jsipfs key
....help text appears here
$ echo $?
1
```