### PR TITLE
chore: upgrade unixfs-importer

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -39,7 +39,7 @@
     "dirty-chai": "^2.0.1",
     "err-code": "^2.0.3",
     "ipfs-unixfs": "^2.0.3",
-    "ipfs-unixfs-importer": "^3.0.4",
+    "ipfs-unixfs-importer": "^4.0.0",
     "ipfs-utils": "^4.0.0",
     "ipld-block": "^0.10.1",
     "ipld-dag-cbor": "^0.17.0",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -75,7 +75,7 @@
     "ipfs-repo": "^6.0.3",
     "ipfs-unixfs": "^2.0.3",
     "ipfs-unixfs-exporter": "^3.0.4",
-    "ipfs-unixfs-importer": "^3.0.4",
+    "ipfs-unixfs-importer": "^4.0.0",
     "ipfs-utils": "^4.0.0",
     "ipld": "^0.27.2",
     "ipld-block": "^0.10.1",

--- a/packages/ipfs-core/src/components/add-all/index.js
+++ b/packages/ipfs-core/src/components/add-all/index.js
@@ -41,6 +41,23 @@ module.exports = ({ block, gcLock, preload, pin, options: constructorOptions }) 
       opts.strategy = 'trickle'
     }
 
+    if (opts.strategy === 'trickle') {
+      opts.leafType = 'raw'
+      opts.reduceSingleLeafToSelf = false
+    }
+
+    if (opts.cidVersion > 0 && opts.rawLeaves === undefined) {
+      // if the cid version is 1 or above, use raw leaves as this is
+      // what go does.
+      opts.rawLeaves = true
+    }
+
+    if (opts.hashAlg !== undefined && opts.rawLeaves === undefined) {
+      // if a non-default hash alg has been specified, use raw leaves as this is
+      // what go does.
+      opts.rawLeaves = true
+    }
+
     delete opts.trickle
 
     if (opts.progress) {


### PR DESCRIPTION
Restores changes to defaults removed from the importer to ensure CID compatibility with go-IPFS.