### PR TITLE
fix: align behaviour between go and js for content without paths

### DIFF
--- a/docs/core-api/FILES.md
+++ b/docs/core-api/FILES.md
@@ -171,7 +171,7 @@ An optional object which may have the following keys:
 | hashAlg | `String` | `'sha2-256'` | multihash hashing algorithm to use |
 | onlyHash | `boolean` | `false` | If true, will not add blocks to the blockstore |
 | pin | `boolean` | `true` | pin this object when adding |
-| progress | function | `undefined` | a function that will be called with the byte length of chunks as a file is added to ipfs |
+| progress | function | `undefined` | a function that will be called with the number of bytes added as a file is added to ipfs and the path of the file being added |
 | rawLeaves | `boolean` | `false` | if true, DAG leaves will contain raw file data and not be wrapped in a protobuf |
 | trickle | `boolean` | `false` | if true will use the [trickle DAG](https://godoc.org/github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-unixfs/importer/trickle) format for DAG generation |
 | wrapWithDirectory | `boolean` | `false` | Adds a wrapping node around the content |
@@ -252,7 +252,7 @@ An optional object which may have the following keys:
 | hashAlg | `String` | `'sha2-256'` | multihash hashing algorithm to use |
 | onlyHash | `boolean` | `false` | If true, will not add blocks to the blockstore |
 | pin | `boolean` | `true` | pin this object when adding |
-| progress | function | `undefined` | a function that will be called with the number of bytes added as a file is added to ipfs and the name of the file being added |
+| progress | function | `undefined` | a function that will be called with the number of bytes added as a file is added to ipfs and the path of the file being added |
 | rawLeaves | `boolean` | `false` | if true, DAG leaves will contain raw file data and not be wrapped in a protobuf |
 | shardSplitThreshold | `Number` | `1000` | Directories with more than this number of files will be created as HAMT-sharded directories |
 | trickle | `boolean` | `false` | if true will use the [trickle DAG](https://godoc.org/github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-unixfs/importer/trickle) format for DAG generation |

--- a/packages/interface-ipfs-core/src/add-all.js
+++ b/packages/interface-ipfs-core/src/add-all.js
@@ -171,6 +171,28 @@ module.exports = (common, options) => {
       expect(root.cid.toString()).to.equal(fixtures.directory.cid)
     })
 
+    it('should receive progress path as empty string when adding content without paths', async function () {
+      const content = (name) => fixtures.directory.files[name]
+      const progressSizes = {}
+
+      const dirs = [
+        content('pp.txt'),
+        content('holmes.txt'),
+        content('jungle.txt')
+      ]
+
+      const total = {
+        '': dirs.reduce((acc, curr) => acc + curr.length, 0)
+      }
+
+      const handler = (bytes, path) => {
+        progressSizes[path] = bytes
+      }
+
+      await drain(ipfs.addAll(dirs, { progress: handler }))
+      expect(progressSizes).to.deep.equal(total)
+    })
+
     it('should receive file name from progress event', async () => {
       const receivedNames = []
       function handler (p, name) {

--- a/packages/ipfs-core/src/components/add-all/index.js
+++ b/packages/ipfs-core/src/components/add-all/index.js
@@ -96,7 +96,6 @@ module.exports = ({ block, gcLock, preload, pin, options: constructorOptions }) 
 
         yield added
       }
-      yield * iterator
     } finally {
       releaseLock()
     }

--- a/packages/ipfs-core/src/components/add.js
+++ b/packages/ipfs-core/src/components/add.js
@@ -25,7 +25,7 @@ module.exports = ({ addAll }) => {
  * @property {string} [hashAlg] - multihash hashing algorithm to use (default: `'sha2-256'`)
  * @property {boolean} [onlyHash] - If true, will not add blocks to the blockstore (default: `false`)
  * @property {boolean} [pin] - pin this object when adding (default: `true`)
- * @property {Function} [progress] - a function that will be called with the byte length of chunks as a file is added to ipfs (default: `undefined`)
+ * @property {(bytes:number, path:string) => void} [progress] - a function that will be called with the number of bytes added as a file is added to ipfs and the path of the file being added
  * @property {boolean} [rawLeaves] - if true, DAG leaves will contain raw file data and not be wrapped in a protobuf (default: `false`)
  * @property {boolean} [trickle] - if true will use the [trickle DAG](https://godoc.org/github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-unixfs/importer/trickle) format for DAG generation (default: `false`)
  * @property {boolean} [wrapWithDirectory] - Adds a wrapping node around the content (default: `false`)

--- a/packages/ipfs-http-server/src/api/resources/files-regular.js
+++ b/packages/ipfs-http-server/src/api/resources/files-regular.js
@@ -260,7 +260,7 @@ exports.add = {
       multipart(request),
       async function * (source) {
         for await (const entry of source) {
-          currentFileName = entry.name || 'unknown'
+          currentFileName = entry.name || ''
 
           if (entry.type === 'file') {
             filesParsed = true


### PR DESCRIPTION
Aligns behaviour between js and go when no path is present during an import
- we now pass an empty string instead of `'unknown'`.