### PR TITLE
chore: downgrade merge-options

### DIFF
--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -58,7 +58,7 @@
     "it-tar": "^1.2.2",
     "it-to-buffer": "^1.0.0",
     "it-to-stream": "^0.1.1",
-    "merge-options": "^3.0.1",
+    "merge-options": "^2.0.0",
     "multiaddr": "^8.0.0",
     "multiaddr-to-uri": "^6.0.0",
     "multibase": "^3.0.0",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -145,7 +145,7 @@
     "libp2p-webrtc-star": "^0.20.0",
     "libp2p-websockets": "^0.14.0",
     "mafmt": "^8.0.0",
-    "merge-options": "^3.0.1",
+    "merge-options": "^2.0.0",
     "mortice": "^2.0.0",
     "multiaddr": "^8.0.0",
     "multiaddr-to-uri": "^6.0.0",


### PR DESCRIPTION
Downgrades merge-options because v3 removed node 12 support.

Fixes: https://github.com/ipfs/js-ipfs/issues/3270
Refs: https://github.com/schnittstabil/merge-options/issues/23