### PR TITLE
fix: correct raw leaves setting

### DIFF
--- a/packages/ipfs-cli/src/commands/add.js
+++ b/packages/ipfs-cli/src/commands/add.js
@@ -79,8 +79,7 @@ module.exports = {
     },
     'raw-leaves': {
       type: 'boolean',
-      describe: 'Use raw blocks for leaf nodes. (experimental)',
-      default: false
+      describe: 'Use raw blocks for leaf nodes. (experimental)'
     },
     'cid-version': {
       type: 'integer',
@@ -239,6 +238,10 @@ module.exports = {
       if (mtimeNsecs != null) {
         mtime.nsecs = mtimeNsecs
       }
+    }
+
+    if (options.rawLeaves == null) {
+      options.rawLeaves = cidVersion > 0
     }
 
     const source = file

--- a/packages/ipfs-cli/test/add.js
+++ b/packages/ipfs-cli/test/add.js
@@ -101,7 +101,8 @@ describe('add', () => {
 
     ipfs.addAll.withArgs(matchIterable(), {
       ...defaultOptions,
-      cidVersion: 1
+      cidVersion: 1,
+      rawLeaves: true
     }).returns([{
       cid,
       path: 'README.md'


### PR DESCRIPTION
If raw-leaves is unset, default to true if cid version is > 0.

This is in line with go-IPFS and is what the importer used to do internally.