### PR TITLE
chore: test aegir global object fix

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -66,7 +66,7 @@
     "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "ipfsd-ctl": "^7.0.2"
   },
   "contributors": [

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -75,7 +75,7 @@
     "yargs": "^16.0.3"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "nanoid": "^3.1.12",
     "ncp": "^2.0.0",
     "rimraf": "^3.0.2",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -48,7 +48,7 @@
     "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "delay": "^4.4.0",
     "typescript": "^4.0.3"
   }

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -125,7 +125,7 @@
     "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "delay": "^4.4.0",
     "ipfsd-ctl": "^7.0.2",
     "interface-ipfs-core": "^0.140.0",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -79,7 +79,7 @@
     "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "cross-env": "^7.0.0",
     "go-ipfs": "^0.7.0",
     "interface-ipfs-core": "^0.140.0",

--- a/packages/ipfs-http-gateway/package.json
+++ b/packages/ipfs-http-gateway/package.json
@@ -47,7 +47,7 @@
     "uri-to-multiaddr": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "file-type": "^15.0.1",
     "sinon": "^9.0.3",
     "typescript": "^4.0.3"

--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -71,7 +71,7 @@
     "uri-to-multiaddr": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "form-data": "^3.0.0",
     "iso-random-stream": "^1.1.1",
     "it-to-buffer": "^1.0.2",

--- a/packages/ipfs-message-port-client/package.json
+++ b/packages/ipfs-message-port-client/package.json
@@ -45,7 +45,7 @@
     "cids": "^1.0.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "cross-env": "^7.0.0",
     "interface-ipfs-core": "^0.140.0",
     "ipfs": "^0.50.2",

--- a/packages/ipfs-message-port-protocol/package.json
+++ b/packages/ipfs-message-port-protocol/package.json
@@ -45,7 +45,7 @@
     "ipld-block": "^0.10.1"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "uint8arrays": "^1.1.0",
     "typescript": "^4.0.3"
   },

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/it-all": "^1.0.0",
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "cross-env": "^7.0.0",
     "ipfs-message-port-protocol": "^0.2.0",
     "typescript": "^4.0.3"

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -45,7 +45,7 @@
     "update-notifier": "^5.0.0"
   },
   "devDependencies": {
-    "aegir": "^28.0.0",
+    "aegir": "ipfs/aegir#fix/global-object",
     "clear-module": "^4.0.0",
     "cross-env": "^7.0.0",
     "delay": "^4.4.0",


### PR DESCRIPTION
Not for merging, just making sure the tests still pass with Karma's webpack output type set to 'umd' instead of 'var'

See: ipfs/aegir#408