### PR TITLE
chore: use dnsaddr for bootstrap nodes

### DIFF
--- a/packages/ipfs-core/.aegir.js
+++ b/packages/ipfs-core/.aegir.js
@@ -15,7 +15,7 @@ let sigServerB
 let ipfsdServer
 
 module.exports = {
-  bundlesize: { maxSize: '518kB' },
+  bundlesize: { maxSize: '520kB' },
   karma: {
     files: [{
       pattern: 'node_modules/interface-ipfs-core/test/fixtures/**/*',

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -90,7 +90,7 @@
     "it-first": "^1.0.4",
     "it-last": "^1.0.4",
     "it-pipe": "^1.1.0",
-    "libp2p": "^0.29.0",
+    "libp2p": "^0.29.3",
     "libp2p-bootstrap": "^0.12.1",
     "libp2p-crypto": "^0.18.0",
     "libp2p-floodsub": "^0.23.1",

--- a/packages/ipfs-core/src/runtime/config-browser.js
+++ b/packages/ipfs-core/src/runtime/config-browser.js
@@ -23,12 +23,11 @@ module.exports = () => ({
     }
   },
   Bootstrap: [
-    '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-    '/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-    '/dns4/sfo-3.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-    '/dns4/sgp-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-    '/dns4/nyc-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-    '/dns4/nyc-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt',
     '/dns4/node0.preload.ipfs.io/tcp/443/wss/p2p/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
     '/dns4/node1.preload.ipfs.io/tcp/443/wss/p2p/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6',
     '/dns4/node2.preload.ipfs.io/tcp/443/wss/p2p/QmV7gnbW5VTcJ3oyM2Xk1rdFBJ3kTkvxc87UFGsun29STS',

--- a/packages/ipfs-core/test/config.spec.js
+++ b/packages/ipfs-core/test/config.spec.js
@@ -31,19 +31,19 @@ describe('config', function () {
 
     expect(res.Peers).to.not.be.empty()
 
-    const onlyWss = res.Peers.reduce((acc, curr) => {
+    const onlyWssOrResolvableAddr = res.Peers.reduce((acc, curr) => {
       if (!acc) {
         return acc
       }
 
       const ma = multiaddr(curr)
-      return ma.protos().some(proto => proto.name === 'wss')
+      return ma.protos().some(proto => proto.name === 'wss' || proto.resolvable)
     }, true)
 
     if (isBrowser || isWebWorker) {
-      expect(onlyWss).to.be.true()
+      expect(onlyWssOrResolvableAddr).to.be.true()
     } else {
-      expect(onlyWss).to.be.false()
+      expect(onlyWssOrResolvableAddr).to.be.false()
     }
   })
 })


### PR DESCRIPTION
This PR adds the new `dnsaddr` multiaddrs for browser bootstrapping peers per https://github.com/libp2p/js-libp2p/pull/772 and https://github.com/libp2p/js-libp2p/pull/782 

cc @mburns 