### PR TITLE
fix: types for withTimeoutOptions

### DIFF
--- a/packages/ipfs-core-utils/src/index.js
+++ b/packages/ipfs-core-utils/src/index.js
@@ -1,7 +1,1 @@
 'use strict'
-
-/**
- * @template {any[]} ARGS
- * @template R
- * @typedef {(...args: ARGS) => R} Fn
- */

--- a/packages/ipfs-core-utils/src/with-timeout-option.js
+++ b/packages/ipfs-core-utils/src/with-timeout-option.js
@@ -7,15 +7,15 @@ const parseDuration = require('parse-duration').default
 const { TimeoutError } = require('./errors')
 
 /**
- * @template {any[]} ARGS
+ * @template {any[]} Args
  * @template {Promise<any> | AsyncIterable<any>} R - The return type of `fn`
- * @param {Fn<ARGS, R>} fn
+ * @param {(...args:Args) => R} fn
  * @param {number} [optionsArgIndex]
- * @returns {Fn<ARGS, R>}
+ * @returns {(...args:Args) => R}
  */
 function withTimeoutOption (fn, optionsArgIndex) {
   // eslint-disable-next-line
-  return /** @returns {R} */(/** @type {ARGS} */...args) => {
+  return /** @returns {R} */(/** @type {Args} */...args) => {
     const options = args[optionsArgIndex == null ? args.length - 1 : optionsArgIndex]
     if (!options || !options.timeout) return fn(...args)
 


### PR DESCRIPTION
https://github.com/ipfs/js-ipfs/pull/3407/ has introduced regression in type inference for `withTimeoutOptions` function which end up referring to `Fn<Args, R>` type which was declared in other file https://github.com/ipfs/js-ipfs/pull/3407/files#diff-722621abc3ed4edc6ab202fdf684f1607c261394b95da6b3ec79748711056f20

I think TS has this strange WTF where when it can't figure out when JS file is a module it will treat it as if everything is loaded in the same scope. I think that caused `withTimeoutOptions` not to report errors but silently fail and infer return function as `any`.

This change fixes that by removes `Fn` type all together, as it seemed like unnecessary complexity. 

Unfortunately nothing seemed to have caught this regression because we set [`noImplicitAny`](https://www.typescriptlang.org/tsconfig#noImplicitAny) to `false` given that many of our dependencies are untyped.