### PR TITLE
chore: windows compat

### DIFF
--- a/examples/browser-browserify/package.json
+++ b/examples/browser-browserify/package.json
@@ -8,7 +8,7 @@
     "bundle": "browserify src/index.js > public/bundle.js",
     "serve": "http-server public -a 127.0.0.1 -p 8888",
     "start": "npm run bundle && npm run serve",
-    "clean": "rm -rf public/bundle.js",
+    "clean": "rimraf public/bundle.js",
     "test": "test-ipfs-example"
   },
   "keywords": [],
@@ -19,6 +19,7 @@
     "execa": "^4.0.3",
     "http-server": "^0.12.3",
     "ipfs": "^0.52.1",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3"
   },
   "browser": {

--- a/examples/browser-create-react-app/package.json
+++ b/examples/browser-create-react-app/package.json
@@ -12,6 +12,7 @@
     "tachyons": "^4.11.1"
   },
   "devDependencies": {
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3"
   },
   "scripts": {
@@ -19,7 +20,7 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "test-ipfs-example",
-    "clean": "rm -rf ./build"
+    "clean": "rimraf ./build"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/examples/browser-exchange-files/package.json
+++ b/examples/browser-exchange-files/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "clean": "rm -rf public/bundle.js",
+    "clean": "rimraf public/bundle.js",
     "bundle": "browserify public/app.js > public/bundle.js",
     "start": "http-server -c-1 -p 12345 public",
     "dev": "npm run bundle && npm run start",
@@ -20,6 +20,7 @@
   "dependencies": {
     "ipfs": "^0.52.1",
     "it-all": "^1.0.4",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3"
   },
   "browser": {

--- a/examples/browser-http-client-upload-file/package.json
+++ b/examples/browser-http-client-upload-file/package.json
@@ -4,7 +4,7 @@
   "description": "Upload file to IPFS via browser using js-ipfs-http-client with Webpack",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "parcel build index.html --public-url '.'",
     "start": "parcel index.html",
     "test": "test-ipfs-example"
@@ -22,6 +22,7 @@
     "parcel-bundler": "^1.12.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3"
   },
   "browserslist": [

--- a/examples/browser-mfs/package.json
+++ b/examples/browser-mfs/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "webpack",
     "start": "npm run build && http-server dist -a 127.0.0.1 -p 8888",
     "test": "test-ipfs-example"
@@ -15,6 +15,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "http-server": "^0.12.3",
+    "rimraf": "^3.0.2",
     "terser-webpack-plugin": "^1.2.1",
     "test-ipfs-example": "^2.0.3",
     "webpack": "^4.43.0",

--- a/examples/browser-parceljs/package.json
+++ b/examples/browser-parceljs/package.json
@@ -8,7 +8,7 @@
     "last 2 Chrome versions"
   ],
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "standard public/**/*.js",
     "start": "parcel public/index.html",
     "build": "parcel build public/index.html --public-url ./",
@@ -28,6 +28,7 @@
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "parcel-bundler": "^1.12.4",
+    "rimraf": "^3.0.2",
     "standard": "^13.1.0",
     "test-ipfs-example": "^2.0.3"
   }

--- a/examples/browser-readablestream/package.json
+++ b/examples/browser-readablestream/package.json
@@ -5,7 +5,7 @@
   "version": "2.0.1",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "webpack",
     "start": "npm run build && http-server dist -a 127.0.0.1 -p 8888",
     "test": "test-ipfs-example"
@@ -15,6 +15,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "http-server": "^0.12.3",
+    "rimraf": "^3.0.2",
     "terser-webpack-plugin": "^1.2.1",
     "test-ipfs-example": "^2.0.3",
     "webpack": "^4.43.0"

--- a/examples/browser-sharing-node-across-tabs/package.json
+++ b/examples/browser-sharing-node-across-tabs/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "webpack",
     "start": "node server.js",
     "test": "test-ipfs-example"
@@ -16,6 +16,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-loader": "^8.0.5",
     "copy-webpack-plugin": "^5.0.4",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/browser-vue/package.json
+++ b/examples/browser-vue/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
@@ -21,6 +21,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^6.2.1",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3",
     "vue-template-compiler": "^2.6.11"
   },

--- a/examples/browser-webpack/package.json
+++ b/examples/browser-webpack/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.1",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "webpack",
     "start": "node server.js",
     "test": "test-ipfs-example"
@@ -20,6 +20,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-hot-loader": "^4.12.21",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "parcel build index.html --public-url '.'",
     "start": "parcel index.html",
     "deploy": "ipfs add -r --quieter dist",
@@ -24,6 +24,7 @@
     "ipfs-css": "^0.13.1",
     "ipfs-http-client": "^48.1.1",
     "parcel-bundler": "^1.12.4",
