### PR TITLE
Typecheck github action

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches:
+      - master
+      - main
+      - default
+  pull_request:
+    branches:
+      - '**'
+
+name: Typecheck
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Typecheck ipfs-core
+        uses: gozala/typescript-error-reporter-action@v1.0.4
+        with:
+          project: packages/ipfs-core
+      - name: Generate typedefs for dependencies
+        run: npm run build:types --scope={ipfs-core}
+      - name: Typecheck ipfs
+        uses: gozala/typescript-error-reporter-action@v1.0.4
+        with:
+          project: packages/ipfs


### PR DESCRIPTION
This pull request adds a github action to #3281, which runs type check and reports any missmateches in the pull request diff view. Screenshots below are from #3328 which reverted two changes from #3281 back to how they were on master which pass all tests, but fail type checker:

<img width="550" alt="image" src="https://user-images.githubusercontent.com/21236/95822852-87c5e380-0ce1-11eb-809f-68354217b4e4.png">

<img width="555" alt="image" src="https://user-images.githubusercontent.com/21236/95823437-79c49280-0ce2-11eb-9558-e88b2efab57c.png">


Since this adds a separate action, it allows us to have more relaxed policies in regards to changes that fail checks. Also I hope that messages in the pull request may encourage contributors to resolve reported issues and sometimes (unfortunately not always) they are clear enough to require no TS knowledge at all.


