### PR TITLE
fix: implement message-port ipfs.ls

### DIFF
--- a/packages/ipfs-message-port-client/test/interface-message-port-client.js
+++ b/packages/ipfs-message-port-client/test/interface-message-port-client.js
@@ -75,10 +75,6 @@ describe('interface-ipfs-core tests', () => {
         reason: 'Not implemented'
       },
       {
-        name: 'ls',
-        reason: 'Not implemented'
-      },
-      {
         name: 'refs',
         reason: 'Not implemented'
       },

--- a/packages/ipfs-message-port-server/src/ipfs.ts
+++ b/packages/ipfs-message-port-server/src/ipfs.ts
@@ -59,6 +59,8 @@ export interface Core {
   addAll(inputs: AddAllInput, options: AddOptions): AsyncIterable<FileOutput>
   add(input: AddInput, options: AddOptions): Promise<FileOutput>
   cat(ipfsPath: CID | string, options: CatOptions): AsyncIterable<Buffer>
+
+  ls(ipfsPath: CID | string, options: CoreLsOptions): AsyncIterable<LsEntry>
 }
 
 interface AddOptions extends AbortOptions {
@@ -95,6 +97,11 @@ interface CatOptions extends AbortOptions {
   length?: number
 }
 
+interface CoreLsOptions extends AbortOptions {
+  preload?: boolean
+  recursive?: boolean
+}
+
 export interface Files {
   chmod(path: string | CID, mode: Mode, options?: ChmodOptions): Promise<void>
 
@@ -120,13 +127,15 @@ interface LsOptions extends AbortOptions {
   sort?: boolean
 }
 
-type LsEntry = {
+export type LsEntry = {
   name: string
+  path: string
   type: FileType
   size: number
+  depth: number
   cid: CID
-  mode: Mode
-  mtime: UnixFSTime
+  mode?: Mode
+  mtime?: UnixFSTime
 }
 
 interface StatOptions extends AbortOptions {

--- a/packages/ipfs-message-port-server/src/ipfs.ts
+++ b/packages/ipfs-message-port-server/src/ipfs.ts
@@ -134,7 +134,7 @@ export type LsEntry = {
   size: number
   depth: number
   cid: CID
-  mode?: Mode
+  mode: Mode
   mtime?: UnixFSTime
 }
 


### PR DESCRIPTION
This implements `ipfs.ls` for the `ipfs-message-port-*` libraries as per https://github.com/ipfs/js-ipfs/issues/3252