+    "rimraf": "^3.0.2",
     "tachyons": "^4.11.1",
     "test-ipfs-example": "^2.0.3"
   },

--- a/examples/http-client-bundle-webpack/package.json
+++ b/examples/http-client-bundle-webpack/package.json
@@ -4,7 +4,7 @@
   "description": "Bundle js-ipfs-http-client with Webpack",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "webpack",
     "start": "node server.js",
     "test": "test-ipfs-example"
@@ -27,6 +27,7 @@
     "ipfs": "^0.52.1",
     "ipfsd-ctl": "^7.0.2",
     "react-hot-loader": "^4.12.21",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.11.0"

--- a/examples/http-client-name-api/package.json
+++ b/examples/http-client-name-api/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "build": "parcel build index.html --public-url '.'",
     "start": "parcel index.html -p 8888",
     "test": "test-ipfs-example"
@@ -20,6 +20,7 @@
     "go-ipfs": "^0.7.0",
     "ipfsd-ctl": "^7.0.2",
     "parcel-bundler": "^1.12.4",
+    "rimraf": "^3.0.2",
     "test-ipfs-example": "^2.0.3"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "lerna bootstrap",
     "link": "lerna link",
-    "reset": "lerna run clean && rm -rf packages/*/node_modules node_modules",
+    "reset": "lerna run clean && rimraf packages/*/node_modules node_modules",
     "test": "lerna run test",
     "test:node": "lerna run test:node",
     "test:browser": "lerna run test:browser",
@@ -34,7 +34,7 @@
     "release:pre:build": "NODE_ENV=production npm run build -- --scope={ipfs-core,ipfs,ipfs-http-client,ipfs-message-port-*}",
     "release:pre:add-examples": "json -I -f ./lerna.json -e \"this.packages.push('examples/*'); this.packages = [...new Set(this.packages)]\"",
     "release:pre:add-hoisted-modules": "json -I -f ./lerna.json -e \"this.command.bootstrap.nohoist = ['ipfs-css', 'tachyons']; this.command.bootstrap.nohoist = [...new Set(this.command.bootstrap.nohoist)]\"",
-    "release:pre:reinstall": "rm -rf node_modules */*/node_modules package-lock.json */*/package-lock.json && npm i && rm -rf package-lock.json */*/package-lock.json",
+    "release:pre:reinstall": "rimraf node_modules */*/node_modules package-lock.json */*/package-lock.json && npm i && rimraf package-lock.json */*/package-lock.json",
     "release:publish": "lerna publish",
     "docker:release": "run-s docker:release:*",
     "docker:release:build": "docker build . --no-cache --tag js-ipfs:latest --file ./Dockerfile.latest",
@@ -57,7 +57,8 @@
   "devDependencies": {
     "json": "^10.0.0",
     "lerna": "^3.22.0",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^3.0.2"
   },
   "repository": {
     "type": "git",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "clean": "rm -rf ./dist",
     "test": "echo 'No tests here'",
     "dep-check": "aegir dep-check"
   },

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -25,7 +25,7 @@
     "test": "npm run test:node",
     "test:node": "aegir test -t node",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i @types/yargs -i typescript -i cid-tool"
   },
   "dependencies": {

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -33,7 +33,7 @@
     "build": "npm run build:js && npm run build:types",
     "build:js": "aegir build",
     "build:types": "tsc --build",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i typescript"
   },
   "license": "MIT",
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "aegir": "^28.2.0",
+    "rimraf": "^3.0.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -34,7 +34,7 @@
     "build:js": "aegir build",
     "build:types": "tsc --build",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i typescript"
