### PR TITLE
fix: ensure correct progress is reported

### DIFF
--- a/docs/core-api/FILES.md
+++ b/docs/core-api/FILES.md
@@ -171,7 +171,7 @@ An optional object which may have the following keys:
 | hashAlg | `String` | `'sha2-256'` | multihash hashing algorithm to use |
 | onlyHash | `boolean` | `false` | If true, will not add blocks to the blockstore |
 | pin | `boolean` | `true` | pin this object when adding |
-| progress | function | `undefined` | a function that will be called with the byte length of chunks as a file is added to ipfs |
+| progress | function | `undefined` | a function that will be called with the number of bytes added as a file is added to ipfs and the path of the file being added |
 | rawLeaves | `boolean` | `false` | if true, DAG leaves will contain raw file data and not be wrapped in a protobuf |
 | trickle | `boolean` | `false` | if true will use the [trickle DAG](https://godoc.org/github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-unixfs/importer/trickle) format for DAG generation |
 | wrapWithDirectory | `boolean` | `false` | Adds a wrapping node around the content |
@@ -252,7 +252,7 @@ An optional object which may have the following keys:
 | hashAlg | `String` | `'sha2-256'` | multihash hashing algorithm to use |
 | onlyHash | `boolean` | `false` | If true, will not add blocks to the blockstore |
 | pin | `boolean` | `true` | pin this object when adding |
-| progress | function | `undefined` | a function that will be called with the number of bytes added as a file is added to ipfs and the name of the file being added |
+| progress | function | `undefined` | a function that will be called with the number of bytes added as a file is added to ipfs and the path of the file being added |
 | rawLeaves | `boolean` | `false` | if true, DAG leaves will contain raw file data and not be wrapped in a protobuf |
 | shardSplitThreshold | `Number` | `1000` | Directories with more than this number of files will be created as HAMT-sharded directories |
 | trickle | `boolean` | `false` | if true will use the [trickle DAG](https://godoc.org/github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-unixfs/importer/trickle) format for DAG generation |

--- a/packages/ipfs-core/src/components/add-all/index.js
+++ b/packages/ipfs-core/src/components/add-all/index.js
@@ -96,7 +96,6 @@ module.exports = ({ block, gcLock, preload, pin, options: constructorOptions }) 
 
         yield added
       }
-      yield * iterator
     } finally {
       releaseLock()
     }

--- a/packages/ipfs-core/src/components/add.js
+++ b/packages/ipfs-core/src/components/add.js
@@ -25,7 +25,7 @@ module.exports = ({ addAll }) => {
  * @property {string} [hashAlg] - multihash hashing algorithm to use (default: `'sha2-256'`)
  * @property {boolean} [onlyHash] - If true, will not add blocks to the blockstore (default: `false`)
  * @property {boolean} [pin] - pin this object when adding (default: `true`)
- * @property {Function} [progress] - a function that will be called with the byte length of chunks as a file is added to ipfs (default: `undefined`)
+ * @property {(bytes:number, path:string) => void} [progress] - a function that will be called with the number of bytes added as a file is added to ipfs and the path of the file being added
  * @property {boolean} [rawLeaves] - if true, DAG leaves will contain raw file data and not be wrapped in a protobuf (default: `false`)
  * @property {boolean} [trickle] - if true will use the [trickle DAG](https://godoc.org/github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-unixfs/importer/trickle) format for DAG generation (default: `false`)
  * @property {boolean} [wrapWithDirectory] - Adds a wrapping node around the content (default: `false`)


### PR DESCRIPTION
Fixes a bug where due to parallel file imports, the reported size of
ingested bytes was getting mixed up.

We now tally imported bytes against the reported file name instead of
assuming a sequential import, taking care to not let the tally grow
until memory is exhausted.