### PR TITLE
fix: strip control characters from user output

### DIFF
--- a/packages/ipfs-cli/src/commands/cat.js
+++ b/packages/ipfs-cli/src/commands/cat.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
-const uint8ArrayToString = require('uint8arrays/to-string')
 
 module.exports = {
   command: 'cat <ipfsPath>',
@@ -27,7 +26,7 @@ module.exports = {
 
   async handler ({ ctx: { ipfs, print }, ipfsPath, offset, length, timeout }) {
     for await (const buf of ipfs.cat(ipfsPath, { offset, length, timeout })) {
-      print.write(uint8ArrayToString(buf))
+      print.write(buf)
     }
   }
 }

--- a/packages/ipfs-cli/src/commands/dns.js
+++ b/packages/ipfs-cli/src/commands/dns.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../utils')
 
 module.exports = {
   command: 'dns <domain>',
@@ -25,6 +28,6 @@ module.exports = {
 
   async handler ({ ctx: { ipfs, print }, domain, recursive, format, timeout }) {
     const path = await ipfs.dns(domain, { recursive, format, timeout })
-    print(path)
+    print(stripControlCharacters(path))
   }
 }

--- a/packages/ipfs-cli/src/commands/files/ls.js
+++ b/packages/ipfs-cli/src/commands/files/ls.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const {
-  asBoolean
+  asBoolean,
+  stripControlCharacters
 } = require('../../utils')
 const formatMode = require('ipfs-core-utils/src/files/format-mode')
 const formatMtime = require('ipfs-core-utils/src/files/format-mtime')
@@ -37,10 +38,12 @@ module.exports = {
     timeout
   }) {
     const printListing = file => {
+      const name = stripControlCharacters(file.name)
+
       if (long) {
-        print(`${formatMode(file.mode, file.type === 1)}\t${formatMtime(file.mtime)}\t${file.name}\t${file.cid.toString(cidBase)}\t${file.size}`)
+        print(`${formatMode(file.mode, file.type === 1)}\t${formatMtime(file.mtime)}\t${name}\t${file.cid.toString(cidBase)}\t${file.size}`)
       } else {
-        print(file.name)
+        print(name)
       }
     }
 

--- a/packages/ipfs-cli/src/commands/get.js
+++ b/packages/ipfs-cli/src/commands/get.js
@@ -6,6 +6,9 @@ const toIterable = require('stream-to-it')
 const { pipe } = require('it-pipe')
 const { map } = require('streaming-iterables')
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../utils')
 
 module.exports = {
   command: 'get <ipfsPath>',
@@ -30,7 +33,7 @@ module.exports = {
   },
 
   async handler ({ ctx: { ipfs, print }, ipfsPath, output, force, timeout }) {
-    print(`Saving file(s) ${ipfsPath}`)
+    print(`Saving file(s) ${stripControlCharacters(ipfsPath)}`)
 
     for await (const file of ipfs.get(ipfsPath, {
       timeout

--- a/packages/ipfs-cli/src/commands/key/gen.js
+++ b/packages/ipfs-cli/src/commands/key/gen.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'gen <name>',
@@ -31,6 +34,6 @@ module.exports = {
       size,
       timeout
     })
-    print(`generated ${key.id} ${key.name}`)
+    print(`generated ${key.id} ${stripControlCharacters(key.name)}`)
   }
 }

--- a/packages/ipfs-cli/src/commands/key/list.js
+++ b/packages/ipfs-cli/src/commands/key/list.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'list',
@@ -18,6 +21,6 @@ module.exports = {
     const keys = await ipfs.key.list({
       timeout
     })
-    keys.forEach((ki) => print(`${ki.id} ${ki.name}`))
+    keys.forEach((ki) => print(`${ki.id} ${stripControlCharacters(ki.name)}`))
   }
 }

--- a/packages/ipfs-cli/src/commands/key/rename.js
+++ b/packages/ipfs-cli/src/commands/key/rename.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'rename <name> <newName>',
@@ -18,6 +21,6 @@ module.exports = {
     const res = await ipfs.key.rename(name, newName, {
       timeout
     })
-    print(`renamed to ${res.id} ${res.now}`)
+    print(`renamed to ${res.id} ${stripControlCharacters(res.now)}`)
   }
 }

--- a/packages/ipfs-cli/src/commands/key/rm.js
+++ b/packages/ipfs-cli/src/commands/key/rm.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'rm <name>',
@@ -18,6 +21,6 @@ module.exports = {
     const key = await ipfs.key.rm(name, {
       timeout
     })
-    print(`${key.id} ${key.name}`)
+    print(`${key.id} ${stripControlCharacters(key.name)}`)
   }
 }

--- a/packages/ipfs-cli/src/commands/ls.js
+++ b/packages/ipfs-cli/src/commands/ls.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const multibase = require('multibase')
-const { rightpad } = require('../utils')
+const { rightpad, stripControlCharacters } = require('../utils')
 const { cidToString } = require('ipfs-core-utils/src/cid')
 const formatMode = require('ipfs-core-utils/src/files/format-mode')
 const formatMtime = require('ipfs-core-utils/src/files/format-mtime')
@@ -65,6 +65,7 @@ module.exports = {
     }
 
     const printLink = (mode, mtime, cid, size, name, depth = 0) => {
+      name = stripControlCharacters(name)
       const widths = getMaxWidths(mode, mtime, cid, size, name)
       // todo: fix this by resolving https://github.com/ipfs/js-ipfs-unixfs-exporter/issues/24
       const padding = Math.max(depth - pathParts.length, 0)
@@ -82,7 +83,7 @@ module.exports = {
       const mtime = formatMtime(link.mtime)
       const cid = cidToString(link.cid, { base: cidBase })
       const size = link.size ? String(link.size) : '-'
-      const name = link.type === 'dir' ? `${link.name || ''}/` : link.name
+      const name = stripControlCharacters(link.type === 'dir' ? `${link.name || ''}/` : link.name)
 
       if (first) {
         first = false

--- a/packages/ipfs-cli/src/commands/name/publish.js
+++ b/packages/ipfs-cli/src/commands/name/publish.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'publish <ipfsPath>',
@@ -45,6 +48,6 @@ module.exports = {
       ttl,
       timeout
     })
-    print(`Published to ${result.name}: ${result.value}`)
+    print(`Published to ${stripControlCharacters(result.name)}: ${result.value}`)
   }
 }

--- a/packages/ipfs-cli/src/commands/name/pubsub/subs.js
+++ b/packages/ipfs-cli/src/commands/name/pubsub/subs.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../../utils')
 
 module.exports = {
   command: 'subs',
@@ -18,6 +21,6 @@ module.exports = {
     const result = await ipfs.name.pubsub.subs({
       timeout
     })
-    result.forEach(s => print(s))
+    result.forEach(s => print(stripControlCharacters(s)))
   }
 }

--- a/packages/ipfs-cli/src/commands/object/get.js
+++ b/packages/ipfs-cli/src/commands/object/get.js
@@ -4,6 +4,9 @@ const multibase = require('multibase')
 const { cidToString } = require('ipfs-core-utils/src/cid')
 const parseDuration = require('parse-duration').default
 const uint8ArrayToString = require('uint8arrays/to-string')
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'get <key>',
@@ -52,7 +55,7 @@ module.exports = {
       Size: node.Size,
       Links: node.Links.map((l) => {
         return {
-          Name: l.Name,
+          Name: stripControlCharacters(l.Name),
           Size: l.Tsize,
           Hash: cidToString(l.Hash, { base: cidBase, upgrade: false })
         }

--- a/packages/ipfs-cli/src/commands/object/links.js
+++ b/packages/ipfs-cli/src/commands/object/links.js
@@ -3,6 +3,9 @@
 const multibase = require('multibase')
 const { cidToString } = require('ipfs-core-utils/src/cid')
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'links <key>',
@@ -26,7 +29,7 @@ module.exports = {
 
     links.forEach((link) => {
       const cidStr = cidToString(link.Hash, { base: cidBase, upgrade: false })
-      print(`${cidStr} ${link.Tsize} ${link.Name}`)
+      print(`${cidStr} ${link.Tsize} ${stripControlCharacters(link.Name)}`)
     })
   }
 }

--- a/packages/ipfs-cli/src/commands/pin/ls.js
+++ b/packages/ipfs-cli/src/commands/pin/ls.js
@@ -4,6 +4,9 @@ const multibase = require('multibase')
 const all = require('it-all')
 const { cidToString } = require('ipfs-core-utils/src/cid')
 const parseDuration = require('parse-duration').default
+const {
+  makeEntriesPrintable
+} = require('../../utils')
 
 module.exports = {
   // bracket syntax with '...' tells yargs to optionally accept a list
@@ -48,8 +51,8 @@ module.exports = {
       if (!quiet) {
         line += ` ${res.type}`
 
-        if (res.comments) {
-          line += ` ${res.comments}`
+        if (res.metadata) {
+          line += ` ${JSON.stringify(makeEntriesPrintable(res.metadata))}`
         }
       }
       print(line)

--- a/packages/ipfs-cli/src/commands/pubsub/ls.js
+++ b/packages/ipfs-cli/src/commands/pubsub/ls.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../../utils')
 
 module.exports = {
   command: 'ls',
@@ -18,6 +21,6 @@ module.exports = {
     const subscriptions = await ipfs.pubsub.ls({
       timeout
     })
-    subscriptions.forEach(sub => print(sub))
+    subscriptions.forEach(sub => print(stripControlCharacters(sub)))
   }
 }

--- a/packages/ipfs-cli/src/commands/resolve.js
+++ b/packages/ipfs-cli/src/commands/resolve.js
@@ -2,6 +2,9 @@
 
 const multibase = require('multibase')
 const parseDuration = require('parse-duration').default
+const {
+  stripControlCharacters
+} = require('../utils')
 
 module.exports = {
   command: 'resolve <name>',
@@ -25,8 +28,8 @@ module.exports = {
     }
   },
 
-  async handler ({ ctx: { ipfs }, name, recursive, cidBase, timeout }) {
+  async handler ({ ctx: { print, ipfs }, name, recursive, cidBase, timeout }) {
     const res = await ipfs.resolve(name, { recursive, cidBase, timeout })
-    return res
+    print(stripControlCharacters(res))
   }
 }

--- a/packages/ipfs-cli/src/utils.js
+++ b/packages/ipfs-cli/src/utils.js
@@ -195,6 +195,8 @@ const coerceMtimeNsecs = (value) => {
   return value
 }
 
+const DEL = 127
+
 /**
  * Strip control characters from a string
  *
@@ -204,7 +206,11 @@ const coerceMtimeNsecs = (value) => {
 const stripControlCharacters = (str) => {
   return (str || '')
     .split('')
-    .filter((c) => c.charCodeAt(0) > 31)
+    .filter((c) => {
+      const charCode = c.charCodeAt(0)
+
+      return charCode > 31 && charCode !== DEL
+    })
     .join('')
 }
 
@@ -228,7 +234,9 @@ const escapeControlCharacters = (str) => {
   return (str || '')
     .split('')
     .map((c) => {
-      if (c.charCodeAt(0) > 31) {
+      const charCode = c.charCodeAt(0)
+
+      if (charCode > 31 && charCode !== DEL) {
         return c
       }
 

--- a/packages/ipfs-cli/src/utils.js
+++ b/packages/ipfs-cli/src/utils.js
@@ -251,8 +251,8 @@ const escapeControlCharacters = (str) => {
  * Removes control characters from all key/values and stringifies
  * CID properties
  *
- * @param {object} obj - a string to strip control characters from
- * @param {string} cidBase - a string to strip control characters from
+ * @param {object} obj - all keys/values in this object will be have control characters stripped
+ * @param {string} cidBase - any encountered CIDs will be stringified using this base
  * @returns {object}
  */
 const makeEntriesPrintable = (obj, cidBase = 'base58btc') => {

--- a/packages/ipfs-cli/src/utils.js
+++ b/packages/ipfs-cli/src/utils.js
@@ -7,6 +7,8 @@ const log = require('debug')('ipfs:cli:utils')
 const Progress = require('progress')
 const byteman = require('byteman')
 const IPFS = require('ipfs-core')
+const CID = require('cids')
+const { cidToString } = require('ipfs-core-utils/src/cid')
 
 const getRepoPath = () => {
   return process.env.IPFS_PATH || path.join(os.homedir(), '/.jsipfs')
@@ -37,8 +39,10 @@ const print = (msg, includeNewline = true, isError = false) => {
     if (msg === undefined) {
       msg = ''
     }
+    msg = msg.toString()
     msg = includeNewline ? msg + '\n' : msg
     const outStream = isError ? process.stderr : process.stdout
+
     outStream.write(msg)
   }
 }
@@ -191,6 +195,93 @@ const coerceMtimeNsecs = (value) => {
   return value
 }
 
+/**
+ * Strip control characters from a string
+ *
+ * @param {string} str - a string to strip control characters from
+ * @returns {string}
+ */
+const stripControlCharacters = (str) => {
+  return (str || '')
+    .split('')
+    .filter((c) => c.charCodeAt(0) > 31)
+    .join('')
+}
+
+/**
+ * Escape control characters in a string
+ *
+ * @param {string} str - a string to escape control characters in
+ * @returns {string}
+ */
+const escapeControlCharacters = (str) => {
+  const escapes = {
+    '00': '\\0',
+    '08': '\\b',
+    '09': '\\t',
+    '0A': '\\n',
+    '0B': '\\v',
+    '0C': '\\f',
+    '0D': '\\r'
+  }
+
+  return (str || '')
+    .split('')
+    .map((c) => {
+      if (c.charCodeAt(0) > 31) {
+        return c
+      }
+
+      const hex = Number(c).toString(16).padStart(2, '0')
+
+      return escapes[hex] || `\\x${hex}`
+    })
+    .join('')
+}
+
+/**
+ * Removes control characters from all key/values and stringifies
+ * CID properties
+ *
+ * @param {object} obj - a string to strip control characters from
+ * @param {string} cidBase - a string to strip control characters from
+ * @returns {object}
+ */
+const makeEntriesPrintable = (obj, cidBase = 'base58btc') => {
+  if (CID.isCID(obj)) {
+    return { '/': cidToString(obj, { base: cidBase }) }
+  }
+
+  if (typeof obj === 'string') {
+    return stripControlCharacters(obj)
+  }
+
+  if (typeof obj === 'number' || obj == null || obj === true || obj === false) {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    const output = []
+
+    for (const key of obj) {
+      output.push(makeEntriesPrintable(key, cidBase))
+    }
+
+    return output
+  }
+
+  const output = {}
+
+  Object.entries(obj)
+    .forEach(([key, value]) => {
+      const outputKey = stripControlCharacters(key)
+
+      output[outputKey] = makeEntriesPrintable(value, cidBase)
+    })
+
+  return output
+}
+
 module.exports = {
   getIpfs,
   isDaemonOn,
@@ -204,5 +295,8 @@ module.exports = {
   asOctal,
   asMtimeFromSeconds,
   coerceMtime,
-  coerceMtimeNsecs
+  coerceMtimeNsecs,
+  stripControlCharacters,
+  escapeControlCharacters,
+  makeEntriesPrintable
 }

--- a/packages/ipfs-cli/test/add.js
+++ b/packages/ipfs-cli/test/add.js
@@ -59,8 +59,19 @@ describe('add', () => {
     }])
 
     const out = await cli('add --progress false README.md', { ipfs })
-    expect(out)
-      .to.equal(`added ${cid} README.md\n`)
+    expect(out).to.equal(`added ${cid} README.md\n`)
+  })
+
+  it('should strip control characters from paths when add a file', async () => {
+    const cid = new CID('QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB')
+
+    ipfs.addAll.withArgs(matchIterable(), defaultOptions).returns([{
+      cid: new CID(cid),
+      path: 'R\b\n\tEADME.md'
+    }])
+
+    const out = await cli('add --progress false README.md', { ipfs })
+    expect(out).to.equal(`added ${cid} README.md\n`)
   })
 
   it('adds a file path with progress', async () => {
@@ -244,7 +255,7 @@ describe('add', () => {
     }])
 
     const out = await cli('add --silent README.md', { ipfs })
-    expect(out).to.equal('')
+    expect(out).to.be.empty()
   })
 
   it('add --only-hash outputs correct hash', async () => {

--- a/packages/ipfs-cli/test/bitswap.js
+++ b/packages/ipfs-cli/test/bitswap.js
@@ -57,7 +57,7 @@ describe('bitswap', () => {
       ipfs.bitswap.wantlistForPeer.withArgs(peerId, defaultOptions).resolves([])
 
       const out = await cli(`bitswap wantlist ${peerId}`, { ipfs })
-      expect(out).to.eql('')
+      expect(out).to.be.empty()
     })
 
     it('wantlist with a timeout', async () => {
@@ -67,7 +67,7 @@ describe('bitswap', () => {
       }).resolves([])
 
       const out = await cli('bitswap wantlist --timeout=1s', { ipfs })
-      expect(out).to.eql('')
+      expect(out).to.be.empty()
     })
 
     it('wantlist for peer with a timeout', async () => {
@@ -77,7 +77,7 @@ describe('bitswap', () => {
       }).resolves([])
 
       const out = await cli(`bitswap wantlist ${peerId} --timeout=1s`, { ipfs })
-      expect(out).to.eql('')
+      expect(out).to.be.empty()
     })
   })
 

--- a/packages/ipfs-cli/test/block.js
+++ b/packages/ipfs-cli/test/block.js
@@ -212,7 +212,7 @@ describe('block', () => {
       }])
 
       const out = await cli('block rm --quiet QmZjTnYw2TFhn9Nn7tjmPSoTBoY7YRkwPzwSrSbabY24Kp', { ipfs })
-      expect(out).to.eql('')
+      expect(out).to.be.empty()
     })
 
     it('rm force', async () => {

--- a/packages/ipfs-cli/test/cat.js
+++ b/packages/ipfs-cli/test/cat.js
@@ -6,7 +6,6 @@ const CID = require('cids')
 const cli = require('./utils/cli')
 const sinon = require('sinon')
 const uint8ArrayFromString = require('uint8arrays/from-string')
-const uint8ArrayToString = require('uint8arrays/to-string')
 
 const defaultOptions = {
   offset: undefined,
@@ -29,8 +28,8 @@ describe('cat', () => {
 
     ipfs.cat.withArgs(cid.toString(), defaultOptions).returns([buf])
 
-    const out = await cli(`cat ${cid}`, { ipfs })
-    expect(out).to.equal(uint8ArrayToString(buf))
+    const out = await cli(`cat ${cid}`, { ipfs, raw: true })
+    expect(out).to.deep.equal(buf)
   })
 
   it('cat part of a file using `count`', async () => {
@@ -43,8 +42,8 @@ describe('cat', () => {
       length: 5
     }).returns([buf])
 
-    const out = await cli('cat QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB --offset 21 --count 5', { ipfs })
-    expect(out).to.equal(uint8ArrayToString(buf))
+    const out = await cli('cat QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB --offset 21 --count 5', { ipfs, raw: true })
+    expect(out).to.deep.equal(buf)
   })
 
   it('cat part of a file using `length`', async () => {
@@ -57,8 +56,8 @@ describe('cat', () => {
       length: 5
     }).returns([buf])
 
-    const out = await cli('cat QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB --offset 21 --length 5', { ipfs })
-    expect(out).to.equal(uint8ArrayToString(buf))
+    const out = await cli('cat QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB --offset 21 --length 5', { ipfs, raw: true })
+    expect(out).to.deep.equal(buf)
   })
 
   it('cat non-existent file', async () => {
@@ -80,7 +79,7 @@ describe('cat', () => {
       timeout: 1000
     }).returns([buf])
 
-    const out = await cli(`cat ${cid} --timeout=1s`, { ipfs })
-    expect(out).to.equal(uint8ArrayToString(buf))
+    const out = await cli(`cat ${cid} --timeout=1s`, { ipfs, raw: true })
+    expect(out).to.deep.equal(buf)
   })
 })

--- a/packages/ipfs-cli/test/dag.js
+++ b/packages/ipfs-cli/test/dag.js
@@ -11,7 +11,9 @@ const uint8ArrayFromString = require('uint8arrays/from-string')
 const uint8ArrayToString = require('uint8arrays/to-string')
 
 describe('dag', () => {
-  const cid = new CID('Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z')
+  const dagPbCid = new CID('Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z')
+  const rawCid = new CID(1, 'raw', dagPbCid.multihash)
+  const dagCborCid = new CID(1, 'dag-cbor', dagPbCid.multihash)
   let ipfs
 
   beforeEach(() => {
@@ -31,16 +33,117 @@ describe('dag', () => {
       path: undefined
     }
 
-    it('should get a node', async () => {
+    it('should get a raw node', async () => {
       const result = {
         value: uint8ArrayFromString('hello world')
       }
 
-      ipfs.dag.get.withArgs(cid, defaultOptions).returns(result)
+      ipfs.dag.get.withArgs(rawCid, defaultOptions).returns(result)
 
-      const out = await cli(`dag get ${cid}`, { ipfs })
+      const out = await cli(`dag get ${rawCid} --data-enc base16`, { ipfs })
 
-      expect(out).to.be.eql('0x' + uint8ArrayToString(result.value, 'base16') + '\n')
+      expect(out).to.equal(uint8ArrayToString(result.value, 'base16') + '\n')
+    })
+
+    it('should get a dag-pb node', async () => {
+      const result = {
+        value: {
+          Data: Buffer.from([0, 1, 3]),
+          Links: [{
+            Hash: dagCborCid,
+            Name: 'foo',
+            Size: 10
+          }]
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagPbCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagPbCid}`, { ipfs })
+
+      expect(out).to.equal(`{"data":"AAED","links":[{"Name":"foo","Size":10,"Cid":{"/":"${dagCborCid.toString()}"}}]}\n`)
+    })
+
+    it('should get a dag-pb node and specify data encoding', async () => {
+      const result = {
+        value: {
+          Data: Buffer.from([0, 1, 3]),
+          Links: [{
+            Hash: dagCborCid,
+            Name: 'foo',
+            Size: 10
+          }]
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagPbCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagPbCid} --data-enc base16`, { ipfs })
+
+      expect(out).to.equal(`{"data":"000103","links":[{"Name":"foo","Size":10,"Cid":{"/":"${dagCborCid.toString()}"}}]}\n`)
+    })
+
+    it('should get a dag-pb node and specify CID encoding', async () => {
+      const result = {
+        value: {
+          Data: Buffer.from([0, 1, 3]),
+          Links: [{
+            Hash: dagCborCid,
+            Name: 'foo',
+            Size: 10
+          }]
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagPbCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagPbCid} --cid-base base16`, { ipfs })
+
+      expect(out).to.equal(`{"data":"AAED","links":[{"Name":"foo","Size":10,"Cid":{"/":"${dagCborCid.toString('base16')}"}}]}\n`)
+    })
+
+    it('should get a dag-cbor node', async () => {
+      const result = {
+        value: {
+          foo: 'bar'
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagCborCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagCborCid}`, { ipfs })
+
+      expect(out).to.equal('{"foo":"bar"}\n')
+    })
+
+    it('should get a dag-cbor node with a nested CID', async () => {
+      const result = {
+        value: {
+          foo: 'bar',
+          baz: dagPbCid
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagCborCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagCborCid}`, { ipfs })
+
+      expect(out).to.equal(`{"foo":"bar","baz":{"/":"${dagPbCid}"}}\n`)
+    })
+
+    it('should get a dag-cbor node with a nested CID and change the encoding', async () => {
+      const result = {
+        value: {
+          foo: 'bar',
+          baz: rawCid
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagCborCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagCborCid} --cid-base=base64`, { ipfs })
+
+      expect(out).to.equal(`{"foo":"bar","baz":{"/":"${rawCid.toString('base64')}"}}\n`)
     })
 
     it('should get a node with a deep path', async () => {
@@ -49,14 +152,14 @@ describe('dag', () => {
         value: uint8ArrayFromString('hello world')
       }
 
-      ipfs.dag.get.withArgs(cid, {
+      ipfs.dag.get.withArgs(rawCid, {
         ...defaultOptions,
         path
       }).returns(result)
 
-      const out = await cli(`dag get ${cid}${path}`, { ipfs })
+      const out = await cli(`dag get ${rawCid}${path} --data-enc base16`, { ipfs })
 
-      expect(out).to.be.eql('0x' + uint8ArrayToString(result.value, 'base16') + '\n')
+      expect(out).to.be.eql(uint8ArrayToString(result.value, 'base16') + '\n')
     })
 
     it('should get a node with a deep path and an ipfs prefix', async () => {
@@ -65,14 +168,14 @@ describe('dag', () => {
         value: uint8ArrayFromString('hello world')
       }
 
-      ipfs.dag.get.withArgs(cid, {
+      ipfs.dag.get.withArgs(rawCid, {
         ...defaultOptions,
         path
       }).returns(result)
 
-      const out = await cli(`dag get /ipfs/${cid}${path}`, { ipfs })
+      const out = await cli(`dag get /ipfs/${rawCid}${path} --data-enc base16`, { ipfs })
 
-      expect(out).to.be.eql('0x' + uint8ArrayToString(result.value, 'base16') + '\n')
+      expect(out).to.be.eql(uint8ArrayToString(result.value, 'base16') + '\n')
     })
 
     it('should get a node with local resolve', async () => {
@@ -80,16 +183,16 @@ describe('dag', () => {
         value: uint8ArrayFromString('hello world')
       }
 
-      ipfs.dag.get.withArgs(cid, {
+      ipfs.dag.get.withArgs(rawCid, {
         ...defaultOptions,
         localResolve: true
       }).returns(result)
 
-      const out = await cli(`dag get ${cid} --local-resolve`, { ipfs })
+      const out = await cli(`dag get ${rawCid} --local-resolve --data-enc base16`, { ipfs })
 
       expect(out).to.include('resolving path within the node only\n')
       expect(out).to.include('remainder path: n/a\n')
-      expect(out).to.include('0x' + uint8ArrayToString(result.value, 'base16') + '\n')
+      expect(out).to.include(uint8ArrayToString(result.value, 'base16') + '\n')
     })
 
     it('should get a node with a timeout', async () => {
@@ -97,14 +200,46 @@ describe('dag', () => {
         value: uint8ArrayFromString('hello world')
       }
 
-      ipfs.dag.get.withArgs(cid, {
+      ipfs.dag.get.withArgs(rawCid, {
         ...defaultOptions,
         timeout: 1000
       }).returns(result)
 
-      const out = await cli(`dag get ${cid} --timeout=1s`, { ipfs })
+      const out = await cli(`dag get ${rawCid} --timeout=1s --data-enc base16`, { ipfs })
 
-      expect(out).to.be.eql('0x' + uint8ArrayToString(result.value, 'base16') + '\n')
+      expect(out).to.be.eql(uint8ArrayToString(result.value, 'base16') + '\n')
+    })
+
+    it('should strip control characters from dag-pb nodes', async () => {
+      const result = {
+        value: {
+          Links: [{
+            Hash: dagPbCid,
+            Name: 'foo\b\n\t.txt',
+            Size: 9000
+          }]
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagPbCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagPbCid}`, { ipfs })
+
+      expect(out).to.equal(`{"links":[{"Name":"foo.txt","Size":9000,"Cid":{"/":"${dagPbCid}"}}]}\n`)
+    })
+
+    it('should strip control characters from dag-cbor nodes', async () => {
+      const result = {
+        value: {
+          'lo\nl': 'ok\t'
+        }
+      }
+
+      ipfs.dag.get.withArgs(dagCborCid, defaultOptions).returns(result)
+
+      const out = await cli(`dag get ${dagCborCid}`, { ipfs })
+
+      expect(out).to.equal('{"lol":"ok"}\n')
     })
   })
 
@@ -114,33 +249,33 @@ describe('dag', () => {
     }
 
     it('resolves a cid ref', async () => {
-      ipfs.dag.resolve.withArgs(cid.toString(), defaultOptions).returns([{
-        value: new CID(cid)
+      ipfs.dag.resolve.withArgs(dagPbCid.toString(), defaultOptions).returns([{
+        value: new CID(dagPbCid)
       }])
 
-      const out = await cli(`dag resolve ${cid}`, { ipfs })
-      expect(out).to.equal(`${cid}\n`)
+      const out = await cli(`dag resolve ${dagPbCid}`, { ipfs })
+      expect(out).to.equal(`${dagPbCid}\n`)
     })
 
     it('resolves an ipfs path', async () => {
-      ipfs.dag.resolve.withArgs(`/ipfs/${cid}`, defaultOptions).returns([{
-        value: new CID(cid)
+      ipfs.dag.resolve.withArgs(`/ipfs/${dagPbCid}`, defaultOptions).returns([{
+        value: new CID(dagPbCid)
       }])
 
-      const out = await cli(`dag resolve /ipfs/${cid}`, { ipfs })
-      expect(out).to.equal(`${cid}\n`)
+      const out = await cli(`dag resolve /ipfs/${dagPbCid}`, { ipfs })
+      expect(out).to.equal(`${dagPbCid}\n`)
     })
 
     it('resolves a cid ref with a timeout', async () => {
-      ipfs.dag.resolve.withArgs(cid.toString(), {
+      ipfs.dag.resolve.withArgs(dagPbCid.toString(), {
         ...defaultOptions,
         timeout: 1000
       }).returns([{
-        value: new CID(cid)
+        value: new CID(dagPbCid)
       }])
 
-      const out = await cli(`dag resolve ${cid} --timeout=1s`, { ipfs })
-      expect(out).to.equal(`${cid}\n`)
+      const out = await cli(`dag resolve ${dagPbCid} --timeout=1s`, { ipfs })
+      expect(out).to.equal(`${dagPbCid}\n`)
     })
   })
 
@@ -156,14 +291,14 @@ describe('dag', () => {
     }
 
     it('puts json string', async () => {
-      ipfs.dag.put.withArgs({}, defaultOptions).resolves(new CID(cid))
+      ipfs.dag.put.withArgs({}, defaultOptions).resolves(new CID(dagCborCid))
 
       const out = await cli('dag put "{}"', { ipfs })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagCborCid}\n`)
     })
 
     it('puts piped json string', async () => {
-      ipfs.dag.put.withArgs({}, defaultOptions).resolves(new CID(cid))
+      ipfs.dag.put.withArgs({}, defaultOptions).resolves(new CID(dagCborCid))
 
       const out = await cli('dag put', {
         getStdin: function * () {
@@ -171,11 +306,11 @@ describe('dag', () => {
         },
         ipfs
       })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagCborCid}\n`)
     })
 
     it('puts piped cbor node', async () => {
-      ipfs.dag.put.withArgs({}, defaultOptions).resolves(new CID(cid))
+      ipfs.dag.put.withArgs({}, defaultOptions).resolves(new CID(dagCborCid))
 
       const out = await cli('dag put --input-encoding cbor', {
         getStdin: function * () {
@@ -183,14 +318,14 @@ describe('dag', () => {
         },
         ipfs
       })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagCborCid}\n`)
     })
 
     it('puts piped raw node', async () => {
       ipfs.dag.put.withArgs(Buffer.alloc(10), {
         ...defaultOptions,
         format: 'raw'
-      }).resolves(new CID(cid))
+      }).resolves(new CID(rawCid))
 
       const out = await cli('dag put --input-encoding raw --format raw', {
         getStdin: function * () {
@@ -198,7 +333,7 @@ describe('dag', () => {
         },
         ipfs
       })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${rawCid}\n`)
     })
 
     it('puts piped protobuf node', async () => {
@@ -206,7 +341,7 @@ describe('dag', () => {
         ...defaultOptions,
         format: 'dag-pb',
         version: 0
-      }).resolves(new CID(cid))
+      }).resolves(new CID(dagPbCid))
 
       const out = await cli('dag put --input-encoding protobuf --format protobuf', {
         getStdin: function * () {
@@ -214,7 +349,7 @@ describe('dag', () => {
         },
         ipfs
       })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagPbCid}\n`)
     })
 
     it('puts protobuf node as json', async () => {
@@ -222,12 +357,12 @@ describe('dag', () => {
         ...defaultOptions,
         format: 'dag-pb',
         version: 0
-      }).resolves(new CID(cid))
+      }).resolves(new CID(dagPbCid))
 
       const out = await cli('dag put --format protobuf \'{"Links":[]}\'', {
         ipfs
       })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagPbCid}\n`)
     })
 
     it('puts piped protobuf node with cid-v1', async () => {
@@ -235,7 +370,7 @@ describe('dag', () => {
         ...defaultOptions,
         format: 'dag-pb',
         version: 1
-      }).resolves(new CID(cid))
+      }).resolves(new CID(dagPbCid))
 
       const out = await cli('dag put --input-encoding protobuf --format protobuf --cid-version=1', {
         getStdin: function * () {
@@ -243,45 +378,45 @@ describe('dag', () => {
         },
         ipfs
       })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagPbCid}\n`)
     })
 
     it('puts json string with esoteric hashing algorithm', async () => {
       ipfs.dag.put.withArgs({}, {
         ...defaultOptions,
         hashAlg: 'blake2s-40'
-      }).resolves(new CID(cid))
+      }).resolves(new CID(dagCborCid))
 
       const out = await cli('dag put --hash-alg blake2s-40 "{}"', { ipfs })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagCborCid}\n`)
     })
 
     it('puts json string with cid base', async () => {
-      ipfs.dag.put.withArgs({}, defaultOptions).resolves(cid)
+      ipfs.dag.put.withArgs({}, defaultOptions).resolves(dagCborCid)
 
       const out = await cli('dag put --cid-base base64 "{}"', { ipfs })
-      expect(out).to.equal(`${cid.toV1().toString('base64')}\n`)
+      expect(out).to.equal(`${dagCborCid.toV1().toString('base64')}\n`)
     })
 
     it('pins node after putting', async () => {
       ipfs.dag.put.withArgs({ hello: 'world' }, {
         ...defaultOptions,
         pin: true
-      }).resolves(new CID(cid))
+      }).resolves(new CID(dagCborCid))
 
       const out = await cli('dag put --pin \'{"hello":"world"}\'', { ipfs })
 
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagCborCid}\n`)
     })
 
     it('puts json string with a timeout', async () => {
       ipfs.dag.put.withArgs({}, {
         ...defaultOptions,
         timeout: 1000
-      }).resolves(new CID(cid))
+      }).resolves(new CID(dagCborCid))
 
       const out = await cli('dag put "{}" --timeout=1s', { ipfs })
-      expect(out).to.equal(`${cid}\n`)
+      expect(out).to.equal(`${dagCborCid}\n`)
     })
   })
 })

--- a/packages/ipfs-cli/test/dns.js
+++ b/packages/ipfs-cli/test/dns.js
@@ -91,4 +91,17 @@ describe('dns', () => {
     })
     expect(out).to.equal(`${path}\n`)
   })
+
+  it('strips control characters from response', async () => {
+    const domain = 'ipfs.io'
+    const path = 'path'
+    const junkPath = `${path}\n\b\t`
+
+    ipfs.dns.withArgs(domain, defaultOptions).returns(junkPath)
+
+    const out = await cli('dns ipfs.io', {
+      ipfs
+    })
+    expect(out).to.equal(`${path}\n`)
+  })
 })

--- a/packages/ipfs-cli/test/files/ls.js
+++ b/packages/ipfs-cli/test/files/ls.js
@@ -99,10 +99,24 @@ describe('ls', () => {
     expect(output).to.include(files[0].size)
   })
 
-  it('should list a path with details', async () => {
+  it('should list a path with a timeout', async () => {
+    const path = '/foo'
+
+    await cli(`files ls ${path} --timeout=1s`, { ipfs, print })
+
+    expect(ipfs.files.ls.callCount).to.equal(1)
+    expect(ipfs.files.ls.getCall(0).args).to.deep.equal([
+      path, {
+        ...defaultOptions,
+        timeout: 1000
+      }
+    ])
+  })
+
+  it('should strip control characters from path names', async () => {
     const files = [{
       cid: fileCid,
-      name: 'file-name',
+      name: 'file\n\t\b-name',
       size: 'file-size',
       mode: 0o755,
       mtime: {
@@ -117,43 +131,7 @@ describe('ls', () => {
 
     expect(ipfs.files.ls.callCount).to.equal(1)
     expect(output).to.include(files[0].cid.toString())
-    expect(output).to.include(files[0].name)
+    expect(output).to.include('file-name')
     expect(output).to.include(files[0].size)
-  })
-
-  it('should list a path with details (short option)', async () => {
-    const files = [{
-      cid: fileCid,
-      name: 'file-name',
-      size: 'file-size',
-      mode: 0o755,
-      mtime: {
-        secs: Date.now() / 1000,
-        nsecs: 0
-      }
-    }]
-
-    ipfs.files.ls = sinon.stub().withArgs('/foo', defaultOptions).returns(files)
-
-    await cli('files ls -l /foo', { ipfs, print })
-
-    expect(ipfs.files.ls.callCount).to.equal(1)
-    expect(output).to.include(files[0].cid.toString())
-    expect(output).to.include(files[0].name)
-    expect(output).to.include(files[0].size)
-  })
-
-  it('should list a path with a timeout', async () => {
-    const path = '/foo'
-
-    await cli(`files ls ${path} --timeout=1s`, { ipfs, print })
-
-    expect(ipfs.files.ls.callCount).to.equal(1)
-    expect(ipfs.files.ls.getCall(0).args).to.deep.equal([
-      path, {
-        ...defaultOptions,
-        timeout: 1000
-      }
-    ])
   })
 })

--- a/packages/ipfs-cli/test/get.js
+++ b/packages/ipfs-cli/test/get.js
@@ -183,4 +183,27 @@ describe('get', () => {
 
     await clean(dir)
   })
+
+  it('should strip control characters when getting a file', async () => {
+    const ipfsPath = `/ipfs/${cid}/foo/bar`
+    const junkPath = `/ipfs/${cid}/foo\b/bar`
+
+    ipfs.get.withArgs(junkPath, defaultOptions).returns([{
+      path: junkPath,
+      content: function * () {
+        yield buf
+      }
+    }])
+
+    const outPath = `${process.cwd()}/${junkPath}`
+    await clean(outPath)
+
+    const out = await cli(`get ${junkPath}`, { ipfs })
+    expect(out)
+      .to.equal(`Saving file(s) ${ipfsPath}\n`)
+
+    expect(fs.readFileSync(outPath)).to.deep.equal(buf)
+
+    await clean(outPath)
+  })
 })

--- a/packages/ipfs-cli/test/get.js
+++ b/packages/ipfs-cli/test/get.js
@@ -184,9 +184,14 @@ describe('get', () => {
     await clean(dir)
   })
 
-  it('should strip control characters when getting a file', async () => {
-    const ipfsPath = `/ipfs/${cid}/foo/bar`
-    const junkPath = `/ipfs/${cid}/foo\b/bar`
+  it('should strip control characters when getting a file', async function () {
+    if (process.platform === 'win32') {
+      // windows cannot write files with control characters in the path
+      return this.skip()
+    }
+
+    const ipfsPath = `${cid}/foo/bar`
+    const junkPath = `${cid}/foo\b/bar`
 
     ipfs.get.withArgs(junkPath, defaultOptions).returns([{
       path: junkPath,

--- a/packages/ipfs-cli/test/key.js
+++ b/packages/ipfs-cli/test/key.js
@@ -80,6 +80,18 @@ describe('key', () => {
       const out = await cli(`key gen ${name} --timeout=1s`, { ipfs })
       expect(out).to.equal(`generated ${id} ${name}\n`)
     })
+
+    it('gen strips control characters', async () => {
+      const junkName = `${name}\b\b\b`
+
+      ipfs.key.gen.withArgs(junkName, defaultOptions).resolves({
+        id,
+        name: junkName
+      })
+
+      const out = await cli(`key gen ${junkName}`, { ipfs })
+      expect(out).to.equal(`generated ${id} ${name}\n`)
+    })
   })
 
   describe('list', () => {
@@ -107,6 +119,18 @@ describe('key', () => {
         name
       }])
       const out = await cli('key list --timeout=1s', { ipfs })
+      expect(out).to.equal(`${id} ${name}\n`)
+    })
+
+    it('list strips control characters', async () => {
+      const junkName = `${name}\b\b\b`
+
+      ipfs.key.list.withArgs(defaultOptions).resolves([{
+        id,
+        name: junkName
+      }])
+
+      const out = await cli('key list', { ipfs })
       expect(out).to.equal(`${id} ${name}\n`)
     })
   })
@@ -139,6 +163,18 @@ describe('key', () => {
       const out = await cli(`key rename ${name} ${newName} --timeout=1s`, { ipfs })
       expect(out).to.equal(`renamed to ${id} ${newName}\n`)
     })
+
+    it('rename strips control characters', async () => {
+      const junkName = `${name}\b\b\b`
+
+      ipfs.key.rename.withArgs(name, junkName, defaultOptions).resolves({
+        id,
+        now: junkName
+      })
+
+      const out = await cli(`key rename ${name} ${junkName}`, { ipfs })
+      expect(out).to.equal(`renamed to ${id} ${name}\n`)
+    })
   })
 
   describe('rm', () => {
@@ -168,6 +204,18 @@ describe('key', () => {
       })
 
       const out = await cli(`key rm ${name} --timeout=1s`, { ipfs })
+      expect(out).to.equal(`${id} ${name}\n`)
+    })
+
+    it('remove strips control characters', async () => {
+      const junkName = `${name}\b\b\b`
+
+      ipfs.key.rm.withArgs(junkName, defaultOptions).resolves({
+        id,
+        name: junkName
+      })
+
+      const out = await cli(`key rm ${junkName}`, { ipfs })
       expect(out).to.equal(`${id} ${name}\n`)
     })
   })

--- a/packages/ipfs-cli/test/ls.js
+++ b/packages/ipfs-cli/test/ls.js
@@ -202,4 +202,29 @@ describe('ls', () => {
       '-rw-r--r-- - QmPkWYfSLCEBLZu7BZt4kigGDMe3cpogMbeVf97gN2xJDN 3928 config\n'
     )
   })
+
+  it('removes control characters from paths', async () => {
+    ipfs.ls.withArgs('Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z', defaultOptions).returns([{
+      mode: 0o755,
+      mtime: null,
+      cid: new CID('QmamKEPmEH9RUsqRQsfNf5evZQDQPYL9KXg1ADeT7mkHkT'),
+      type: 'dir',
+      name: 'bl\nock\bs',
+      depth: 0
+    }, {
+      mode: 0o644,
+      mtime: null,
+      cid: new CID('QmPkWYfSLCEBLZu7BZt4kigGDMe3cpogMbeVf97gN2xJDN'),
+      type: 'file',
+      name: 'co\r\tnfig',
+      size: 3928,
+      depth: 0
+    }])
+
+    const out = await cli('ls Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z', { ipfs })
+    expect(out).to.eql(
+      'drwxr-xr-x - QmamKEPmEH9RUsqRQsfNf5evZQDQPYL9KXg1ADeT7mkHkT - blocks/\n' +
+      '-rw-r--r-- - QmPkWYfSLCEBLZu7BZt4kigGDMe3cpogMbeVf97gN2xJDN 3928 config\n'
+    )
+  })
 })