+    "dep-check": "aegir dep-check -i typescript -i rimraf"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -50,7 +50,7 @@
     "test:electron-renderer": "aegir test -t electron-renderer",
     "test:bootstrapers": "IPFS_TEST=bootstrapers aegir test -t browser -f test/bootstrapers.js",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i typescript -i interface-ipfs-core"
   },
   "dependencies": {

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -46,7 +46,7 @@
     "build:js": "aegir build",
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i typescript -i ipfs-core"
   },
   "dependencies": {
@@ -84,6 +84,7 @@
     "it-all": "^1.0.4",
     "it-concat": "^1.0.1",
     "nock": "^13.0.2",
+    "rimraf": "^3.0.2",
     "typescript": "^4.0.3"
   },
   "engines": {

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -47,7 +47,7 @@
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i typescript -i ipfs-core"
+    "dep-check": "aegir dep-check -i typescript -i ipfs-core -i rimraf"
   },
   "dependencies": {
     "any-signal": "^2.0.0",

--- a/packages/ipfs-http-gateway/package.json
+++ b/packages/ipfs-http-gateway/package.json
@@ -26,7 +26,7 @@
     "test:node": "aegir test -t node",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i typescript"
+    "dep-check": "aegir dep-check -i typescript -i rimraf"
   },
   "dependencies": {
     "@hapi/ammo": "^5.0.1",

--- a/packages/ipfs-http-gateway/package.json
+++ b/packages/ipfs-http-gateway/package.json
@@ -25,7 +25,7 @@
     "test": "npm run test:node",
     "test:node": "aegir test -t node",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i typescript"
   },
   "dependencies": {
@@ -48,6 +48,7 @@
   "devDependencies": {
     "aegir": "^28.2.0",
     "file-type": "^16.0.0",
+    "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
     "typescript": "^4.0.3"
   }

--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -25,7 +25,7 @@
     "test": "npm run test:node",
     "test:node": "aegir test -t node",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i typescript -i ipfs-http-client"
   },
   "dependencies": {
@@ -71,6 +71,7 @@
     "iso-random-stream": "^1.1.1",
     "it-to-buffer": "^1.0.2",
     "qs": "^6.9.4",
+    "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
     "stream-to-promise": "^3.0.0",
     "typescript": "^4.0.3"

--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -26,7 +26,7 @@
     "test:node": "aegir test -t node",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i typescript -i ipfs-http-client"
+    "dep-check": "aegir dep-check -i typescript -i ipfs-http-client -i rimraf"
   },
   "dependencies": {
     "@hapi/boom": "^9.1.0",

--- a/packages/ipfs-message-port-client/package.json
+++ b/packages/ipfs-message-port-client/package.json
@@ -38,7 +38,7 @@
     "build:bundle": "aegir build",
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i typescript -i ipfs-core"
   },
   "dependencies": {
@@ -51,6 +51,7 @@
     "ipfs": "^0.52.1",
     "ipfs-core": "^0.2.1",
     "ipfs-message-port-server": "^0.4.1",
+    "rimraf": "^3.0.2",
     "typescript": "^4.0.3"
   },
   "engines": {

--- a/packages/ipfs-message-port-client/package.json
+++ b/packages/ipfs-message-port-client/package.json
@@ -39,7 +39,7 @@
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i typescript -i ipfs-core"
+    "dep-check": "aegir dep-check -i typescript -i ipfs-core -i rimraf"
   },
   "dependencies": {
     "browser-readablestream-to-it": "^1.0.1",

--- a/packages/ipfs-message-port-protocol/package.json
+++ b/packages/ipfs-message-port-protocol/package.json
@@ -38,7 +38,7 @@
     "build:bundle": "aegir build",
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i typescript"
   },
   "dependencies": {
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "aegir": "^28.2.0",
+    "rimraf": "^3.0.2",
     "typescript": "^4.0.3",
     "uint8arrays": "^1.1.0"
   },

--- a/packages/ipfs-message-port-protocol/package.json
+++ b/packages/ipfs-message-port-protocol/package.json
@@ -39,7 +39,7 @@
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i typescript"
+    "dep-check": "aegir dep-check -i typescript -i rimraf"
   },
   "dependencies": {
     "cids": "^1.0.0",

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -40,7 +40,7 @@
     "build:bundle": "aegir build",
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i @types/* -i typescript"
   },
   "dependencies": {
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@types/it-all": "^1.0.0",
     "aegir": "^28.2.0",
+    "rimraf": "^3.0.2",
     "typescript": "^4.0.3"
   },
   "engines": {

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -41,7 +41,7 @@
     "build:types": "tsc --build",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i @types/* -i typescript"
+    "dep-check": "aegir dep-check -i @types/* -i typescript -i rimraf"
   },
   "dependencies": {
     "ipfs-message-port-protocol": "^0.4.1",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -34,7 +34,7 @@
     "test:external": "aegir test-dependant",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:interface:core -- -t node",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i cross-env -i typescript -i ipfs-interop -i electron-webrtc -i wrtc"
+    "dep-check": "aegir dep-check -i cross-env -i typescript -i ipfs-interop -i electron-webrtc -i wrtc -i rimraf"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -33,7 +33,7 @@
     "test:interop": "cross-env IPFS_JS_EXEC=$PWD/src/cli.js IPFS_JS_MODULE=$PWD IPFS_JS_HTTP_MODULE=$PWD/../ipfs-http-client IPFS_REUSEPORT=false ipfs-interop",
     "test:external": "aegir test-dependant",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:interface:core -- -t node",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "dep-check": "aegir dep-check -i cross-env -i typescript -i ipfs-interop -i electron-webrtc -i wrtc"
   },
   "dependencies": {
@@ -57,6 +57,7 @@
     "iso-url": "^1.0.0",
     "libp2p-webrtc-star": "^0.20.1",
     "merge-options": "^2.0.0",
+    "rimraf": "^3.0.2",
     "typescript": "^4.0.3",
     "wrtc": "^0.4.6"
   },


### PR DESCRIPTION
`rm -rf` isn't a thing on windows - use the cross-platform `rimraf` module instead.