### PR TITLE
feat: prioritize noise over secio

### DIFF
--- a/packages/ipfs/src/core/runtime/libp2p-browser.js
+++ b/packages/ipfs/src/core/runtime/libp2p-browser.js
@@ -25,8 +25,8 @@ module.exports = () => {
         Multiplex
       ],
       connEncryption: [
-        SECIO,
-        NOISE
+        NOISE,
+        SECIO
       ],
       peerDiscovery: [],
       dht: KadDHT,

--- a/packages/ipfs/src/core/runtime/libp2p-nodejs.js
+++ b/packages/ipfs/src/core/runtime/libp2p-nodejs.js
@@ -26,8 +26,8 @@ module.exports = () => {
         Multiplex
       ],
       connEncryption: [
-        SECIO,
-        NOISE
+        NOISE,
+        SECIO
       ],
       peerDiscovery: [
         MulticastDNS


### PR DESCRIPTION
This would be good to land in 0.49 as we're planning to remove support for SECIO in 0.50. 

- When dialing js-ipfs >=0.47, or go-ipfs >=0.5 nodes, there will be no latency hit as we can start Noise immediately.
- Incoming dials for ipfs <0.49 and >0=0.47, will take a round trip hit when connecting as they'll fail to negotiate Secio and fallback to Noise