### PR TITLE
fix: files ls should return string

### DIFF
--- a/examples/browser-mfs/filetree.js
+++ b/examples/browser-mfs/filetree.js
@@ -5,8 +5,8 @@ const {
 } = require('./utils')
 
 const FILE_TYPES = {
-  FILE: 0,
-  DIRECTORY: 1
+  FILE: 'file',
+  DIRECTORY: 'directory'
 }
 
 let selected = {}

--- a/packages/interface-ipfs-core/src/files/ls.js
+++ b/packages/interface-ipfs-core/src/files/ls.js
@@ -10,12 +10,6 @@ const drain = require('it-drain')
 const randomBytes = require('iso-random-stream/src/random')
 const testTimeout = require('../utils/test-timeout')
 
-const MFS_FILE_TYPES = {
-  file: 0,
-  directory: 1,
-  'hamt-sharded-directory': 1
-}
-
 /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
  * @param {Factory} common
@@ -53,7 +47,7 @@ module.exports = (common, options) => {
         cid: new CID('Qmetpc7cZmN25Wcc6R27cGCAvCDqCS5GjHG4v7xABEfpmJ'),
         name: fileName,
         size: content.length,
-        type: MFS_FILE_TYPES.file
+        type: 'file'
       }])
     })
 
@@ -81,7 +75,7 @@ module.exports = (common, options) => {
         cid: new CID('Qmetpc7cZmN25Wcc6R27cGCAvCDqCS5GjHG4v7xABEfpmJ'),
         name: fileName,
         size: content.length,
-        type: MFS_FILE_TYPES.file
+        type: 'file'
       }])
     })
 
@@ -99,7 +93,7 @@ module.exports = (common, options) => {
         cid: new CID('Qmetpc7cZmN25Wcc6R27cGCAvCDqCS5GjHG4v7xABEfpmJ'),
         name: fileName,
         size: content.length,
-        type: MFS_FILE_TYPES.file
+        type: 'file'
       }])
     })
 
@@ -128,7 +122,7 @@ module.exports = (common, options) => {
         cid: child.Hash,
         name: child.Hash.toString(),
         size: 262144,
-        type: MFS_FILE_TYPES.file
+        type: 'file'
       }])
     })
 
@@ -160,7 +154,7 @@ module.exports = (common, options) => {
         cid: child.Hash,
         name: child.Hash.toString(),
         size: 262144,
-        type: MFS_FILE_TYPES.file
+        type: 'file'
       }])
     })
 
@@ -200,7 +194,7 @@ module.exports = (common, options) => {
 
         files.forEach(file => {
           // should be a file
-          expect(file.type).to.equal(0)
+          expect(file.type).to.equal('file')
         })
       })
 

--- a/packages/ipfs-core/src/components/files/ls.js
+++ b/packages/ipfs-core/src/components/files/ls.js
@@ -3,7 +3,6 @@
 const exporter = require('ipfs-unixfs-exporter')
 const toMfsPath = require('./utils/to-mfs-path')
 const {
-  MFS_FILE_TYPES,
   withTimeoutOption
 } = require('../../utils')
 
