### PR TITLE
Re-enabling orbit-db and ipfs-log tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -347,14 +347,14 @@ jobs:
       if: branch = master AND type = push AND fork = false
       name: external - orbit-db
       script:
-        - npm run test:external -- -- -- https://github.com/orbitdb/orbit-db.git --deps=ipfs@next
+        - npm run test:external -- -- -- https://github.com/orbitdb/orbit-db.git --deps=orbit-db-test-utils@next
 
     - stage: test-external
       # only run on changes to master
       if: branch = master AND type = push AND fork = false
       name: external - ipfs-log
       script:
-        - npm run test:external -- -- -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@next
+        - npm run test:external -- -- -- https://github.com/orbitdb/ipfs-log.git --deps=orbit-db-test-utils@next
 
     - stage: test-external
       # only run on changes to master


### PR DESCRIPTION
The goal of this PR is to re-enable the automated tests that run against [orbit-db](https://github.com/orbitdb/orbit-db) and [ipfs-log](https://github.com/orbitdb/orbit-db) when Travis CI wants to run them.

I have created [this branch of `orbit-db-test-utils`](https://github.com/orbitdb/orbit-db-test-utils/compare/bleeding-edge) and published it to npm as @next. If all goes according to plan then it will automatically pull in the latest versions of `go-ipfs`, `js-ipfs`, `ipfs-ctl`, and `ipfs-http-client`. Then it should run the OrbitDB tests.

Opening this now to get feedback, since I can't get the `--deps` argument to work locally :sweat_smile: but I'm nearly certain this approach should work. Let me know what I'm missing and if this approach will get us back to testing OrbitDB automatically

Thank you!

Fixes #3202 