### PR TITLE
fix: shared node demo

### DIFF
--- a/examples/browser-sharing-node-across-tabs/package.json
+++ b/examples/browser-sharing-node-across-tabs/package.json
@@ -23,7 +23,7 @@
     "worker-plugin": "4.0.3"
   },
   "dependencies": {
-    "ipfs": "^0.47.0",
+    "ipfs": "^0.48.0",
     "ipfs-message-port-client": "^0.0.1",
     "ipfs-message-port-server": "^0.0.1"
   },

--- a/examples/browser-sharing-node-across-tabs/src/main.js
+++ b/examples/browser-sharing-node-across-tabs/src/main.js
@@ -18,7 +18,7 @@ const main = async () => {
 
 const uploader = async (ipfs) => {
   document.body.outerHTML += '<div>Adding "hello world!" to shared IPFS node</div>'
-  const entry = await ipfs.add(ipfs, new Blob(['hello world!'], { type: "text/plain" }))
+  const entry = await ipfs.add(new Blob(['hello world!'], { type: "text/plain" }))
   const path = `/ipfs/${entry.cid}/`
   document.body.outerHTML += `<div class="ipfs-add">File was added:
   <a target="_blank" href="${new URL(`#${path}`, location)}">${path}</a>

--- a/examples/browser-sharing-node-across-tabs/webpack.config.js
+++ b/examples/browser-sharing-node-across-tabs/webpack.config.js
@@ -3,6 +3,7 @@
 var path = require('path')
 var webpack = require('webpack')
 const WorkerPlugin = require('worker-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = {
   devtool: 'source-map',
@@ -13,14 +14,18 @@ module.exports = {
   ],
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'static/bundle.js'
+    filename: 'static/bundle.js',
+    publicPath: '/'
   },
   plugins: [
     new WorkerPlugin({
       sharedWorker: true,
       globalObject: 'self'
     }),
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new CopyWebpackPlugin([{
+      from: 'index.html'
+    }])
   ],
   module: {
     rules: [


### PR DESCRIPTION
Shared worker example stopped working, and we have not noticed because for some reason CI doesn't seem to run it. There were several problems:

1. I'm guessing ipfs was bumped to 0.48 while things were in the review. And demo was getting older version with older `ipfs.add` API.
2. When I incorporated `add` / `addAll`, I have regressed the example https://github.com/ipfs/js-ipfs/pull/3081/commits/2302b2fcbac64b351d19d201259578ac008d7a39#diff-48144c5d1809a34109f2559846446f22R21.  Have not noticed that, because CI doesn't seem to run it.
3. When I first wrote a example I used `CopyWebpackPlugin` which then I thought was unnecessary and removed. However `index.html` was placed in `dist` from prior runs so after change tests were still passing (and CI never seemed to have run this example).

This pull addresses all of those problems so that example passes tests. I'm still not sure why CI isn't executing this, test but we can figure out in the separate pull.