### PR TITLE
fix: types path for ipfs-core

### DIFF
--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -1,11 +1,5 @@
-/* eslint-disable jsdoc/valid-types */
 'use strict'
 
-const IPFS = require('ipfs-core')
-
-/**
- * @typedef { ReturnType<typeof IPFS['create']> extends Promise<infer U>
- * ? U : never } IPFS
- */
+const IPFS = require('ipfs-core/src')
 
 module.exports = IPFS

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+// TODO: Fix TS issue that prevents use of require('ipfs-core') instead
+// https://github.com/ipfs/js-ipfs/issues/3358
 const IPFS = require('ipfs-core/src')
 
 module.exports = IPFS


### PR DESCRIPTION
For some reason you need to add `/src` after `ipfs-core` otherwise the import in the generated `index.d.ts` has the wrong path.
    
Must fix properly before the next release.