@@ -12,6 +11,7 @@ const {
  * @returns {UnixFSEntry}
  */
 const toOutput = (fsEntry) => {
+  /** @type FileType */
   let type = 'file'
   let size = fsEntry.node.size || fsEntry.node.length
   let mode
@@ -19,7 +19,12 @@ const toOutput = (fsEntry) => {
 
   if (fsEntry.unixfs) {
     size = fsEntry.unixfs.fileSize()
-    type = Object.entries(MFS_FILE_TYPES).find(x => x[1] == fsEntry.unixfs.type)[0]
+    type = fsEntry.unixfs.type
+
+    if (fsEntry.unixfs.type === 'hamt-sharded-directory') {
+      type = 'directory'
+    }
+
     mode = fsEntry.unixfs.mode
     mtime = fsEntry.unixfs.mtime
   }
@@ -89,10 +94,13 @@ module.exports = (context) => {
  * @property {number} [nsecs] - the number of nanoseconds since the last full
  * second.
  *
+ * @typedef {'file'|'directory'} FileType
+ *
  * @typedef {object} UnixFSEntry
  * @property {CID} cid
+ * @property {string} name
  * @property {number} [mode]
  * @property {UnixTimeObj} [mtime]
  * @property {number} size
- * @property {number} type
+ * @property {FileType} type
  */

--- a/packages/ipfs-core/src/components/files/ls.js
+++ b/packages/ipfs-core/src/components/files/ls.js
@@ -12,14 +12,14 @@ const {
  * @returns {UnixFSEntry}
  */
 const toOutput = (fsEntry) => {
-  let type = 0
+  let type = 'file'
   let size = fsEntry.node.size || fsEntry.node.length
   let mode
   let mtime
 
   if (fsEntry.unixfs) {
     size = fsEntry.unixfs.fileSize()
-    type = MFS_FILE_TYPES[fsEntry.unixfs.type]
+    type = Object.entries(MFS_FILE_TYPES).find(x => x[1] == fsEntry.unixfs.type)[0]
     mode = fsEntry.unixfs.mode
     mtime = fsEntry.unixfs.mtime
   }

--- a/packages/ipfs-core/src/utils.js
+++ b/packages/ipfs-core/src/utils.js
@@ -18,7 +18,7 @@ exports.OFFLINE_ERROR = 'This command must be run in online mode. Try running \'
 exports.MFS_FILE_TYPES = {
   file: 0,
   directory: 1,
-  'hamt-sharded-directory': 1
+  'hamt-sharded-directory': 2
 }
 exports.MFS_ROOT_KEY = new Key('/local/filesroot')
 exports.MFS_MAX_CHUNK_SIZE = 262144

--- a/packages/ipfs-core/src/utils.js
+++ b/packages/ipfs-core/src/utils.js
@@ -14,12 +14,6 @@ const toCidAndPath = require('ipfs-core-utils/src/to-cid-and-path')
 const ERR_BAD_PATH = 'ERR_BAD_PATH'
 
 exports.OFFLINE_ERROR = 'This command must be run in online mode. Try running \'ipfs daemon\' first.'
-
-exports.MFS_FILE_TYPES = {
-  file: 0,
-  directory: 1,
-  'hamt-sharded-directory': 2
-}
 exports.MFS_ROOT_KEY = new Key('/local/filesroot')
 exports.MFS_MAX_CHUNK_SIZE = 262144
 exports.MFS_MAX_LINKS = 174

--- a/packages/ipfs-http-client/src/files/ls.js
+++ b/packages/ipfs-http-client/src/files/ls.js
@@ -43,7 +43,13 @@ module.exports = configure(api => {
 })
 
 function toCoreInterface (entry) {
-  if (entry.hash) entry.cid = new CID(entry.hash)
+  if (entry.hash) {
+    entry.cid = new CID(entry.hash)
+  }
+
   delete entry.hash
+
+  entry.type = entry.type === 1 ? 'directory' : 'file'
+
   return entry
 }

--- a/packages/ipfs-http-server/src/api/resources/files/ls.js
+++ b/packages/ipfs-http-server/src/api/resources/files/ls.js
@@ -7,9 +7,11 @@ const { pipe } = require('it-pipe')
 const streamResponse = require('../../../utils/stream-response')
 
 const mapEntry = (entry, options = {}) => {
+  const type = entry.type === 'file' ? 0 : 1
+
   const output = {
     Name: entry.name,
-    Type: options.long ? entry.type : 0,
+    Type: options.long ? type : 0,
     Size: options.long ? entry.size || 0 : 0,
     Hash: entry.cid.toString(options.cidBase)
   }

--- a/packages/ipfs-http-server/test/inject/mfs/ls.js
+++ b/packages/ipfs-http-server/test/inject/mfs/ls.js
@@ -83,7 +83,7 @@ describe('/files/ls', () => {
 
     expect(response).to.have.nested.property('result.Entries.length', 1)
     expect(response).to.have.nested.property('result.Entries[0].Name', file.name)
-    expect(response).to.have.nested.property('result.Entries[0].Type', file.type)
+    expect(response).to.have.nested.property('result.Entries[0].Type', 1)
     expect(response).to.have.nested.property('result.Entries[0].Size', file.size)
     expect(response).to.have.nested.property('result.Entries[0].Hash', file.cid.toString())
     expect(response).to.have.nested.property('result.Entries[0].Mode', file.mode)


### PR DESCRIPTION
Supersedes #3345 #2939
Fixes #3330 #2948

BREAKING CHANGE: types returned by `ipfs.files.ls` are now strings, in line with the docs but different to previous behaviour