### PR TITLE
fix: validate ipns records with inline public keys

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -41,7 +41,7 @@
     "dirty-chai": "^2.0.1",
     "ipfs-unixfs": "^1.0.3",
     "ipfs-unixfs-importer": "^2.0.2",
-    "ipfs-utils": "^2.2.2",
+    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
     "ipld-block": "^0.9.2",
     "ipld-dag-cbor": "^0.16.0",
     "ipld-dag-pb": "^0.19.0",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -41,7 +41,7 @@
     "dirty-chai": "^2.0.1",
     "ipfs-unixfs": "^1.0.3",
     "ipfs-unixfs-importer": "^2.0.2",
-    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
+    "ipfs-utils": "^3.0.0",
     "ipld-block": "^0.9.2",
     "ipld-dag-cbor": "^0.16.0",
     "ipld-dag-pb": "^0.19.0",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -33,7 +33,7 @@
     "buffer": "^5.6.0",
     "cids": "^0.8.3",
     "err-code": "^2.0.0",
-    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
+    "ipfs-utils": "^3.0.0",
     "it-all": "^1.0.1",
     "it-map": "^1.0.0",
     "it-peekable": "0.0.1"

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -33,7 +33,7 @@
     "buffer": "^5.6.0",
     "cids": "^0.8.3",
     "err-code": "^2.0.0",
-    "ipfs-utils": "^2.2.2",
+    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
     "it-all": "^1.0.1",
     "it-map": "^1.0.0",
     "it-peekable": "0.0.1"

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -48,7 +48,7 @@
     "debug": "^4.1.0",
     "form-data": "^3.0.0",
     "ipfs-core-utils": "^0.3.1",
-    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
+    "ipfs-utils": "^3.0.0",
     "ipld-block": "^0.9.2",
     "ipld-dag-cbor": "^0.16.0",
     "ipld-dag-pb": "^0.19.0",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -48,7 +48,7 @@
     "debug": "^4.1.0",
     "form-data": "^3.0.0",
     "ipfs-core-utils": "^0.3.1",
-    "ipfs-utils": "^2.2.2",
+    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
     "ipld-block": "^0.9.2",
     "ipld-dag-cbor": "^0.16.0",
     "ipld-dag-pb": "^0.19.0",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -101,7 +101,7 @@
     "ipfs-unixfs": "^1.0.3",
     "ipfs-unixfs-exporter": "^2.0.2",
     "ipfs-unixfs-importer": "^2.0.2",
-    "ipfs-utils": "^2.2.2",
+    "ipfs-utils": "2.3.1",
     "ipld": "^0.26.2",
     "ipld-bitcoin": "^0.3.0",
     "ipld-block": "^0.9.2",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -101,7 +101,7 @@
     "ipfs-unixfs": "^1.0.3",
     "ipfs-unixfs-exporter": "^2.0.2",
     "ipfs-unixfs-importer": "^2.0.2",
-    "ipfs-utils": "2.3.1",
+    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
     "ipld": "^0.26.2",
     "ipld-bitcoin": "^0.3.0",
     "ipld-block": "^0.9.2",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -101,7 +101,7 @@
     "ipfs-unixfs": "^1.0.3",
     "ipfs-unixfs-exporter": "^2.0.2",
     "ipfs-unixfs-importer": "^2.0.2",
-    "ipfs-utils": "ipfs/js-ipfs-utils#xhr-2",
+    "ipfs-utils": "^3.0.0",
     "ipld": "^0.26.2",
     "ipld-bitcoin": "^0.3.0",
     "ipld-block": "^0.9.2",

--- a/packages/ipfs/src/core/ipns/resolver.js
+++ b/packages/ipfs/src/core/ipns/resolver.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const ipns = require('ipns')
-const crypto = require('libp2p-crypto')
 const PeerId = require('peer-id')
 const errcode = require('err-code')
 const debug = require('debug')

