### PR TITLE
chore: split daemon out into module

### DIFF
--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "IPFS"
   ],
-  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs#readme",
+  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-cli#readme",
   "bugs": "https://github.com/ipfs/js-ipfs/issues",
   "license": "(Apache-2.0 OR MIT)",
   "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",
@@ -34,15 +34,13 @@
     "cid-tool": "^1.0.0",
     "cids": "^1.0.0",
     "debug": "^4.1.1",
-    "dlv": "^1.1.3",
     "err-code": "^2.0.3",
     "execa": "^4.0.3",
     "get-folder-size": "^2.0.1",
     "ipfs-core": "^0.3.0",
     "ipfs-core-utils": "^0.5.3",
+    "ipfs-daemon": "^0.3.1",
     "ipfs-http-client": "^48.1.2",
-    "ipfs-http-gateway": "^0.1.3",
-    "ipfs-http-server": "^0.1.3",
     "ipfs-repo": "^7.0.0",
     "ipfs-utils": "^5.0.0",
     "ipld-dag-cbor": "^0.17.0",
@@ -53,12 +51,7 @@
     "it-glob": "0.0.10",
     "it-pipe": "^1.1.0",
     "jsondiffpatch": "^0.4.1",
-    "just-safe-set": "^2.1.0",
-    "libp2p": "^0.29.3",
     "libp2p-crypto": "^0.18.0",
-    "libp2p-delegated-content-routing": "^0.8.0",
-    "libp2p-delegated-peer-routing": "^0.8.0",
-    "libp2p-webrtc-star": "^0.20.1",
     "mafmt": "^8.0.0",
     "multiaddr": "^8.0.0",
     "multiaddr-to-uri": "^6.0.0",
@@ -83,13 +76,5 @@
     "string-argv": "^0.3.1",
     "temp-write": "^4.0.0",
     "typescript": "4.0.x"
-  },
-  "optionalDependencies": {
-    "prom-client": "^12.0.0",
-    "prometheus-gc-stats": "^0.6.0"
-  },
-  "peerDependencies": {
-    "electron-webrtc": "^0.3.0",
-    "wrtc": "^0.4.6"
   }
 }

--- a/packages/ipfs-cli/src/commands/daemon.js
+++ b/packages/ipfs-cli/src/commands/daemon.js
@@ -65,7 +65,7 @@ module.exports = {
     }
 
     // Required inline to reduce startup time
