### PR TITLE
fix: do not double normalise input url

### DIFF
--- a/packages/ipfs-http-client/src/lib/core.js
+++ b/packages/ipfs-http-client/src/lib/core.js
@@ -122,10 +122,11 @@ class Client extends HTTP {
    */
   constructor (options = {}) {
     const opts = normalizeInput(options)
+
     super({
       timeout: parseTimeout(opts.timeout) || 60000 * 20,
       headers: opts.headers,
-      base: normalizeInput(opts.url).toString(),
+      base: `${opts.url}`,
       handleError: errorHandler,
       transformSearchParams: (search) => {
         const out = new URLSearchParams()

--- a/packages/ipfs-http-client/test/constructor.spec.js
+++ b/packages/ipfs-http-client/test/constructor.spec.js
@@ -86,6 +86,14 @@ describe('ipfs-http-client constructor tests', () => {
       const ipfs = ipfsClient({ host, port, apiPath })
       expectConfig(ipfs, { host, port, apiPath })
     })
+
+    it('url', () => {
+      const host = '10.100.100.255'
+      const port = '9999'
+      const apiPath = '/future/api/v1/'
+      const ipfs = ipfsClient({ url: `http://${host}:${port}${apiPath}` })
+      expectConfig(ipfs, { host, port, apiPath })
+    })
   })
 
   describe('integration', () => {


### PR DESCRIPTION
No need to do this twice.

Fixes #3331