--- a/packages/ipfs/src/core/ipns/resolver.js
+++ b/packages/ipfs/src/core/ipns/resolver.js
@@ -99,34 +99,7 @@ class IpnsResolver {
       throw errcode(new Error('found ipns record that we couldn\'t convert to a value'), 'ERR_INVALID_RECORD_RECEIVED')
     }
 
-    // if the record has a public key validate it
-    if (ipnsEntry.pubKey) {
-      return this._validateRecord(peerId, ipnsEntry)
-    }
-
-    // Otherwise, try to get the public key from routing
-    let pubKey
-    try {
-      pubKey = await this._routing.get(routingKey.toBuffer())
-    } catch (err) {
-      log.error(err)
-
-      if (err.code === ERR_NOT_FOUND) {
-        throw errcode(new Error(`public key requested for ${name} was not found in the network`), 'ERR_NO_RECORD_FOUND')
-      }
-
-      throw errcode(new Error(`unexpected error getting the public key for the ipns record ${peerId.id}`), 'ERR_UNEXPECTED_ERROR_GETTING_PUB_KEY')
-    }
-
-    try {
-      // Insert it into the peer id, in order to be validated by IPNS validator
-      peerId.pubKey = crypto.keys.unmarshalPublicKey(pubKey)
-    } catch (err) {
-      log.error(err)
-
-      throw errcode(new Error('found public key record that we couldn\'t convert to a value'), 'ERR_INVALID_PUB_KEY_RECEIVED')
-    }
-
+    // We should have the public key by now (inline, or in the entry)
     return this._validateRecord(peerId, ipnsEntry)
   }
 

--- a/packages/ipfs/test/core/name-pubsub.js
+++ b/packages/ipfs/test/core/name-pubsub.js
@@ -18,6 +18,12 @@ const factory = require('../utils/factory')
 const namespace = '/record/'
 const ipfsRef = '/ipfs/QmPFVLPmp9zv5Z5KUqLhe2EivAGccQW2r7M7jhVJGLZoZU'
 
+const daemonsOptions = {
+  ipfsOptions: {
+    EXPERIMENTAL: { ipnsPubsub: true }
+  }
+}
+
 describe('name-pubsub', function () {
   const df = factory()
   // TODO make this work in the browser and between daemon and in-proc in nodes
@@ -33,8 +39,8 @@ describe('name-pubsub', function () {
     this.timeout(40 * 1000)
 
     nodes = await Promise.all([
-      df.spawn({ type: 'proc', ipfsOptions: { pass: nanoid(), EXPERIMENTAL: { ipnsPubsub: true } } }),
-      df.spawn({ type: 'proc', ipfsOptions: { pass: nanoid(), EXPERIMENTAL: { ipnsPubsub: true } } })
+      df.spawn({ ...daemonsOptions }),
+      df.spawn({ ...daemonsOptions })
     ])
 
     nodeA = nodes[0].api

--- a/packages/ipfs/test/core/name-pubsub.js
+++ b/packages/ipfs/test/core/name-pubsub.js
@@ -2,7 +2,6 @@
 /* eslint-env mocha */
 'use strict'
 
-const { nanoid } = require('nanoid')
 const { Buffer } = require('buffer')
 const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const base64url = require('base64url')


### PR DESCRIPTION
The IPNS resolver was unnecessarily (and inaccurately) trying to fetch public keys from the network if they weren't embedded in the record. Embedding has been around for some time so we don't need this anymore.

This also fixes a problem where record validation wouldn't happen for inlined public keys. When PeerId's with inlined keys create ipns records, the public key is not embedded because this is duplicative. (this is the behavior of both Go and JS).

This was caught in interop testing of the latest go-ipfs updates to move to ed25519 keys by default. The failing job for this is https://app.circleci.com/pipelines/github/ipfs/go-ipfs/3329/workflows/33457111-bec0-46a9-80ef-f13fc7844231/jobs/38550.

related https://github.com/ipfs/go-ipfs/pull/7579