### PR TITLE
add dag-jose codec

### DIFF
--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -109,6 +109,7 @@
     "ipld-git": "^0.6.1",
     "ipld-raw": "^6.0.0",
     "ipld-zcash": "^0.5.0",
+    "dag-jose": "^0.2.0",
     "ipns": "^0.8.0",
     "is-domain-name": "^1.0.1",
     "is-ipfs": "^2.0.0",

--- a/packages/ipfs/src/http/api/resources/dag.js
+++ b/packages/ipfs/src/http/api/resources/dag.js
@@ -56,7 +56,7 @@ const IpldFormats = {
   },
   get [multicodec.DAG_JOSE] () {
     return require('dag-jose')
-  },
+  }
 }
 
 const encodeBufferKeys = (obj, encoding) => {

--- a/packages/ipfs/src/http/api/resources/dag.js
+++ b/packages/ipfs/src/http/api/resources/dag.js
@@ -53,7 +53,10 @@ const IpldFormats = {
   },
   get [multicodec.ZCASH_BLOCK] () {
     return require('ipld-zcash')
-  }
+  },
+  get [multicodec.DAG_JOSE] () {
+    return require('dag-jose')
+  },
 }
 
 const encodeBufferKeys = (obj, encoding) => {


### PR DESCRIPTION
In situation where `ipfs-http-client` uses `dag-jose` codec as a format, the IPFS instance cannot respond, since it cannot find the codec even if it's registered on bootstrap of the instance:

```js
{
	ipld: {formats: [dagJoseFormat]}
}
```