### PR TITLE
fix: make message-port-protocol non dev dependency

### DIFF
--- a/packages/ipfs-message-port-client/package.json
+++ b/packages/ipfs-message-port-client/package.json
@@ -43,7 +43,8 @@
   },
   "dependencies": {
     "browser-readablestream-to-it": "^1.0.1",
-    "cids": "^1.0.0"
+    "cids": "^1.0.0",
+    "ipfs-message-port-protocol": "^0.4.0"
   },
   "devDependencies": {
     "aegir": "^28.0.0",
@@ -51,7 +52,6 @@
     "interface-ipfs-core": "^0.142.0",
     "ipfs": "^0.52.0",
     "ipfs-core": "^0.2.0",
-    "ipfs-message-port-protocol": "^0.4.0",
     "ipfs-message-port-server": "^0.4.0",
     "ipld-dag-pb": "^0.20.0",
     "typescript": "^4.0.3"

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -45,13 +45,13 @@
   },
   "dependencies": {
     "cids": "^1.0.0",
-    "it-all": "^1.0.4"
+    "it-all": "^1.0.4",
+    "ipfs-message-port-protocol": "^0.4.0"
   },
   "devDependencies": {
     "@types/it-all": "^1.0.0",
     "aegir": "^28.0.0",
     "cross-env": "^7.0.0",
-    "ipfs-message-port-protocol": "^0.4.0",
     "typescript": "^4.0.3"
   },
   "engines": {


### PR DESCRIPTION
Fix message-port-client/server packages by declaring message-port-protocol as dependency that it is, instead of devDependency.