### PR TITLE
chore: pin ts version

### DIFF
--- a/examples/types-use-ipfs-from-ts/package.json
+++ b/examples/types-use-ipfs-from-ts/package.json
@@ -5,7 +5,7 @@
     "ipfs": "^0.52.1"
   },
   "devDependencies": {
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   },
   "scripts": {
     "test": "tsc --noEmit"

--- a/examples/types-use-ipfs-from-typed-js/package.json
+++ b/examples/types-use-ipfs-from-typed-js/package.json
@@ -5,7 +5,7 @@
     "ipfs": "^0.52.1"
   },
   "devDependencies": {
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   },
   "scripts": {
     "test": "tsc --noEmit"

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -82,7 +82,7 @@
     "sinon": "^9.0.3",
     "string-argv": "^0.3.1",
     "temp-write": "^4.0.0",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   },
   "optionalDependencies": {
     "prom-client": "^12.0.0",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -56,6 +56,6 @@
   "devDependencies": {
     "aegir": "^28.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   }
 }

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -128,6 +128,6 @@
     "nanoid": "^3.1.12",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   }
 }

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -85,7 +85,7 @@
     "it-concat": "^1.0.1",
     "nock": "^13.0.2",
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   },
   "engines": {
     "node": ">=10.3.0",

--- a/packages/ipfs-http-gateway/package.json
+++ b/packages/ipfs-http-gateway/package.json
@@ -50,6 +50,6 @@
     "file-type": "^16.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   }
 }

--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -74,7 +74,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
     "stream-to-promise": "^3.0.0",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   },
   "optionalDependencies": {
     "prom-client": "^12.0.0"

--- a/packages/ipfs-message-port-client/package.json
+++ b/packages/ipfs-message-port-client/package.json
@@ -52,7 +52,7 @@
     "ipfs-core": "^0.2.1",
     "ipfs-message-port-server": "^0.4.1",
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   },
   "engines": {
     "node": ">=10.3.0",

--- a/packages/ipfs-message-port-protocol/package.json
+++ b/packages/ipfs-message-port-protocol/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "aegir": "^28.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.3",
+    "typescript": "4.0.x",
     "uint8arrays": "^1.1.0"
   },
   "engines": {

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -51,7 +51,7 @@
     "@types/it-all": "^1.0.0",
     "aegir": "^28.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.3"
+    "typescript": "4.0.x"
   },
   "engines": {
     "node": ">=10.3.0",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -58,7 +58,7 @@
     "libp2p-webrtc-star": "^0.20.1",
     "merge-options": "^2.0.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.3",
+    "typescript": "4.0.x",
     "wrtc": "^0.4.6"
   },
   "typesVersions": {


### PR DESCRIPTION
The TypeScript project [release breaking changes as minor versions](https://github.com/microsoft/TypeScript/issues/41563#issuecomment-730704643) so pin to `4.0.x` until we can do the refactoring needed to upgrade to `4.1.x`.