### PR TITLE
fix: correct typo in module name

### DIFF
--- a/examples/browser-sharing-node-across-tabs/package.json
+++ b/examples/browser-sharing-node-across-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expample-browser-sharing-node-across-tabs",
+  "name": "example-browser-sharing-node-across-tabs",
   "description": "Sharing IPFS node across browsing contexts",
   "version": "1.0.0",
   "private": true,


### PR DESCRIPTION
The name needs to be correct otherwise the tests don't run as part of CI.