### PR TITLE
fix: error invalid version triggered in cli pin add/rm

### DIFF
--- a/packages/ipfs-cli/src/commands/pin/add.js
+++ b/packages/ipfs-cli/src/commands/pin/add.js
@@ -60,7 +60,7 @@ module.exports = {
     }
 
     for await (const res of ipfs.pin.addAll(ipfsPath.map(path => ({ path, recursive, metadata })), { timeout })) {
-      print(`pinned ${cidToString(res.cid, { base: cidBase })} ${type}ly`)
+      print(`pinned ${cidToString(res, { base: cidBase })} ${type}ly`)
     }
   }
 }

--- a/packages/ipfs-cli/src/commands/pin/rm.js
+++ b/packages/ipfs-cli/src/commands/pin/rm.js
@@ -31,7 +31,7 @@ module.exports = {
     const { ipfs, print } = ctx
 
     for await (const res of ipfs.pin.rmAll(ipfsPath.map(path => ({ path, recursive })), { timeout })) {
-      print(`unpinned ${cidToString(res.cid, { base: cidBase })}`)
+      print(`unpinned ${cidToString(res, { base: cidBase })}`)
     }
   }
 }

--- a/packages/ipfs-cli/test/pin.js
+++ b/packages/ipfs-cli/test/pin.js
@@ -122,9 +122,9 @@ describe('pin', () => {
       ipfs.pin.addAll.withArgs([{
         ...defaultPinOptions,
         path: pins.root
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add ${pins.root}`, { ipfs })
       expect(out).to.equal(`pinned ${pins.root} recursively\n`)
@@ -135,9 +135,9 @@ describe('pin', () => {
         ...defaultPinOptions,
         path: pins.root,
         recursive: false
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add --recursive false ${pins.root}`, { ipfs })
       expect(out).to.equal(`pinned ${pins.root} directly\n`)
@@ -148,9 +148,9 @@ describe('pin', () => {
         ...defaultPinOptions,
         path: pins.root,
         recursive: false
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add -r false ${pins.root}`, { ipfs })
       expect(out).to.equal(`pinned ${pins.root} directly\n`)
@@ -163,9 +163,9 @@ describe('pin', () => {
         metadata: {
           key: 'value'
         }
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add --metadata key=value ${pins.root}`, { ipfs })
       expect(out).to.equal(`pinned ${pins.root} recursively\n`)
@@ -178,9 +178,9 @@ describe('pin', () => {
         metadata: {
           key: 'value'
         }
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add -m key=value ${pins.root}`, { ipfs })
       expect(out).to.equal(`pinned ${pins.root} recursively\n`)
@@ -193,9 +193,9 @@ describe('pin', () => {
         metadata: {
           key: 'value'
         }
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add --metadata-json '{"key":"value"}' ${pins.root}`, { ipfs })
       expect(out).to.equal(`pinned ${pins.root} recursively\n`)
@@ -207,9 +207,9 @@ describe('pin', () => {
         path: pins.root,
         recursive: true,
         comments: undefined
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add ${pins.root} --cid-base=base64`, { ipfs })
       const b64CidStr = new CID(pins.root).toV1().toString('base64')
@@ -223,9 +223,9 @@ describe('pin', () => {
       }], {
         ...defaultOptions,
         timeout: 1000
-      }).returns([{
-        cid: new CID(pins.root)
-      }])
+      }).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin add ${pins.root} --timeout=1s`, { ipfs })
       expect(out).to.equal(`pinned ${pins.root} recursively\n`)

--- a/packages/ipfs-cli/test/pin.js
+++ b/packages/ipfs-cli/test/pin.js
@@ -45,9 +45,9 @@ describe('pin', () => {
       ipfs.pin.rmAll.withArgs([{
         ...defaultPinOptions,
         path: pins.root
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin rm ${pins.root}`, { ipfs })
       expect(out).to.equal(`unpinned ${pins.root}\n`)
@@ -58,9 +58,9 @@ describe('pin', () => {
         ...defaultPinOptions,
         path: pins.root,
         recursive: false
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin rm --recursive false ${pins.root}`, { ipfs })
       expect(out).to.equal(`unpinned ${pins.root}\n`)
@@ -71,9 +71,9 @@ describe('pin', () => {
         ...defaultPinOptions,
         path: pins.root,
         recursive: false
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin rm -r false ${pins.root}`, { ipfs })
       expect(out).to.equal(`unpinned ${pins.root}\n`)
@@ -83,9 +83,9 @@ describe('pin', () => {
       ipfs.pin.rmAll.withArgs([{
         ...defaultPinOptions,
         path: pins.root
-      }], defaultOptions).returns([{
-        cid: new CID(pins.root)
-      }])
+      }], defaultOptions).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin rm ${pins.root} --cid-base=base64`, { ipfs })
       const b64CidStr = new CID(pins.root).toV1().toString('base64')
@@ -99,9 +99,9 @@ describe('pin', () => {
       }], {
         ...defaultOptions,
         timeout: 1000
-      }).returns([{
-        cid: new CID(pins.root)
-      }])
+      }).returns([
+        new CID(pins.root)
+      ])
 
       const out = await cli(`pin rm ${pins.root} --timeout=1s`, { ipfs })
       expect(out).to.equal(`unpinned ${pins.root}\n`)


### PR DESCRIPTION
Error `Invalid version, must be a number equal to 1 or 0` triggered when using CLI pin add/rm. 

The return value of `ipfs.pin.addAll` or `ipfs.pin.rmAll` is just [`AsyncIterable` of `CID`s](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/PIN.md#returns-1)