### PR TITLE
Replace _ param prefixes with ts-ignore comments

### DIFF
--- a/packages/ipfs-core/src/components/bitswap/stat.js
+++ b/packages/ipfs-core/src/components/bitswap/stat.js
@@ -30,7 +30,8 @@ module.exports = ({ bitswap }) => {
   /**
    * @type {Stat<{}>}
    */
-  async function stat (_options) { // eslint-disable-line require-await
+  // @ts-ignore - 'options' is declared but its value is never read.ts(6133)
+  async function stat (options) { // eslint-disable-line require-await
     const snapshot = bitswap.stat().snapshot
 
     return {

--- a/packages/ipfs-core/src/components/config.js
+++ b/packages/ipfs-core/src/components/config.js
@@ -64,10 +64,12 @@ module.exports = ({ repo }) => {
 }
 
 /**
- * @param {any} _options
+ * @param options
+ * @param {any} [options]
  * @returns {Promise<{name:string, description:string}[]>}
  */
-async function listProfiles (_options) { // eslint-disable-line require-await
+// @ts-ignore - 'options' is declared but its value is never read.ts(6133)
+async function listProfiles (options) { // eslint-disable-line require-await
   return Object.keys(profiles).map(name => ({
     name,
     description: profiles[name].description

--- a/packages/ipfs-core/src/components/id.js
+++ b/packages/ipfs-core/src/components/id.js
@@ -14,7 +14,7 @@ module.exports = ({ peerId, libp2p }) => {
   /**
    * Returns the identity of the Peer
    *
-   * @param {import('../utils').AbortOptions} [_options]
+   * @param {import('../utils').AbortOptions} [options]
    * @returns {Promise<PeerId>}
    * @example
    * ```js
@@ -22,7 +22,8 @@ module.exports = ({ peerId, libp2p }) => {
    * console.log(identity)
    * ```
    */
-  async function id (_options) { // eslint-disable-line require-await
+  // @ts-ignore - 'options' is declared but its value is never read.ts(6133)
+  async function id (options) { // eslint-disable-line require-await
     const id = peerId.toB58String()
     let addresses = []
     let protocols = []

--- a/packages/ipfs-core/src/components/name/pubsub/state.js
+++ b/packages/ipfs-core/src/components/name/pubsub/state.js
@@ -7,7 +7,7 @@ module.exports = ({ ipns, options: constructorOptions }) => {
   /**
    * Query the state of IPNS pubsub.
    *
-   * @param {AbortOptions} [_options]
+   * @param {AbortOptions} [options]
    * @returns {Promise<{ enabled: boolean }>}
    * ```js
    * const result = await ipfs.name.pubsub.state()
@@ -15,7 +15,8 @@ module.exports = ({ ipns, options: constructorOptions }) => {
    * // Logs: true
    * ```
    */
-  async function state (_options) { // eslint-disable-line require-await
+  // @ts-ignore - 'options' is declared but its value is never read.ts(6133)
+  async function state (options) { // eslint-disable-line require-await
     try {
       return { enabled: Boolean(getPubsubRouting(ipns, constructorOptions)) }
     } catch (err) {

--- a/packages/ipfs-core/src/components/pin/rm-all.js
+++ b/packages/ipfs-core/src/components/pin/rm-all.js
@@ -15,7 +15,7 @@ module.exports = ({ pinManager, gcLock, dag }) => {
    * Unpin one or more blocks from your repo
    *
    * @param {PinsSource} source - Unpin all pins from the source
-   * @param {AbortOptions} [_options]
+   * @param {AbortOptions} [options]
    * @returns {AsyncIterable<CID>}
    * @example
    * ```js
@@ -29,7 +29,8 @@ module.exports = ({ pinManager, gcLock, dag }) => {
    * // CID('QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u')
    * ```
    */
-  async function * rmAll (source, _options = {}) {
+  // @ts-ignore - 'options' is declared but its value is never read.ts(6133)
+  async function * rmAll (source, options = {}) {
     const release = await gcLock.readLock()
 
     try {

--- a/packages/ipfs-core/src/components/pubsub.js
+++ b/packages/ipfs-core/src/components/pubsub.js
@@ -7,7 +7,8 @@ module.exports = ({ libp2p }) => {
   return {
     subscribe: withTimeoutOption((...args) => libp2p.pubsub.subscribe(...args)),
     unsubscribe: withTimeoutOption((...args) => libp2p.pubsub.unsubscribe(...args)),
-    publish: withTimeoutOption(async (topic, data, _options) => {
+    // @ts-ignore - 'options' is declared but its value is never read.ts(6133)
+    publish: withTimeoutOption(async (topic, data, options) => {
       if (!data) {
         throw errCode(new Error('argument "data" is required'), 'ERR_ARG_REQUIRED')
       }

--- a/packages/ipfs-core/src/components/repo/gc.js
+++ b/packages/ipfs-core/src/components/repo/gc.js
@@ -22,6 +22,7 @@ const BLOCK_RM_CONCURRENCY = 256
  * @returns {GC}
  */
 module.exports = ({ gcLock, pin, refs, repo }) => {
+  // @ts-ignore - 'options' is declared but its value is never read.ts(6133)
   async function * gc (options = {}) {
     const start = Date.now()
     log('Creating set of marked blocks')

--- a/packages/ipfs-core/src/components/repo/gc.js
+++ b/packages/ipfs-core/src/components/repo/gc.js
@@ -22,7 +22,7 @@ const BLOCK_RM_CONCURRENCY = 256
  * @returns {GC}
  */
 module.exports = ({ gcLock, pin, refs, repo }) => {
-  async function * gc (_options = {}) {
+  async function * gc (options = {}) {
     const start = Date.now()
     log('Creating set of marked blocks')
 

--- a/packages/ipfs-core/src/components/stop.js
+++ b/packages/ipfs-core/src/components/stop.js
@@ -27,14 +27,15 @@ module.exports = ({
    * Stops the IPFS node and in case of talking with an IPFS Daemon, it stops
    * the process.
    *
-   * @param {AbortOptions} _options
+   * @param {AbortOptions} options
    * @returns {Promise<void>}
    * @example
    * ```js
    * await ipfs.stop()
    * ```
    */
-  async function stop (_options) {
+  // @ts-ignore - 'options' is declared but its value is never read.ts(6133)
+  async function stop (options) {
     const stopPromise = defer()
     const { cancel } = apiManager.update({ stop: () => stopPromise.promise })
 


### PR DESCRIPTION
I have made separate pull from #3281 to [address discussion regarding _ prefix in unused `options` params](https://github.com/ipfs/js-ipfs/pull/3281/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=dotfile#r501007121).

The reason I chose to do it separately is because after our discussion with @achingbrain I realized that main reason we decided to add `ts-ignore` comments was so that generated docs would not have an argument named `_options`, but then we are not generating docs yet and there might be better ways to address that specific problem than potentially swallow other errors while ignoring specific line.

@achingbrain which is why I would like to propose to keep `_` prefixes introduced in #3281 and figure out best way to address naming of parameters in docs when we get there. If it turns out adding these comments is the best way we make that (but better informed) decision then. If you do disagree however feel free to merge this and it will address the that request.