### PR TITLE
fix: disable cors by default

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -286,7 +286,7 @@ The RPC API endpoints running on your local node are protected by the [Cross-Ori
 
 When a request is made that sends an `Origin` header, that Origin must be present in the allowed origins configured for the node, otherwise the browser will disallow that request to proceed, unless `mode: 'no-cors'` is set on the request, in which case the response will be opaque.
 
-To allow requests from web browsers, configure the `API.HTTPHeaders.Access-Control-Allow-Origin` setting.  This is an array of URL strings and/or the wildcard `'*'` character.
+To allow requests from web browsers, configure the `API.HTTPHeaders.Access-Control-Allow-Origin` setting.  This is an array of URL strings with safelisted Origins.
 
 ##### Example
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -308,7 +308,7 @@ Note that the origin must match exactly so `'http://127.0.0.1:8080'` is treated 
 
 The [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) header allows client-side JavaScript running in the browser to send and receive credentials with requests - cookies, auth headers or TLS certificates.
 
-For most applications this will not be necessary but if you require this to be set, see the examnple below for how to configure it.
+For most applications this will not be necessary but if you require this to be set, see the example below for how to configure it.
 
 ##### Example
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -290,19 +290,21 @@ To allow requests from web browsers, configure the `API.HTTPHeaders.Access-Contr
 
 ##### Example
 
+If you are running a webapp locally that you access via the URL `http://127.0.0.1:3000`, you must add it to the list of allowed origins in order to make API requests from that webapp in the browser:
+
 ```json
 {
   "API": {
     "HTTPHeaders": {
       "Access-Control-Allow-Origin": [
-        "http://127.0.0.1:8080"
+        "http://127.0.0.1:3000"
       ]
     }
   }
 }
 ```
 
-Note that the origin must match exactly so `'http://127.0.0.1:8080'` is treated differently to `'http://127.0.0.1:8080/'`
+Note that the origin must match exactly so `'http://127.0.0.1:3000'` is treated differently to `'http://127.0.0.1:3000/'`
 
 #### `Access-Control-Allow-Credentials`
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,6 +25,13 @@ The js-ipfs config file is a JSON document located in the root directory of the 
   - [`Enabled`](#enabled)
 - [`Swarm`](#swarm-1)
   - [`ConnMgr`](#connmgr)
+  - [Example](#example)
+- [`API`](#api-1)
+  - [`HTTPHeaders`](#httpheaders)
+    - [`Access-Control-Allow-Origin`](#access-control-allow-origin)
+      - [Example](#example-1)
+    - [`Access-Control-Allow-Credentials`](#access-control-allow-credentials)
+      - [Example](#example-2)
 
 ## Profiles
 
@@ -260,6 +267,56 @@ The "basic" connection manager tries to keep between `LowWater` and `HighWater` 
     "ConnMgr": {
       "LowWater": 100,
       "HighWater": 200,
+    }
+  }
+}
+```
+
+## `API`
+
+Settings applied to the HTTP RPC API server
+
+### `HTTPHeaders`
+
+HTTP header settings used by the HTTP RPC API server
+
+#### `Access-Control-Allow-Origin`
+
+The RPC API endpoints running on your local node are protected by the [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) mechanism.
+
+When a request is made that sends an `Origin` header, that Origin must be present in the allowed origins configured for the node, otherwise the browser will disallow that request to proceed, unless `mode: 'no-cors'` is set on the request, in which case the response will be opaque.
+
+To allow requests from web browsers, configure the `API.HTTPHeaders.Access-Control-Allow-Origin` setting.  This is an array of URL strings and/or the wildcard `'*'` character.
+
+##### Example
+
+```json
+{
+  "API": {
+    "HTTPHeaders": {
+      "Access-Control-Allow-Origin": [
+        "http://127.0.0.1:8080"
+      ]
+    }
+  }
+}
+```
+
+Note that the origin must match exactly so `'http://127.0.0.1:8080'` is treated differently to `'http://127.0.0.1:8080/'`
+
+#### `Access-Control-Allow-Credentials`
+
+The [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) header allows client-side JavaScript running in the browser to send and receive credentials with requests - cookies, auth headers or TLS certificates.
+
+For most applications this will not be necessary but if you require this to be set, see the examnple below for how to configure it.
+
+##### Example
+
+```json
+{
+  "API": {
+    "HTTPHeaders": {
+      "Access-Control-Allow-Credentials": true
     }
   }
 }

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -342,6 +342,8 @@ $ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin  '["http://exam
 $ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "GET"]'
 ```
 
+If you are using `js-ipfs`, substitute `ipfs` for `jsipfs` in the commands above.
+
 ### Custom Headers
 
 If you wish to send custom headers with each request made by this library, for example, the Authorization header. You can use the config to do so:

--- a/packages/ipfs/src/http/api/routes/index.js
+++ b/packages/ipfs/src/http/api/routes/index.js
@@ -1,16 +1,5 @@
 'use strict'
 
-const Boom = require('@hapi/boom')
-
-// RPC API requires POST, we block every other method
-const BLOCKED_METHODS = [
-  'GET',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'OPTIONS'
-]
-
 const routes = [
   require('./version'),
   require('./shutdown'),
@@ -39,20 +28,5 @@ const routes = [
 
 // webui is loaded from API port, but works over GET (not a part of RPC API)
 const extraRoutes = [...require('./webui')]
-
-const handler = () => {
-  throw Boom.methodNotAllowed()
-}
-
-// add routes that return HTTP 504 for non-POST requests to RPC API
-BLOCKED_METHODS.forEach(method => {
-  routes.forEach(route => {
-    extraRoutes.push({
-      method,
-      handler,
-      path: route.path
-    })
-  })
-})
 
 module.exports = routes.concat(extraRoutes)

--- a/packages/ipfs/src/http/error-handler.js
+++ b/packages/ipfs/src/http/error-handler.js
@@ -39,10 +39,18 @@ module.exports = server => {
       server.logger.error(res)
     }
 
-    return h.response({
+    const response = h.response({
       Message: message,
       Code: code,
       Type: 'error'
     }).code(statusCode)
+
+    const headers = res.output.headers || {}
+
+    Object.keys(headers).forEach(header => {
+      response.header(header, headers[header])
+    })
+
+    return response
   })
 }

--- a/packages/ipfs/src/http/index.js
+++ b/packages/ipfs/src/http/index.js
@@ -114,6 +114,17 @@ class HttpApi {
       }
     })
 
+    // https://tools.ietf.org/html/rfc7231#section-6.5.5
+    server.ext('onPreResponse', (request, h) => {
+      const { response } = request
+
+      if (response.isBoom && response.output && response.output.statusCode === 405) {
+        response.output.headers.Allow = 'OPTIONS, POST'
+      }
+
+      return h.continue
+    })
+
     // https://github.com/ipfs/go-ipfs-cmds/pull/193/files
     server.ext({
       type: 'onRequest',

--- a/packages/ipfs/src/http/index.js
+++ b/packages/ipfs/src/http/index.js
@@ -116,6 +116,11 @@ class HttpApi {
           return h.continue
         }
 
+        if (request.method === 'get' && (request.path.startsWith('/ipfs') || request.path.startsWith('/webui'))) {
+          // allow requests to the webui
+          return h.continue
+        }
+
         throw Boom.methodNotAllowed()
       }
     })

--- a/packages/ipfs/src/http/index.js
+++ b/packages/ipfs/src/http/index.js
@@ -73,15 +73,21 @@ class HttpApi {
   }
 
   async _createApiServer (host, port, ipfs, cors) {
+    cors = {
+      ...cors,
+      additionalHeaders: ['X-Stream-Output', 'X-Chunked-Output', 'X-Content-Length'],
+      additionalExposedHeaders: ['X-Stream-Output', 'X-Chunked-Output', 'X-Content-Length']
+    }
+
+    if (!cors.origin.length) {
+      cors = false
+    }
+
     const server = Hapi.server({
       host,
       port,
       routes: {
-        cors: {
-          ...cors,
-          additionalHeaders: ['X-Stream-Output', 'X-Chunked-Output', 'X-Content-Length'],
-          additionalExposedHeaders: ['X-Stream-Output', 'X-Chunked-Output', 'X-Content-Length']
-        },
+        cors,
         response: {
           emptyStatusCode: 200
         }

--- a/packages/ipfs/src/http/index.js
+++ b/packages/ipfs/src/http/index.js
@@ -79,7 +79,7 @@ class HttpApi {
       additionalExposedHeaders: ['X-Stream-Output', 'X-Chunked-Output', 'X-Content-Length']
     }
 
-    if (!cors.origin.length) {
+    if (!cors.origin || !cors.origin.length) {
       cors = false
     }
 

--- a/packages/ipfs/test/http-api/cors.js
+++ b/packages/ipfs/test/http-api/cors.js
@@ -1,0 +1,123 @@
+/* eslint max-nested-callbacks: ["error", 8] */
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('aegir/utils/chai')
+const http = require('../utils/http')
+const sinon = require('sinon')
+
+describe('cors', () => {
+  let ipfs
+
+  beforeEach(() => {
+    ipfs = {
+      id: sinon.stub().returns({
+        id: 'id',
+        publicKey: 'publicKey',
+        addresses: 'addresses',
+        agentVersion: 'agentVersion',
+        protocolVersion: 'protocolVersion'
+      })
+    }
+  })
+
+  describe('should allow configuring CORS', () => {
+    it('does not return allowed origins when cors is not configured and origin is supplied in request', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin
+        }
+      }, { ipfs })
+
+      expect(res).to.not.have.nested.property('headers.access-control-allow-origin')
+    })
+
+    it('returns allowed origins when origin is supplied in request', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin
+        }
+      }, { ipfs, cors: { origin: [origin] } })
+
+      expect(res).to.have.nested.property('headers.access-control-allow-origin', origin)
+    })
+
+    it('does not allow credentials when omitted in config', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin
+        }
+      }, { ipfs, cors: { origin: [origin] } })
+
+      expect(res).to.not.have.nested.property('headers.access-control-allow-credentials')
+    })
+
+    it('returns allowed credentials when origin is supplied in request', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin
+        }
+      }, { ipfs, cors: { origin: [origin], credentials: true } })
+
+      expect(res).to.have.nested.property('headers.access-control-allow-credentials', 'true')
+    })
+
+    it('does not return allowed origins when origin is not supplied in request', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id'
+      }, { ipfs, cors: { origin: [origin] } })
+
+      expect(res).to.not.have.nested.property('headers.access-control-allow-origin')
+    })
+
+    it('does not return allowed credentials when origin is not supplied in request', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id'
+      }, { ipfs, cors: { origin: [origin], credentials: true } })
+
+      expect(res).to.not.have.nested.property('headers.access-control-allow-credentials')
+    })
+
+    it('does not return allowed origins when different origin is supplied in request', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin: origin + '/'
+        }
+      }, { ipfs, cors: { origin: [origin] } })
+
+      expect(res).to.not.have.nested.property('headers.access-control-allow-origin')
+    })
+
+    it('allows wildcard origins', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin: origin + '/'
+        }
+      }, { ipfs, cors: { origin: ['*'] } })
+
+      expect(res).to.have.nested.property('headers.access-control-allow-origin', origin + '/')
+    })
+  })
+})

--- a/packages/ipfs/test/http-api/index.js
+++ b/packages/ipfs/test/http-api/index.js
@@ -6,4 +6,5 @@ if (isNode) {
   require('./routes')
 }
 
+require('./cors')
 require('./interface')

--- a/packages/ipfs/test/utils/http.js
+++ b/packages/ipfs/test/utils/http.js
@@ -2,9 +2,9 @@
 
 const HttpApi = require('../../src/http')
 
-module.exports = async (request, { ipfs } = {}) => {
+module.exports = async (request, { ipfs, cors } = {}) => {
   const api = new HttpApi(ipfs)
-  const server = await api._createApiServer('127.0.0.1', 8080, ipfs)
+  const server = await api._createApiServer('127.0.0.1', 8080, ipfs, cors)
 
   return server.inject(request)
 }

--- a/packages/ipfs/test/utils/test-http-method.js
+++ b/packages/ipfs/test/utils/test-http-method.js
@@ -8,7 +8,6 @@ const METHODS = [
   'PUT',
   'PATCH',
   'DELETE',
-  'OPTIONS',
   'HEAD'
 ]
 

--- a/packages/ipfs/test/utils/test-http-method.js
+++ b/packages/ipfs/test/utils/test-http-method.js
@@ -19,5 +19,6 @@ module.exports = async (url, ipfs) => {
     }, { ipfs })
 
     expect(res).to.have.property('statusCode', 405)
+    expect(res).to.have.nested.property('headers.allow', 'OPTIONS, POST')
   }
 }


### PR DESCRIPTION
Brings js-ipfs into line with go-ipfs by not having CORS on by default, instead requiring the user to explicitly configure it.

BREAKING CHANGE:

- CORS origins will need to be [configured manually](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/README.md#cors) before use with ipfs-http-client