--- a/packages/ipfs-cli/test/name-pubsub.js
+++ b/packages/ipfs-cli/test/name-pubsub.js
@@ -117,5 +117,17 @@ describe('name pubsub', () => {
 
       expect(out).to.equal(`${subName}\n`)
     })
+
+    it('should strip control characters when listing subscriptions', async () => {
+      const junkSubname = `${subName}\n\b`
+
+      ipfs.name.pubsub.subs.withArgs(defaultOptions).resolves([
+        junkSubname
+      ])
+
+      const out = await cli('name pubsub subs', { ipfs })
+
+      expect(out).to.equal(`${subName}\n`)
+    })
   })
 })

--- a/packages/ipfs-cli/test/name.js
+++ b/packages/ipfs-cli/test/name.js
@@ -278,5 +278,20 @@ describe('name', () => {
       const out = await cli(`name publish ${name} --timeout=1s`, { ipfs })
       expect(out).to.equal(`Published to ${name}: ${value}\n`)
     })
+
+    it('should strip control characters when publishing names', async () => {
+      const name = 'name'
+      const junkName = `${name}\b`
+      const value = 'data'
+
+      ipfs.name.publish.withArgs(junkName, defaultOptions)
+        .resolves({
+          name: junkName,
+          value
+        })
+
+      const out = await cli(`name publish ${junkName}`, { ipfs })
+      expect(out).to.equal(`Published to ${name}: ${value}\n`)
+    })
   })
 })

