### PR TITLE
feat: announce addresses via config

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -10,6 +10,7 @@ The js-ipfs config file is a JSON document located in the root directory of the 
   - [`Delegates`](#delegates)
   - [`Gateway`](#gateway)
   - [`Swarm`](#swarm)
+  - [`Announce`](#announce)
 - [`Bootstrap`](#bootstrap)
 - [`Datastore`](#datastore)
   - [`Spec`](#spec)
@@ -109,6 +110,15 @@ Default:
   "/ip4/0.0.0.0/tcp/4002",
   "/ip4/127.0.0.1/tcp/4003/ws"
 ]
+```
+
+### `Announce`
+
+Array of [Multiaddr](https://github.com/multiformats/multiaddr/) describing which addresses to [announce](https://github.com/libp2p/js-libp2p/tree/master/src/address-manager#announce-addresses) over the network.
+
+Default:
+```json
+[]
 ```
 
 ## `Bootstrap`

--- a/packages/ipfs-core/src/components/libp2p.js
+++ b/packages/ipfs-core/src/components/libp2p.js
@@ -101,7 +101,9 @@ function getLibp2pOptions ({ options, config, datastore, keys, keychainConfig, p
       }
     },
     addresses: {
-      listen: multiaddrs
+      listen: multiaddrs,
+      announce: get(options, 'addresses.announce',
+        get(config, 'Addresses.Announce', []))
     },
     connectionManager: get(options, 'connectionManager', {
       maxConnections: get(options, 'config.Swarm.ConnMgr.HighWater',

--- a/packages/ipfs-core/src/runtime/config-browser.js
+++ b/packages/ipfs-core/src/runtime/config-browser.js
@@ -4,6 +4,7 @@ module.exports = () => ({
   Addresses: {
     Swarm: [
     ],
+    Announce: [],
     API: '',
     Gateway: '',
     Delegates: [

--- a/packages/ipfs-core/src/runtime/config-nodejs.js
+++ b/packages/ipfs-core/src/runtime/config-nodejs.js
@@ -6,6 +6,7 @@ module.exports = () => ({
       '/ip4/0.0.0.0/tcp/4002',
       '/ip4/127.0.0.1/tcp/4003/ws'
     ],
+    Announce: [],
     API: '/ip4/127.0.0.1/tcp/5002',
     Gateway: '/ip4/127.0.0.1/tcp/9090',
     Delegates: [

--- a/packages/ipfs-core/test/libp2p.spec.js
+++ b/packages/ipfs-core/test/libp2p.spec.js
@@ -158,6 +158,8 @@ describe('libp2p customization', function () {
     })
 
     it('should allow for overriding via options', async () => {
+      const annAddr = '/dns4/test.ipfs.io/tcp/443/wss'
+
       libp2p = libp2pComponent({
         peerId,
         repo: { datastore },
@@ -169,7 +171,10 @@ describe('libp2p customization', function () {
               transport: [DummyTransport],
               peerDiscovery: [DummyDiscovery]
             },
-            config: { relay: { enabled: false } }
+            config: { relay: { enabled: false } },
+            addresses: {
+              announce: [annAddr]
+            }
           }
         }
       })
@@ -183,10 +188,33 @@ describe('libp2p customization', function () {
       const discoveries = Array.from(libp2p._discovery.values())
       expect(discoveries).to.have.length(1)
       expect(discoveries[0] instanceof DummyDiscovery).to.be.true()
+
+      expect(libp2p.multiaddrs.map(m => m.toString())).to.include(annAddr)
     })
   })
 
   describe('config', () => {
+    it('should be able to specify Announce addresses', async () => {
+      const annAddr = '/dns4/test.ipfs.io/tcp/443/wss'
+
+      libp2p = libp2pComponent({
+        peerId,
+        repo: { datastore },
+        print: console.log, // eslint-disable-line no-console
+        config: {
+          ...testConfig,
+          Addresses: {
+            ...testConfig.Addresses,
+            Announce: [annAddr]
+          }
+        }
+      })
+
+      await libp2p.start()
+
+      expect(libp2p.multiaddrs.map(m => m.toString())).to.include(annAddr)
+    })
+
     it('should select gossipsub as pubsub router', async () => {
       libp2p = libp2pComponent({
         peerId,


### PR DESCRIPTION
This PR adds the ability to add announces addresses via the config file and create options.

This is really useful for browser contexts, so that other peers can announce their public addresses, like dns addresses.

Ref: https://github.com/ipfs/js-ipfs/issues/3400