### PR TITLE
fix: export IPFS type

### DIFF
--- a/examples/types-use-ipfs-from-ts/package.json
+++ b/examples/types-use-ipfs-from-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "types-use-ipfs-from-ts",
+  "name": "example-types-use-ipfs-from-ts",
   "private": true,
   "dependencies": {
     "ipfs": "^0.52.1"

--- a/examples/types-use-ipfs-from-ts/src/main.ts
+++ b/examples/types-use-ipfs-from-ts/src/main.ts
@@ -1,7 +1,8 @@
-import IPFS from 'ipfs'
+import { IPFS, create } from 'ipfs'
+import CID from 'cids'
 
-export default async function main () {
-  const node = await IPFS.create()
+export default async function main() {
+  const node = await create()
   const version = await node.version()
 
   console.log('Version:', version.version)
@@ -14,15 +15,21 @@ export default async function main () {
   console.log('Added file:', file.path, file.cid.toString())
   try {
     file.cid.toUpperCase()
-  } catch(error) {
+  } catch (error) {
 
   }
 
-  const decoder = new TextDecoder()
-  let content = ''
-  for await (const chunk of node.cat(file.cid)) {
-    content += decoder.decode(chunk)  
-  }
+  const content = await readFile(node, file.cid)
 
   console.log('Added file contents:', content)
+}
+
+const readFile = async (ipfs: IPFS, cid: CID): Promise<string> => {
+  const decoder = new TextDecoder()
+  let content = ''
+  for await (const chunk of ipfs.cat(cid)) {
+    content += decoder.decode(chunk)
+  }
+
+  return content
 }

--- a/examples/types-use-ipfs-from-ts/src/main.ts
+++ b/examples/types-use-ipfs-from-ts/src/main.ts
@@ -14,6 +14,7 @@ export default async function main() {
 
   console.log('Added file:', file.path, file.cid.toString())
   try {
+    // @ts-expect-error CID has no toUpperCase method
     file.cid.toUpperCase()
   } catch (error) {
 

--- a/examples/types-use-ipfs-from-typed-js/package.json
+++ b/examples/types-use-ipfs-from-typed-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "types-use-ipfs-from-typed-js",
+  "name": "example-types-use-ipfs-from-typed-js",
   "private": true,
   "dependencies": {
     "ipfs": "^0.52.1"

--- a/examples/types-use-ipfs-from-typed-js/src/main.js
+++ b/examples/types-use-ipfs-from-typed-js/src/main.js
@@ -1,11 +1,11 @@
 const { create } = require('ipfs')
 /**
- * @typedef {import('ipfs').IPFS} IPFS 
+ * @typedef {import('ipfs').IPFS} IPFS
  * @typedef {import('cids')} CID
  */
 
 async function main () {
-  const node = await IPFS.create()
+  const node = await create()
   const version = await node.version()
 
   console.log('Version:', version.version)
@@ -17,6 +17,7 @@ async function main () {
 
   console.log('Added file:', file.path, file.cid.toString())
   try {
+    // @ts-expect-error CID has no toUpperCase method
     file.cid.toUpperCase()
   } catch(error) {
 
@@ -28,15 +29,15 @@ async function main () {
 }
 
 /**
- * @param {IPFS} ipfs 
- * @param {CID} cid 
+ * @param {IPFS} ipfs
+ * @param {CID} cid
  * @returns {Promise<string>}
  */
 const readFile = async (ipfs, cid) => {
     const decoder = new TextDecoder()
   let content = ''
   for await (const chunk of ipfs.cat(cid)) {
-    content += decoder.decode(chunk)  
+    content += decoder.decode(chunk)
   }
   return content
 }

--- a/examples/types-use-ipfs-from-typed-js/src/main.js
+++ b/examples/types-use-ipfs-from-typed-js/src/main.js
@@ -1,4 +1,8 @@
-const IPFS = require('ipfs')
+const { create } = require('ipfs')
+/**
+ * @typedef {import('ipfs').IPFS} IPFS 
+ * @typedef {import('cids')} CID
+ */
 
 async function main () {
   const node = await IPFS.create()
@@ -18,13 +22,23 @@ async function main () {
 
   }
 
-  const decoder = new TextDecoder()
-  let content = ''
-  for await (const chunk of node.cat(file.cid)) {
-    content += decoder.decode(chunk)  
-  }
+  const content = await readFile(node, file.cid)
 
   console.log('Added file contents:', content)
+}
+
+/**
+ * @param {IPFS} ipfs 
+ * @param {CID} cid 
+ * @returns {Promise<string>}
+ */
+const readFile = async (ipfs, cid) => {
+    const decoder = new TextDecoder()
+  let content = ''
+  for await (const chunk of ipfs.cat(cid)) {
+    content += decoder.decode(chunk)  
+  }
+  return content
 }
 
 main()

--- a/packages/ipfs-core/src/index.js
+++ b/packages/ipfs-core/src/index.js
@@ -11,10 +11,14 @@ const multicodec = require('multicodec')
 const multihashing = require('multihashing-async')
 const multihash = multihashing.multihash
 const CID = require('cids')
-const IPFS = require('./components')
+const { create } = require('./components')
+
+/**
+ * @typedef {import('./components')} IPFS
+ */
 
 module.exports = {
-  create: IPFS.create,
+  create,
   crypto,
   isIPFS,
   CID,

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
-const IPFS = require('ipfs-core')
+/**
+ * @typedef {import('ipfs-core/src/components')} IPFS
+ */
 
-module.exports = IPFS
+module.exports = { ...require('ipfs-core') }


### PR DESCRIPTION
This is an attempt to illustrate a different approach for exporting IPFS type than one proposed in #3439.

Here instead of using `default export` for type `IPFS` type is just exported with it's name so that user in ts can write `import { IPFS, create } from "ipfs"` and equivalent in js as well.

Pull also updates two examples we have in place to both illustrate & test this.