### PR TITLE
feat: make re-init a noop

### DIFF
--- a/packages/ipfs-core/src/components/init.js
+++ b/packages/ipfs-core/src/components/init.js
@@ -14,7 +14,6 @@ const UnixFs = require('ipfs-unixfs')
 const multicodec = require('multicodec')
 const {
   AlreadyInitializingError,
-  AlreadyInitializedError,
   NotStartedError,
   NotEnabledError
 } = require('../errors')
@@ -390,7 +389,7 @@ function createApi ({
     files: Components.files({ ipld, block, blockService, repo, preload, options: constructorOptions }),
     get: Components.get({ ipld, preload }),
     id: Components.id({ peerId }),
-    init: async () => { throw new AlreadyInitializedError() }, // eslint-disable-line require-await
+    init: () => {},
     isOnline: Components.isOnline({}),
     key: {
       export: Components.key.export({ keychain }),

--- a/packages/ipfs-core/src/components/start.js
+++ b/packages/ipfs-core/src/components/start.js
@@ -8,7 +8,7 @@ const defer = require('p-defer')
 const errCode = require('err-code')
 const IPNS = require('../ipns')
 const routingConfig = require('../ipns/routing/config')
-const { AlreadyInitializedError, NotEnabledError } = require('../errors')
+const { NotEnabledError } = require('../errors')
 const Components = require('./')
 const createMfsPreload = require('../mfs-preload')
 const { withTimeoutOption } = require('../utils')
@@ -292,7 +292,7 @@ function createApi ({
     files,
     get: Components.get({ ipld, preload }),
     id: Components.id({ peerId, libp2p }),
-    init: async () => { throw new AlreadyInitializedError() }, // eslint-disable-line require-await
+    init: () => {},
     isOnline,
     key: {
       export: Components.key.export({ keychain }),

--- a/packages/ipfs-core/src/components/stop.js
+++ b/packages/ipfs-core/src/components/stop.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const defer = require('p-defer')
-const { NotStartedError, AlreadyInitializedError } = require('../errors')
+const { NotStartedError } = require('../errors')
 const Components = require('./')
 const { withTimeoutOption } = require('../utils')
 
@@ -171,9 +171,7 @@ function createApi ({
     files: Components.files({ ipld, block, blockService, repo, preload, options: constructorOptions }),
     get: Components.get({ ipld, preload }),
     id: Components.id({ peerId }),
-    init: async () => { // eslint-disable-line require-await
-      throw new AlreadyInitializedError()
-    },
+    init: () => {},
     isOnline: Components.isOnline({}),
     key: {
       export: Components.key.export({ keychain }),

--- a/packages/ipfs-core/src/errors.js
+++ b/packages/ipfs-core/src/errors.js
@@ -15,23 +15,12 @@ class AlreadyInitializingError extends Error {
   constructor (message = 'cannot initialize an initializing node') {
     super(message)
     this.name = 'AlreadyInitializingError'
-    this.code = AlreadyInitializedError.code
+    this.code = AlreadyInitializingError.code
   }
 }
 
 AlreadyInitializingError.code = 'ERR_ALREADY_INITIALIZING'
 exports.AlreadyInitializingError = AlreadyInitializingError
-
-class AlreadyInitializedError extends Error {
-  constructor (message = 'cannot re-initialize an initialized node') {
-    super(message)
-    this.name = 'AlreadyInitializedError'
-    this.code = AlreadyInitializedError.code
-  }
-}
-
-AlreadyInitializedError.code = 'ERR_ALREADY_INITIALIZED'
-exports.AlreadyInitializedError = AlreadyInitializedError
 
 class NotStartedError extends Error {
   constructor (message = 'not started') {

--- a/packages/ipfs/.aegir.js
+++ b/packages/ipfs/.aegir.js
@@ -5,6 +5,7 @@ const MockPreloadNode = require('./test/utils/mock-preload-node')
 const EchoServer = require('aegir/utils/echo-server')
 const webRTCStarSigServer = require('libp2p-webrtc-star/src/sig-server')
 const path = require('path')
+const { commonOptions, commonOverrides } = require('./test/utils/factory')
 
 let preloadNode
 let echoServer = new EchoServer()
@@ -68,26 +69,13 @@ module.exports = {
           port: 14578,
           metrics: false
         })
+
+        const url = new URL(commonOptions.endpoint)
+
         ipfsdServer = await createServer({
-          host: '127.0.0.1',
-          port: 57483
-        }, {
-          type: 'js',
-          ipfsModule: require(__dirname),
-          ipfsHttpModule: require('ipfs-http-client'),
-          ipfsBin: path.join(__dirname, 'src', 'cli.js'),
-          ipfsOptions: {
-            libp2p: {
-              dialer: {
-                dialTimeout: 60e3 // increase timeout because travis is slow
-              }
-            }
-          }
-        }, {
-          go: {
-            ipfsBin: require('go-ipfs').path()
-          }
-        }).start()
+          host: url.hostname,
+          port: url.port
+        }, commonOptions, commonOverrides).start()
 
         return {
           env: {

--- a/packages/ipfs/test/utils/factory.js
+++ b/packages/ipfs/test/utils/factory.js
@@ -14,9 +14,12 @@ const commonOptions = {
       dialer: {
         dialTimeout: 60e3 // increase timeout because travis is slow
       }
+    },
+    init: {
+      bits: 512
     }
   },
-  endpoint: 'http://localhost:57483'
+  endpoint: 'http://127.0.0.1:57483'
 }
 
 const commonOverrides = {
@@ -54,3 +57,5 @@ const factory = (options = {}, overrides = {}) => {
 }
 
 module.exports = factory
+module.exports.commonOptions = commonOptions
+module.exports.commonOverrides = commonOverrides


### PR DESCRIPTION
If init is called on a running/stopped node, just do nothing instead
of exploding.  This lets the user not care about the state of the repo
and just start a node.

Also:

1. Deduplicates ipfsd config for interface tests
2. Sets the default key size to 512 bytes to make starting test nodes faster