### PR TITLE
chore: add @types/yargs for better inference

### DIFF
--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -83,7 +83,8 @@
     "string-argv": "^0.3.1",
     "temp-write": "^4.0.0",
     "typescript": "^4.0.3",
-    "wrtc": "^0.4.6"
+    "wrtc": "^0.4.6",
+    "@types/yargs": "^15.0.9"
   },
   "optionalDependencies": {
     "prom-client": "^12.0.0",

--- a/packages/ipfs-cli/src/parser.js
+++ b/packages/ipfs-cli/src/parser.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// @ts-ignore
 const yargs = require('yargs/yargs')(process.argv.slice(2))
 const utils = require('./utils')
 


### PR DESCRIPTION
This was prompted by #3353. I am guessing that something end up pulling old version of `@types/yargs` that was unaware of `onFinishCommand`. This pull explicitly adds latest `@types/yargs` into `ipfs-cli` dev dependencies which:

1. Seems to be aware of `onFinishCommand`.
2. Makes ipfs-cli aware of yargs interface, which without this just appears as `any`.

