### PR TITLE
chore: run electron main CI on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,6 @@ jobs:
 
     - stage: test
       name: interop - electron-main
-      os: osx
       script:
         - npm run test:interop:electron-main -- $RUN_SINCE -- -- --bail --timeout 10000
 

--- a/packages/interface-ipfs-core/README.md
+++ b/packages/interface-ipfs-core/README.md
@@ -181,4 +181,5 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 Copyright (c) Protocol Labs, Inc. under the **MIT License**. See [LICENSE.md](./LICENSE.md) for details.
 
+
 [UnixFS]: https://github.com/ipfs/specs/tree/master/unixfs

--- a/packages/interface-ipfs-core/README.md
+++ b/packages/interface-ipfs-core/README.md
@@ -181,5 +181,4 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 Copyright (c) Protocol Labs, Inc. under the **MIT License**. See [LICENSE.md](./LICENSE.md) for details.
 
-
 [UnixFS]: https://github.com/ipfs/specs/tree/master/unixfs


### PR DESCRIPTION
Can't run the renderer on linux until go-ipfs accepts requests from the renderer user agent.