--- a/packages/ipfs-cli/test/object.js
+++ b/packages/ipfs-cli/test/object.js
@@ -96,6 +96,26 @@ describe('object', () => {
       expect(result.Data).to.equal('')
     })
 
+    it('should get an object and strip control characters from link names', async () => {
+      const node = new DAGNode()
+      node.addLink({
+        Name: 'derp\n\b',
+        Tsize: 10,
+        Hash: cid
+      })
+
+      ipfs.object.get.withArgs(cid.toString(), defaultOptions).resolves(node)
+
+      const out = await cli(`object get ${cid}`, { ipfs })
+      const result = JSON.parse(out)
+      expect(result.Links).to.deep.equal([{
+        Name: 'derp',
+        Size: 10,
+        Hash: cid.toString()
+      }])
+      expect(result.Data).to.equal('')
+    })
+
     it('get with data', async () => {
       const node = new DAGNode(uint8ArrayFromString('aGVsbG8gd29ybGQK', 'base64'))
 
@@ -327,6 +347,17 @@ describe('object', () => {
       const out = await cli(`object links ${cid} --timeout=1s`, { ipfs })
       expect(out).to.equal(
         'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V 8 some link\n'
+      )
+    })
+
+    it('should get an object and strip control characters from link names', async () => {
+      ipfs.object.links.withArgs(cid.toString(), defaultOptions).resolves([
+        new DAGLink('derp\t\n\b', 8, new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V'))
+      ])
+
+      const out = await cli(`object links ${cid}`, { ipfs })
+      expect(out).to.equal(
+        'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V 8 derp\n'
       )
     })
   })

--- a/packages/ipfs-cli/test/pin.js
+++ b/packages/ipfs-cli/test/pin.js
@@ -308,5 +308,18 @@ describe('pin', () => {
       const out = await cli('pin ls --timeout=1s', { ipfs })
       expect(out).to.equal(`${pins.root} recursive\n`)
     })
+
+    it('strips control characters from metadata', async () => {
+      ipfs.pin.ls.withArgs(defaultOptions).returns([{
+        cid: new CID(pins.root),
+        type: 'recursive',
+        metadata: {
+          'herp\n\t': 'de\brp'
+        }
+      }])
+
+      const out = await cli('pin ls', { ipfs })
+      expect(out).to.equal(`${pins.root} recursive {"herp":"derp"}\n`)
+    })
   })
 })

