### PR TITLE
fix: handle progress for empty files

### DIFF
--- a/packages/interface-ipfs-core/src/add.js
+++ b/packages/interface-ipfs-core/src/add.js
@@ -113,6 +113,29 @@ module.exports = (common, options) => {
       expect(accumProgress).to.equal(fixtures.bigFile.data.length)
     })
 
+    it('should add an empty file with progress enabled', async () => {
+      let progCalled = false
+      let accumProgress = 0
+      function handler (p) {
+        progCalled = true
+        accumProgress = p
+      }
+
+      const file = await ipfs.add(fixtures.emptyFile.data, { progress: handler })
+
+      expect(file.cid.toString()).to.equal(fixtures.emptyFile.cid)
+      expect(file.path).to.equal(fixtures.emptyFile.cid)
+      expect(progCalled).to.be.true()
+      expect(accumProgress).to.equal(fixtures.emptyFile.data.length)
+    })
+
+    it('should add an empty file without progress enabled', async () => {
+      const file = await ipfs.add(fixtures.emptyFile.data)
+
+      expect(file.cid.toString()).to.equal(fixtures.emptyFile.cid)
+      expect(file.path).to.equal(fixtures.emptyFile.cid)
+    })
+
     it('should add a Buffer as tuple', async () => {
       const tuple = { path: 'testfile.txt', content: fixtures.smallFile.data }
 

--- a/packages/interface-ipfs-core/src/utils/index.js
+++ b/packages/interface-ipfs-core/src/utils/index.js
@@ -21,5 +21,9 @@ exports.fixtures = Object.freeze({
   bigFile: Object.freeze({
     cid: 'Qme79tX2bViL26vNjPsF3DP1R9rMKMvnPYJiKTTKPrXJjq',
     data: loadFixture('test/fixtures/15mb.random', 'interface-ipfs-core')
+  }),
+  emptyFile: Object.freeze({
+    cid: 'QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH',
+    data: new Uint8Array(0)
   })
 })

--- a/packages/ipfs-http-client/src/add-all.js
+++ b/packages/ipfs-http-client/src/add-all.js
@@ -32,10 +32,10 @@ module.exports = configure((api) => {
     for await (let file of res.ndjson()) {
       file = toCamel(file)
 
-      if (progressFn && file.bytes) {
-        progressFn(file.bytes)
-      } else {
+      if (file.hash !== undefined) {
         yield toCoreInterface(file)
+      } else if (progressFn) {
+        progressFn(file.bytes || 0)
       }
     }
   }


### PR DESCRIPTION
When a file is empty the progress event will have a `Bytes` property that is `0` so test if the property is not undefined rather than if it is truthy.

Fixes #3255