### PR TITLE
fix(types): correct factory options types

### DIFF
--- a/packages/ipfs-http-client/src/index.js
+++ b/packages/ipfs-http-client/src/index.js
@@ -10,7 +10,7 @@ const globSource = require('ipfs-utils/src/files/glob-source')
 const urlSource = require('ipfs-utils/src/files/url-source')
 
 /**
- * @param {import("./lib/core").ClientOptions} options
+ * @param {import("./lib/core").ClientOptions|URL|multiaddr|string} options
  */
 function ipfsClient (options = {}) {
   return {


### PR DESCRIPTION
This extends the range of allowed `ipfsClient`'s options that is possible to pass to `ipfsClient`. Relates to https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/lib/core.js#L19