### PR TITLE
fix: make port transferables unique

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Bundlesize ${{ matrix.project }}
-        uses: ipfs/aegir/actions/bundle-size@v28.0.0
+        uses: ipfs/aegir/actions/bundle-size@v29.0.0
         with:
           project: ${{ matrix.project }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ipfs-message-port-client/README.md
+++ b/packages/ipfs-message-port-client/README.md
@@ -102,7 +102,7 @@ values instead of copying.
 
 > **Note:** Transferring data will empty it on the sender side which can lead to
 > errors if that data is used again later. To avoid these errors transfer option
-> was added so user can explicitily give up reference when it is safe to do so.
+> was added so user can explicitly give up reference when it is safe to do so.
 
 ```js
 /**
@@ -115,7 +115,7 @@ const example = async (data) => {
 }
 ```
 
-It is however recommended to prefer web native [Blob][] / [File][] intances as
+It is however recommended to prefer web native [Blob][] / [File][] instances as
 most web APIs provide them as option & can be send across without copying
 underlying memory.
 

--- a/packages/ipfs-message-port-client/src/client/transport.js
+++ b/packages/ipfs-message-port-client/src/client/transport.js
@@ -178,7 +178,7 @@ module.exports = class MessageTransport {
         input: query.toJSON()
       },
       // @ts-ignore - TS seems to want second arg to postMessage to not be undefined
-      query.transfer()
+      [...new Set(query.transfer() || [])]
     )
   }
 

--- a/packages/ipfs-message-port-protocol/src/core.js
+++ b/packages/ipfs-message-port-protocol/src/core.js
@@ -197,7 +197,7 @@ const decodeCallback = ({ port }) => {
    * @returns {void}
    */
   const callback = (args, transfer = []) => {
-    port.postMessage(args, transfer)
+    port.postMessage(args, [...new Set(transfer)])
   }
 
   return callback

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -51,6 +51,7 @@
     "@types/it-all": "^1.0.0",
     "aegir": "^28.2.0",
     "cids": "^1.0.0",
+    "ipfs-utils": "^5.0.0",
     "rimraf": "^3.0.2",
     "typescript": "4.0.x"
   },

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@types/it-all": "^1.0.0",
     "aegir": "^28.2.0",
+    "cids": "^1.0.0",
     "rimraf": "^3.0.2",
     "typescript": "4.0.x"
   },

--- a/packages/ipfs-message-port-server/src/server.js
+++ b/packages/ipfs-message-port-server/src/server.js
@@ -212,9 +212,12 @@ exports.Server = class Server {
     if (!query.signal.aborted) {
       try {
         const value = await query.result
+        const transfer = [...new Set(value.transfer || [])]
+        delete value.transfer
+
         port.postMessage(
           { type: 'result', id, result: { ok: true, value } },
-          value.transfer || []
+          transfer
         )
       } catch (error) {
         port.postMessage({

--- a/packages/ipfs-message-port-server/test/transfer.spec.js
+++ b/packages/ipfs-message-port-server/test/transfer.spec.js
@@ -1,0 +1,46 @@
+'use strict'
+
+/* eslint-env mocha */
+const { encodeCID } = require('ipfs-message-port-protocol/src/cid')
+const { expect } = require('aegir/utils/chai')
+
+const CID = require('cids')
+const { Query, Server } = require('../src/server')
+const { IPFSService } = require('../src/index')
+
+describe('Server', function () {
+  this.timeout(10 * 1000)
+
+  it('should be able to transfer multiple of the same CID instances', () => {
+    const cid = new CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
+
+    return new Promise((resolve, reject) => {
+      const channel = process.browser
+        ? new MessageChannel()
+        : new (require('worker_threads').MessageChannel)()
+
+      channel.port1.onmessageerror = reject
+      channel.port1.onmessage = event => {
+        const result = event.data.result
+        result.ok ? resolve(result.value) : reject(new Error(result.error.message))
+      }
+
+      const service = new IPFSService()
+      const server = new Server(service)
+      const transfer = []
+
+      server.run = a => a
+      server.handleQuery(
+        "",
+        {
+          result: {
+            value: [ encodeCID(cid, transfer), encodeCID(cid, transfer) ],
+            transfer: transfer
+          },
+          signal: { aborted: false }
+        },
+        channel.port2
+      )
+    })
+  })
+})

--- a/packages/ipfs-message-port-server/test/transfer.spec.js
+++ b/packages/ipfs-message-port-server/test/transfer.spec.js
@@ -2,21 +2,21 @@
 
 /* eslint-env mocha */
 const { encodeCID } = require('ipfs-message-port-protocol/src/cid')
-const { expect } = require('aegir/utils/chai')
+const globalThis = require('ipfs-utils/src/globalthis')
 
 const CID = require('cids')
-const { Query, Server } = require('../src/server')
+const { Server } = require('../src/server')
 const { IPFSService } = require('../src/index')
 
 describe('Server', function () {
   this.timeout(10 * 1000)
 
   it('should be able to transfer multiple of the same CID instances', () => {
-    const cid = new CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
+    const cid = new CID('QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D')
 
     return new Promise((resolve, reject) => {
       const channel = process.browser
-        ? new MessageChannel()
+        ? new globalThis.MessageChannel()
         : new (require('worker_threads').MessageChannel)()
 
       channel.port1.onmessageerror = reject
@@ -31,10 +31,10 @@ describe('Server', function () {
 
       server.run = a => a
       server.handleQuery(
-        "",
+        '',
         {
           result: {
-            value: [ encodeCID(cid, transfer), encodeCID(cid, transfer) ],
+            value: [encodeCID(cid, transfer), encodeCID(cid, transfer)],
             transfer: transfer
           },
           signal: { aborted: false }


### PR DESCRIPTION
Fixes #3402

The `transfer` list, ie. the second argument to `postMessage`, should always contain unique values, multiple of the same pointers cause errors. This PR fixes that, see linked issue above for more info. My solution was to just make everything in the list unique by converting the array to a set and back. Let me know if this works, or if another solution is preferred.