### PR TITLE
chore: ignore typecheck for onFinishCommand

### DIFF
--- a/packages/ipfs-cli/src/index.js
+++ b/packages/ipfs-cli/src/index.js
@@ -12,6 +12,7 @@ module.exports = (command, ctxMiddleware) => {
     try {
       parser
         .middleware(ctxMiddleware)
+        // @ts-ignore
         .onFinishCommand((data) => {
           resolve(data)
         })


### PR DESCRIPTION
Adds a ts-ignore for the yargs `onFinishCommand` method as otherwise building fails with:

```
Property 'onFinishCommand' does not exist on type 'Argv<{ silent: boolean; } & { pass: string; } & { migrate: boolean; } & { api: string | undefined; }>'
```