### PR TITLE
Export IPFS instance type

### DIFF
--- a/packages/ipfs-core/src/index.js
+++ b/packages/ipfs-core/src/index.js
@@ -13,6 +13,10 @@ const multihash = multihashing.multihash
 const CID = require('cids')
 const IPFS = require('./components')
 
+/**
+ * @typedef {import('./components')} default
+ */
+
 module.exports = {
   create: IPFS.create,
   crypto,

--- a/packages/ipfs-core/src/index.js
+++ b/packages/ipfs-core/src/index.js
@@ -11,14 +11,14 @@ const multicodec = require('multicodec')
 const multihashing = require('multihashing-async')
 const multihash = multihashing.multihash
 const CID = require('cids')
-const IPFS = require('./components')
+const { create } = require('./components')
 
 /**
  * @typedef {import('./components')} default
  */
 
 module.exports = {
-  create: IPFS.create,
+  create,
   crypto,
   isIPFS,
   CID,

--- a/packages/ipfs-core/src/index.js
+++ b/packages/ipfs-core/src/index.js
@@ -14,6 +14,11 @@ const CID = require('cids')
 const { create } = require('./components')
 
 /**
+ * Export IPFS instance type
+ *
+ * This will result in `export default import("./components")`
+ * in the generated `d.ts` file
+ *
  * @typedef {import('./components')} default
  */
 

--- a/packages/ipfs/src/index.d.ts
+++ b/packages/ipfs/src/index.d.ts
@@ -1,0 +1,3 @@
+type IPFS = import('ipfs-core/src/components')
+declare const IPFS: typeof import('ipfs-core')
+export = IPFS

--- a/packages/ipfs/src/index.d.ts
+++ b/packages/ipfs/src/index.d.ts
@@ -1,3 +1,0 @@
-type IPFS = import('ipfs-core/src/components')
-declare const IPFS: typeof import('ipfs-core')
-export = IPFS

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -3,7 +3,12 @@
 const IPFS = require('ipfs-core')
 
 /**
- * @typedef {import('ipfs-core/src/components')} IPFS default
+ * Export IPFS instance type
+ *
+ * This will overlap onto the default export
+ * in the generated `d.ts` file
+ *
+ * @typedef {import('ipfs-core').default} IPFS
  */
 
 module.exports = IPFS

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -1,14 +1,12 @@
 'use strict'
 
-const IPFS = require('ipfs-core')
+module.exports = require('ipfs-core')
 
 /**
  * Export IPFS instance type
  *
- * This will overlap onto the default export
+ * This will result in `export default …`
  * in the generated `d.ts` file
- *
- * @typedef {import('ipfs-core').default} IPFS
  */
-
-module.exports = IPFS
+// @ts-ignore duplicate identifier
+/** @typedef {import('ipfs-core').default} default */

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -2,4 +2,8 @@
 
 const IPFS = require('ipfs-core')
 
+/**
+ * @typedef {import('ipfs-core/src/components')} IPFS
+ */
+
 module.exports = IPFS

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -1,12 +1,14 @@
 'use strict'
 
-module.exports = require('ipfs-core')
+const IPFS = require('ipfs-core')
 
 /**
  * Export IPFS instance type
  *
- * This will result in `export default …`
+ * This will overlap onto the default export
  * in the generated `d.ts` file
+ *
+ * @typedef {import('ipfs-core').default} IPFS
  */
-// @ts-ignore duplicate identifier
-/** @typedef {import('ipfs-core/src/components')} default */
+
+module.exports = IPFS

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -9,4 +9,4 @@ module.exports = require('ipfs-core')
  * in the generated `d.ts` file
  */
 // @ts-ignore duplicate identifier
-/** @typedef {import('ipfs-core').default} default */
+/** @typedef {import('ipfs-core/src/components')} default */

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -3,7 +3,7 @@
 const IPFS = require('ipfs-core')
 
 /**
- * @typedef {import('ipfs-core/src/components')} IPFS
+ * @typedef {import('ipfs-core/src/components')} IPFS default
  */
 
 module.exports = IPFS


### PR DESCRIPTION
solves https://github.com/ipfs/js-ipfs/issues/2945#issuecomment-731784171

## Usage 

```ts

import IPFS from 'ipfs'

function doSomething (ipfs: IPFS) {
    // ...
}

// ...
doSomething(await IPFS.create())
```