--- a/packages/ipfs-cli/test/pubsub.js
+++ b/packages/ipfs-cli/test/pubsub.js
@@ -49,6 +49,18 @@ describe('pubsub', () => {
       const out = await cli('pubsub ls --timeout=1s', { ipfs })
       expect(out).to.equal(`${subName}\n`)
     })
+
+    it('should strip control characters from sub names', async () => {
+      const subName = 'sub-name'
+      const junkSubName = 'sub-nam\b\te\n'
+
+      ipfs.pubsub.ls.withArgs(defaultOptions).resolves([
+        junkSubName
+      ])
+
+      const out = await cli('pubsub ls', { ipfs })
+      expect(out).to.equal(`${subName}\n`)
+    })
   })
 
   describe('peers', () => {

--- a/packages/ipfs-cli/test/resolve.js
+++ b/packages/ipfs-cli/test/resolve.js
@@ -1,0 +1,78 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('aegir/utils/chai')
+const CID = require('cids')
+const cli = require('./utils/cli')
+const sinon = require('sinon')
+
+const defaultOptions = {
+  recursive: false,
+  cidBase: undefined,
+  timeout: undefined
+}
+
+describe('resolve', () => {
+  let ipfs
+  const cid = new CID('Qmaj2NmcyAXT8dFmZRRytE12wpcaHADzbChKToMEjBsj5Z')
+
+  beforeEach(() => {
+    ipfs = {
+      resolve: sinon.stub()
+    }
+  })
+
+  it('resolves a CID', async () => {
+    const resolved = `/ipfs/${cid}`
+
+    ipfs.resolve.withArgs(cid.toString(), defaultOptions).resolves(resolved)
+
+    const out = await cli(`resolve ${cid}`, { ipfs })
+    expect(out).to.equal(resolved + '\n')
+  })
+
+  it('resolves a CID recursively', async () => {
+    const resolved = `/ipfs/${cid}`
+
+    ipfs.resolve.withArgs(cid.toString(), {
+      ...defaultOptions,
+      recursive: true
+    }).resolves(resolved)
+
+    const out = await cli(`resolve ${cid} --recursive`, { ipfs })
+    expect(out).to.equal(resolved + '\n')
+  })
+
+  it('resolves a CID recursively (short option)', async () => {
+    const resolved = `/ipfs/${cid}`
+
+    ipfs.resolve.withArgs(cid.toString(), {
+      ...defaultOptions,
+      recursive: true
+    }).resolves(resolved)
+
+    const out = await cli(`resolve ${cid} -r`, { ipfs })
+    expect(out).to.equal(resolved + '\n')
+  })
+
+  it('resolves a CID with a timeout', async () => {
+    const resolved = `/ipfs/${cid}`
+
+    ipfs.resolve.withArgs(cid.toString(), {
+      ...defaultOptions,
+      timeout: 1000
+    }).resolves(resolved)
+
+    const out = await cli(`resolve ${cid} --timeout 1s`, { ipfs })
+    expect(out).to.equal(resolved + '\n')
+  })
+
+  it('strips control characters when resolving a CID', async () => {
+    const resolved = `/ipfs/${cid}/derp/\bherp`
+
+    ipfs.resolve.withArgs(cid.toString(), defaultOptions).resolves(resolved)
+
+    const out = await cli(`resolve ${cid}`, { ipfs })
+    expect(out).to.equal(`/ipfs/${cid}/derp/herp\n`)
+  })
+})


### PR DESCRIPTION
Removes control characters (e.g. char code < 32 or 127 (DEL)) from any fields printed by the CLI that could have once have been user input.

For `jsipfs dag get` it attempts to strip control characters from dag-pb and dag-cbor nodes and escapes them from everything else.

raw nodes get blurted into the terminal the same as if you'd done `jsipfs cat ...`

Also brings the output of `jsipfs dag get` more into line with go-ipfs and allows specifying which encoding to display data fields in.