-    const Daemon = require('../../src/daemon')
+    const Daemon = require('ipfs-daemon')
     const daemon = new Daemon({
       config,
       silent: argv.silent,

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "IPFS"
   ],
-  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs#readme",
+  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-core#readme",
   "bugs": "https://github.com/ipfs/js-ipfs/issues",
   "license": "(Apache-2.0 OR MIT)",
   "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",

--- a/packages/ipfs-daemon/.eslintrc
+++ b/packages/ipfs-daemon/.eslintrc
@@ -1,0 +1,3 @@
+{
+"extends": "ipfs"
+}

--- a/packages/ipfs-daemon/CODE_OF_CONDUCT.md
+++ b/packages/ipfs-daemon/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Contributor Code of Conduct
+
+The `js-ipfs` project follows the [`IPFS Community Code of Conduct`](https://github.com/ipfs/community/blob/master/code-of-conduct.md)

--- a/packages/ipfs-daemon/CONTRIBUTING.md
+++ b/packages/ipfs-daemon/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing guidelines
+
+IPFS as a project, including js-ipfs and all of its modules, follows the [standard IPFS Community contributing guidelines](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md).
+
+We also adhere to the [IPFS JavaScript Community contributing guidelines](https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md) which provide additional information of how to collaborate and contribute in the JavaScript implementation of IPFS.
+
+We appreciate your time and attention for going over these. Please open an issue on [ipfs/community](https://github.com/ipfs/community) if you have any question.
+
+Thank you.

--- a/packages/ipfs-daemon/COPYRIGHT
+++ b/packages/ipfs-daemon/COPYRIGHT
@@ -1,0 +1,5 @@
+This project is transitioning from an MIT-only license to a dual MIT/Apache-2.0 license.
+Unless otherwise noted, all code contributed prior to 2019-11-21 and not contributed by
+a user listed in [this signoff issue](https://github.com/ipfs/js-ipfs/issues/2624) is
+licensed under MIT-only. All new contributions (and past contributions since 2019-11-21)
+are licensed under a dual MIT/Apache-2.0 license.

--- a/packages/ipfs-daemon/LICENSE-APACHE
+++ b/packages/ipfs-daemon/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/ipfs-daemon/LICENSE-MIT
+++ b/packages/ipfs-daemon/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/ipfs-daemon/README.md
+++ b/packages/ipfs-daemon/README.md
@@ -1,0 +1,44 @@
+# ipfs-daemon <!-- omit in toc -->
+
+> The implementation of the js-IPFS daemon
+
+## Lead Maintainer <!-- omit in toc -->
+
+[Alex Potsides](http://github.com/achingbrain)
+
+## Table of Contents <!-- omit in toc -->
+
+- [Install](#install)
+- [Want to hack on IPFS?](#want-to-hack-on-ipfs)
+- [License](#license)
+
+## Install
+
+You probably don't need to install this module directly, use it by installing the `ipfs` module:
+
+```console
+$ npm install -g ipfs
+// npm install output
+$ jsipfs daemon
+```
+
+## Want to hack on IPFS?
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
+
+The IPFS implementation in JavaScript needs your help!  There are a few things you can do right now to help out:
+
+Read the [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md) and [JavaScript Contributing Guidelines](https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md).
+
+- **Check out existing issues** The [issue list](https://github.com/ipfs/js-ipfs/issues) has many that are marked as ['help wanted'](https://github.com/ipfs/js-ipfs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22) or ['difficulty:easy'](https://github.com/ipfs/js-ipfs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Adifficulty%3Aeasy) which make great starting points for development, many of which can be tackled with no prior IPFS knowledge
+- **Look at the [IPFS Roadmap](https://github.com/ipfs/roadmap)** This are the high priority items being worked on right now
+- **Perform code reviews** More eyes will help
+  a. speed the project along
+  b. ensure quality, and
+  c. reduce possible future bugs.
+- **Add tests**. There can never be enough tests.
+- **Join the [Weekly Core Implementations Call](https://github.com/ipfs/team-mgmt/issues/992)** it's where everyone discusses what's going on with IPFS and what's next
+
+## License
+
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fipfs%2Fjs-ipfs.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fipfs%2Fjs-ipfs?ref=badge_large)

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "ipfs-daemon",
+  "version": "0.3.1",
+  "description": "JavaScript implementation of the IPFS specification",
+  "keywords": [
+    "IPFS"
+  ],
+  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-daemon#readme",
+  "bugs": "https://github.com/ipfs/js-ipfs/issues",
+  "license": "(Apache-2.0 OR MIT)",
+  "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ipfs/js-ipfs.git"
+  },
+  "scripts": {
+    "lint": "aegir lint",
+    "build": "npm run build:types",
+    "build:types": "tsc --build",
+    "test": "npm run test:node",
+    "test:node": "aegir test -t node",
+    "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
+    "clean": "rimraf ./dist",
+    "dep-check": "aegir dep-check -i @types/yargs -i typescript"
+  },
+  "dependencies": {
+    "debug": "^4.1.1",
+    "dlv": "^1.1.3",
+    "ipfs-core": "^0.3.0",
+    "ipfs-http-client": "^48.1.2",
+    "ipfs-http-gateway": "^0.1.3",
+    "ipfs-http-server": "^0.1.3",
+    "ipfs-utils": "^5.0.0",
+    "just-safe-set": "^2.1.0",
+    "libp2p": "^0.29.3",
+    "libp2p-delegated-content-routing": "^0.8.0",
+    "libp2p-delegated-peer-routing": "^0.8.0",
+    "libp2p-webrtc-star": "^0.20.1",
+    "multiaddr": "^8.0.0"
+  },
+  "devDependencies": {
+    "aegir": "^28.2.0",
+    "node-fetch": "^2.6.1",
+    "typescript": "4.0.x"
+  },
+  "optionalDependencies": {
+    "prom-client": "^12.0.0",
+    "prometheus-gc-stats": "^0.6.0"
+  },
+  "peerDependencies": {
+    "electron-webrtc": "^0.3.0",
+    "wrtc": "^0.4.6"
+  }
+}

--- a/packages/ipfs-daemon/src/index.js
+++ b/packages/ipfs-daemon/src/index.js
@@ -12,6 +12,7 @@ const IPFS = require('ipfs-core')
 const HttpApi = require('ipfs-http-server')
 const HttpGateway = require('ipfs-http-gateway')
 const createRepo = require('ipfs-core/src/runtime/repo-nodejs')
+const { isElectron } = require('ipfs-utils/src/env')
 
 class Daemon {
   constructor (options = {}) {
@@ -51,7 +52,7 @@ class Daemon {
     const httpGateway = new HttpGateway(ipfs, ipfsOpts)
     this._httpGateway = await httpGateway.start()
 
-    // for the CLI to know the where abouts of the API
+    // for the CLI to know the whereabouts of the API
     // @ts-ignore - _apiServers is possibly undefined
     if (this._httpApi._apiServers.length) {
       // @ts-ignore - _apiServers is possibly undefined
@@ -79,17 +80,23 @@ function getLibp2p ({ libp2pOptions, options, config, peerId }) {
   // Attempt to use any of the WebRTC versions available globally
   let electronWebRTC
   let wrtc
-  try {
-    // @ts-ignore - cant find type info
-    electronWebRTC = require('electron-webrtc')()
-  } catch (err) {
-    log('failed to load optional electron-webrtc dependency')
+
+  if (isElectron) {
+    try {
+      // @ts-ignore - cant find type info
+      electronWebRTC = require('electron-webrtc')()
+    } catch (err) {
+      log('failed to load optional electron-webrtc dependency')
+    }
   }
-  try {
-    // @ts-ignore - cant find type info
-    wrtc = require('wrtc')
-  } catch (err) {
-    log('failed to load optional webrtc dependency')
+
+  if (!electronWebRTC) {
+    try {
+      // @ts-ignore - cant find type info
+      wrtc = require('wrtc')
+    } catch (err) {
+      log('failed to load optional webrtc dependency')
+    }
   }
 
   if (wrtc || electronWebRTC) {

--- a/packages/ipfs-daemon/test/index.spec.js
+++ b/packages/ipfs-daemon/test/index.spec.js
@@ -1,0 +1,63 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('aegir/utils/chai')
+const Daemon = require('../')
+const fetch = require('node-fetch')
+
+describe('daemon', () => {
+  let daemon
+
+  it('should start a http api server', async () => {
+    daemon = new Daemon({})
+
+    await daemon.start()
+
+    const {
+      uri
+    } = daemon._httpApi._apiServers[0].info
+
+    const httpId = (await fetch(`${uri}/api/v0/id`, {
+      method: 'POST'
+    })).json()
+
+    const apiId = await daemon._ipfs.id()
+
+    await expect(httpId).to.eventually.have.property('PublicKey', apiId.publicKey)
+
+    await daemon.stop()
+  })
+
+  it('should start a http gateway server', async () => {
+    daemon = new Daemon({})
+
+    await daemon.start()
+
+    const {
+      uri
+    } = daemon._httpGateway._gatewayServers[0].info
+
+    const result = await (await fetch(`${uri}/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`, {
+      method: 'POST'
+    })).text()
+
+    expect(result).to.include('Index of /ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/')
+
+    await daemon.stop()
+  })
+
+  it('should stop', async () => {
+    daemon = new Daemon({})
+
+    await daemon.start()
+    await daemon.stop()
+
+    const {
+      uri
+    } = daemon._httpApi._apiServers[0].info
+
+    await expect(fetch(`${uri}/api/v0/id`, {
+      method: 'POST'
+    })).to.eventually.be.rejectedWith(/ECONNREFUSED/)
+  })
+})

--- a/packages/ipfs-daemon/tsconfig.json
+++ b/packages/ipfs-daemon/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../ipfs-core-utils"
     },
     {
-      "path": "../ipfs-daemon"
-    },
-    {
       "path": "../ipfs-http-client"
     },
     {

--- a/packages/ipfs-http-gateway/package.json
+++ b/packages/ipfs-http-gateway/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "IPFS"
   ],
-  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs#readme",
+  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-gateway#readme",
   "bugs": "https://github.com/ipfs/js-ipfs/issues",
   "license": "(Apache-2.0 OR MIT)",
   "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",

--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "IPFS"
   ],
-  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs#readme",
+  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-server#readme",
   "bugs": "https://github.com/ipfs/js-ipfs/issues",
   "license": "(Apache-2.0 OR MIT)",
   "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
       "ipfs-core-utils/*": [
         "ipfs-core-utils/*"
       ],
+      "ipfs-daemon/*": [
+        "ipfs-daemon/*"
+      ],
       "ipfs-http-client/*": [
         "ipfs-http-client/*"
       ],


### PR DESCRIPTION
The daemon is a way of exposing IPFS functionality that's used by the
CLI, in the same way that IPFS itself is used by the CLI so split it
out into it's own module for better separation of concerns.