### PR TITLE
feat: webui v2.11.4

### DIFF
--- a/packages/ipfs-http-server/src/api/routes/webui.js
+++ b/packages/ipfs-http-server/src/api/routes/webui.js
@@ -5,7 +5,7 @@ const { gateway } = require('ipfs-http-gateway/src/resources')
 const log = debug('ipfs:webui:info')
 log.error = debug('ipfs:webui:error')
 
-const webuiCid = 'bafybeigkbbjnltbd4ewfj7elajsbnjwinyk6tiilczkqsibf3o7dcr6nn4' // v2.9.0
+const webuiCid = 'bafybeigv2xkwu2v27rx56m7ndg5dnz4b7235pn33andlriqhyy5s6nwyvq' // v2.11.3
 
 module.exports = [
   {

--- a/packages/ipfs-http-server/src/api/routes/webui.js
+++ b/packages/ipfs-http-server/src/api/routes/webui.js
@@ -5,7 +5,7 @@ const { gateway } = require('ipfs-http-gateway/src/resources')
 const log = debug('ipfs:webui:info')
 log.error = debug('ipfs:webui:error')
 
-const webuiCid = 'bafybeigv2xkwu2v27rx56m7ndg5dnz4b7235pn33andlriqhyy5s6nwyvq' // v2.11.3
+const webuiCid = 'bafybeif4zkmu7qdhkpf3pnhwxipylqleof7rl6ojbe7mq3fzogz6m4xk3i' // v2.11.4
 
 module.exports = [
   {


### PR DESCRIPTION
<del>https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.11.3</del>
https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.11.4


<del>Sadly #2580 broke E2E tests: we don't see if changing this hash broke anything until we release  `ipfs-http-server` and bump it in `ipfs` </del>

- [x] manual test (swapped hash in js-ipfs sources  of v0.50.2 and looks good)
- [x] figure out how to run webui's e2e tests
  - we test `ipfs@next` against webui master already ([.travis.yml#L260-L265](https://github.com/ipfs/js-ipfs/blob/8e44e52e9860bc7d0270ae7d0710d9692d82df8b/.travis.yml#L260-L265))