### PR TITLE
chore: upgrade to go-ipfs 0.7.0

### DIFF
--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -28,7 +28,7 @@
     "delay": "^4.4.0",
     "execa": "^4.0.0",
     "ipfsd-ctl": "^7.0.0",
-    "go-ipfs": "^0.6.0",
+    "go-ipfs": "^0.7.0",
     "parcel-bundler": "^1.12.4",
     "path": "^0.12.7",
     "test-ipfs-example": "^2.0.3"

--- a/examples/http-client-browser-pubsub/package.json
+++ b/examples/http-client-browser-pubsub/package.json
@@ -19,7 +19,7 @@
   ],
   "devDependencies": {
     "execa": "^4.0.0",
-    "go-ipfs": "^0.6.0",
+    "go-ipfs": "^0.7.0",
     "ipfs": "^0.50.1",
     "ipfsd-ctl": "^7.0.0",
     "parcel-bundler": "^1.12.4",

--- a/examples/http-client-name-api/package.json
+++ b/examples/http-client-name-api/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "execa": "^4.0.0",
-    "go-ipfs": "^0.6.0",
+    "go-ipfs": "^0.7.0",
     "ipfsd-ctl": "^7.0.0",
     "parcel-bundler": "^1.12.4",
     "test-ipfs-example": "^2.0.3"

--- a/examples/http-client-name-api/test.js
+++ b/examples/http-client-name-api/test.js
@@ -92,7 +92,7 @@ module.exports[pkg.name] = function (browser) {
     .pause(1000)
     .click('#add-file-submit')
 
-  browser.expect.element('#publish-result').text.to.contain('/ipns/Qm')
+  browser.expect.element('#publish-result').text.to.contain('/ipns/k')
 
   // resolve a name
   browser.getText('#publish-result', (result) => {

--- a/packages/interface-ipfs-core/src/name/publish.js
+++ b/packages/interface-ipfs-core/src/name/publish.js
@@ -8,7 +8,6 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const last = require('it-last')
 const testTimeout = require('../utils/test-timeout')
 const CID = require('cids')
-const all = require('it-all')
 
 /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**

--- a/packages/interface-ipfs-core/src/name/publish.js
+++ b/packages/interface-ipfs-core/src/name/publish.js
@@ -7,6 +7,8 @@ const { fixture } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const last = require('it-last')
 const testTimeout = require('../utils/test-timeout')
+const CID = require('cids')
+const all = require('it-all')
 
 /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
@@ -41,10 +43,13 @@ module.exports = (common, options) => {
       this.timeout(50 * 1000)
 
       const value = fixture.cid
+      const keys = await ipfs.key.list()
+      const self = keys.find(key => key.name === 'self')
 
       const res = await ipfs.name.publish(value, { allowOffline: true })
       expect(res).to.exist()
-      expect(res.name).to.equal(nodeId)
+
+      expect(new CID(res.name).toV1().toString('base36')).to.equal(new CID(self.id).toV1().toString('base36'))
       expect(res.value).to.equal(`/ipfs/${value}`)
     })
 
@@ -58,6 +63,8 @@ module.exports = (common, options) => {
       this.timeout(50 * 1000)
 
       const value = 'QmPFVLPmp9zv5Z5KUqLhe2EivAGccQW2r7M7jhVJGLZoZU'
+      const keys = await ipfs.key.list()
+      const self = keys.find(key => key.name === 'self')
 
       const options = {
         resolve: false,
@@ -69,7 +76,7 @@ module.exports = (common, options) => {
 
       const res = await ipfs.name.publish(value, options)
       expect(res).to.exist()
-      expect(res.name).to.equal(nodeId)
+      expect(new CID(res.name).toV1().toString('base36')).to.equal(new CID(self.id).toV1().toString('base36'))
       expect(res.value).to.equal(`/ipfs/${value}`)
     })
 
@@ -89,7 +96,7 @@ module.exports = (common, options) => {
       const res = await ipfs.name.publish(value, options)
 
       expect(res).to.exist()
-      expect(res.name).to.equal(key.id)
+      expect(new CID(res.name).toV1().toString('base36')).to.equal(new CID(key.id).toV1().toString('base36'))
       expect(res.value).to.equal(`/ipfs/${value}`)
     })
   })

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "aegir": "^26.0.0",
     "cross-env": "^7.0.0",
-    "go-ipfs": "^0.6.0",
+    "go-ipfs": "^0.7.0",
     "interface-ipfs-core": "^0.140.0",
     "ipfsd-ctl": "^7.0.0",
     "it-all": "^1.0.4",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -48,7 +48,7 @@
     "cross-env": "^7.0.0",
     "delay": "^4.4.0",
     "form-data": "^3.0.0",
-    "go-ipfs": "^0.6.0",
+    "go-ipfs": "^0.7.0",
     "interface-ipfs-core": "^0.140.0",
     "ipfs-http-client": "^47.0.1",
     "ipfs-interop": "^3.0.0",


### PR DESCRIPTION
Tests against the latest go-ipfs release.