### PR TITLE
chore: add non-bundled format in test

### DIFF
--- a/packages/ipfs-core/test/ipld.spec.js
+++ b/packages/ipfs-core/test/ipld.spec.js
@@ -15,7 +15,7 @@ describe('ipld', function () {
     const res = await createNode({
       ipld: {
         formats: [
-          require('ipld-dag-pb')
+          require('ipld-git')
         ]
       }
     })


### PR DESCRIPTION
Since https://github.com/ipld/js-ipld/pull/293 was merged IPLD now validates existing formats correctly so use a non-bundled one in the test otherwise it throws when we try to re-add the `dag-pb` format.