### PR TITLE
fix: do not write to prefix outside of output directory

### DIFF
--- a/packages/ipfs-cli/src/commands/get.js
+++ b/packages/ipfs-cli/src/commands/get.js
@@ -18,19 +18,28 @@ module.exports = {
       type: 'string',
       default: process.cwd()
     },
+    force: {
+      alias: 'f',
+      type: 'boolean',
+      default: false
+    },
     timeout: {
       type: 'string',
       coerce: parseDuration
     }
   },
 
-  async handler ({ ctx: { ipfs, print }, ipfsPath, output, timeout }) {
+  async handler ({ ctx: { ipfs, print }, ipfsPath, output, force, timeout }) {
     print(`Saving file(s) ${ipfsPath}`)
 
     for await (const file of ipfs.get(ipfsPath, {
       timeout
     })) {
       const fullFilePath = path.join(output, file.path)
+
+      if (fullFilePath.substring(0, output.length) !== output && !force) {
+        throw new Error(`File prefix invalid, would write to files outside of ${output}, pass --force to override`)
+      }
 
       if (file.content) {
         await fs.promises.mkdir(path.join(output, path.dirname(file.path)), { recursive: true })


### PR DESCRIPTION
Adds a check to prevent overwriting files not under the output
directory, which you can override with a `--force` option.