### PR TITLE
fix(http-client): allow stream option to be overridden

### DIFF
--- a/packages/ipfs-http-client/src/name/resolve.js
+++ b/packages/ipfs-http-client/src/name/resolve.js
@@ -10,8 +10,8 @@ module.exports = configure(api => {
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: path,
-        ...options,
-        stream: true
+        stream: true,
+        ...options
       }),
       headers: options.headers
     })


### PR DESCRIPTION
`stream: true` was being set after the options were decapsulated. This makes it impossible to override streaming in the http api.

