### PR TITLE
feat: enable custom formats for server/client DAG (put|get) operations

### DIFF
--- a/packages/ipfs-cli/src/daemon.js
+++ b/packages/ipfs-cli/src/daemon.js
@@ -29,6 +29,7 @@ class Daemon {
 
   /**
    * Starts the IPFS HTTP server
+   * @param {object} [opts] - specify advanced configuration
    * @param {object} [opts.ipld.formats] - IPLD custom formats
    * @return {Promise<HttpApi>}
    */

--- a/packages/ipfs-cli/src/daemon.js
+++ b/packages/ipfs-cli/src/daemon.js
@@ -27,7 +27,12 @@ class Daemon {
     }
   }
 
-  async start () {
+  /**
+   * Starts the IPFS HTTP server
+   * @param {object} [opts.ipld.formats] - IPLD custom formats
+   * @return {Promise<HttpApi>}
+   */
+  async start (opts = {}) {
     log('starting')
 
     const repo = typeof this._options.repo === 'string' || this._options.repo == null
@@ -40,7 +45,7 @@ class Daemon {
 
     // start HTTP servers (if API or Gateway is enabled in options)
     const httpApi = new HttpApi(ipfs, ipfsOpts)
-    this._httpApi = await httpApi.start()
+    this._httpApi = await httpApi.start(opts)
 
     const httpGateway = new HttpGateway(ipfs, ipfsOpts)
     this._httpGateway = await httpGateway.start()

--- a/packages/ipfs-http-client/src/dag/get.js
+++ b/packages/ipfs-http-client/src/dag/get.js
@@ -4,23 +4,32 @@ const dagPB = require('ipld-dag-pb')
 const dagCBOR = require('ipld-dag-cbor')
 const raw = require('ipld-raw')
 const configure = require('../lib/configure')
-
-const resolvers = {
-  'dag-cbor': dagCBOR.resolver,
-  'dag-pb': dagPB.resolver,
-  raw: raw.resolver
-}
+const multicodec = require('multicodec')
 
 module.exports = configure((api, options) => {
   const getBlock = require('../block/get')(options)
   const dagResolve = require('./resolve')(options)
 
+  const formats = {
+    [multicodec.DAG_PB]: dagPB,
+    [multicodec.DAG_CBOR]: dagCBOR,
+    [multicodec.RAW]: raw
+  }
+
+  const ipldOptions = (options && options.ipld) || {}
+  const configuredFormats = (ipldOptions && ipldOptions.formats) || []
+  configuredFormats.forEach(format => {
+    formats[format.codec] = format
+  })
+
   return async (cid, options = {}) => {
     const resolved = await dagResolve(cid, options)
     const block = await getBlock(resolved.cid, options)
-    const dagResolver = resolvers[resolved.cid.codec]
 
-    if (!dagResolver) {
+    const codec = multicodec[resolved.cid.codec.toUpperCase().replace(/-/g, '_')]
+    const format = formats[codec]
+
+    if (!format) {
       throw Object.assign(
         new Error(`Missing IPLD format "${resolved.cid.codec}"`),
         { missingMulticodec: resolved.cid.codec }
@@ -31,6 +40,6 @@ module.exports = configure((api, options) => {
       resolved.remainderPath = '/'
     }
 
-    return dagResolver.resolve(block.data, resolved.remainderPath)
+    return format.resolver.resolve(block.data, resolved.remainderPath)
   }
 })

--- a/packages/ipfs-http-server/src/api/resources/dag.js
+++ b/packages/ipfs-http-server/src/api/resources/dag.js
@@ -209,7 +209,9 @@ exports.put = {
             const { opts } = request.server.app
             if (opts) {
               const { ipld } = opts
-              ipldFormat = ipld.formats.find((f) => f.codec === codec)
+              if (ipld) {
+                ipldFormat = ipld.formats.find((f) => f.codec === codec)
+              }
             }
           }
 

--- a/packages/ipfs-http-server/src/api/resources/dag.js
+++ b/packages/ipfs-http-server/src/api/resources/dag.js
@@ -206,12 +206,9 @@ exports.put = {
           let ipldFormat = IpldFormats[codec]
           if (!ipldFormat) {
             // look at the passed config
-            const { opts } = request.server.app
-            if (opts) {
-              const { ipld } = opts
-              if (ipld) {
-                ipldFormat = ipld.formats.find((f) => f.codec === codec)
-              }
+            const ipldOpts = (request.server.app.opts && request.server.app.opts.ipld) || {}
+            if (ipldOpts.formats) {
+              ipldFormat = ipldOpts.formats.find((f) => f.codec === codec)
             }
           }
 

--- a/packages/ipfs-http-server/src/api/resources/dag.js
+++ b/packages/ipfs-http-server/src/api/resources/dag.js
@@ -203,11 +203,20 @@ exports.put = {
         } else {
           const codec = multicodec[format.toUpperCase().replace(/-/g, '_')]
 
-          if (!IpldFormats[codec]) {
-            throw new Error(`Missing IPLD format "${codec}"`)
+          let ipldFormat = IpldFormats[codec]
+          if (!ipldFormat) {
+            // look at the passed config
+            const { opts } = request.server.app
+            if (opts) {
+              const { ipld } = opts
+              ipldFormat = ipld.formats.find((f) => f.codec === codec)
+            }
           }
 
-          node = await IpldFormats[codec].util.deserialize(data)
+          if (!ipldFormat) {
+            throw new Error(`Missing IPLD format "${codec}"`)
+          }
+          node = await ipldFormat.util.deserialize(data)
         }
 
         return {

--- a/packages/ipfs-http-server/src/index.js
+++ b/packages/ipfs-http-server/src/index.js
@@ -95,6 +95,7 @@ class HttpApi {
       compression: false
     })
     server.app.ipfs = ipfs
+    server.app.opts = opts
 
     await server.register({
       plugin: Pino,

--- a/packages/ipfs-http-server/src/index.js
+++ b/packages/ipfs-http-server/src/index.js
@@ -51,6 +51,7 @@ class HttpApi {
 
   /**
    * Starts the IPFS HTTP server
+   * @param {object} [opts] - specify advanced configuration
    * @param {object} [opts.ipld.formats] - IPLD custom formats
    * @return {Promise<HttpApi>}
    */


### PR DESCRIPTION
- add customizable codecs in `ipfs-http-client` for DAG **get**
- add customizable codecs in `ipfs-http-server` for DAG **put**