### PR TITLE
fix: remove buffer export from ipfs-core

### DIFF
--- a/packages/ipfs-core/src/index.js
+++ b/packages/ipfs-core/src/index.js
@@ -82,7 +82,6 @@ module.exports = {
   create,
   crypto,
   isIPFS,
-  Buffer,
   CID,
   multiaddr,
   multibase,


### PR DESCRIPTION
Everything is Uint8Arrays now so there's no need to export node's
Buffer module any more.

Fixes #3312

BREAKING CHANGE: `Buffer` is no longer exported from core