### PR TITLE
fix: remove electron-webrtc dependency

### DIFF
--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -35,7 +35,6 @@
     "cids": "^1.0.0",
     "debug": "^4.1.1",
     "dlv": "^1.1.3",
-    "electron-webrtc": "^0.3.0",
     "err-code": "^2.0.3",
     "execa": "^4.0.3",
     "get-folder-size": "^2.0.1",


### PR DESCRIPTION
Remove electron-webrtc dep - as it was only being used by daemon startup which doesn't typically run under electron.

If your application requires webrtc, see [the FAQ](https://github.com/ipfs/js-ipfs/blob/master/docs/FAQ.md#is-there-webrtc-support-for-js-ipfs-with-nodejs) for more information.

Fixes #3376