### PR TITLE
chore: Replace transfer arrays with sets in ipfs-message-port-*

### DIFF
--- a/packages/ipfs-message-port-client/src/client/transport.js
+++ b/packages/ipfs-message-port-client/src/client/transport.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { decodeError } = require('ipfs-message-port-protocol/src/error')
+const { ensureUniqueBuffers } = require('ipfs-message-port-protocol/src/buffer')
 const { DisconnectError, TimeoutError, AbortError } = require('./error')
 
 /**
@@ -177,8 +178,8 @@ module.exports = class MessageTransport {
         id,
         input: query.toJSON()
       },
-      // @ts-ignore - TS seems to want second arg to postMessage to not be undefined
-      [...new Set(query.transfer() || [])]
+      // @ts-expect-error - TS seems to want second arg to postMessage to not be undefined
+      ensureUniqueBuffers(query.transfer() || [])
     )
   }
 

--- a/packages/ipfs-message-port-protocol/README.md
+++ b/packages/ipfs-message-port-protocol/README.md
@@ -176,7 +176,7 @@ port2.onmessage = async ({data}) => {
 
 ### Callback
 
-Primitive callbacks that take single parameter supported by [structured cloning algorithm][] like progress callback used across IPFS APIs can be encoded / decoded. Unilke most encoders `transfer` argument is required (because value is encoded to a [MessagePort][] that can only be transferred)
+Primitive callbacks that take single parameter supported by [structured cloning algorithm][] like progress callback used across IPFS APIs can be encoded / decoded. Unlike most encoders `transfer` argument is required (because value is encoded to a [MessagePort][] that can only be transferred)
 
 ```js
 const { encodeCallback, decodeCallback } = require('ipfs-message-port-protocol/src/core')
@@ -217,4 +217,3 @@ Check out our [contributing document](https://github.com/ipfs/community/blob/mas
 ## License
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fipfs%2Fjs-ipfs.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fipfs%2Fjs-ipfs?ref=badge_large)
-

--- a/packages/ipfs-message-port-protocol/src/buffer.js
+++ b/packages/ipfs-message-port-protocol/src/buffer.js
@@ -1,0 +1,11 @@
+'use strict'
+
+/**
+ * Transforms an array of ArrayBuffers into a Set,
+ * and makes sure the buffers are not detached.
+ *
+ * @param {Transferable[]} values
+ * @returns {Set<Transferable>}
+ */
+const ensureUniqueBuffers = values => new Set(values)
+exports.ensureUniqueBuffers = ensureUniqueBuffers

--- a/packages/ipfs-message-port-server/test/transfer.spec.js
+++ b/packages/ipfs-message-port-server/test/transfer.spec.js
@@ -15,7 +15,7 @@ describe('Server', function () {
     const cid = new CID('QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D')
 
     return new Promise((resolve, reject) => {
-      const channel = process.browser
+      const channel = globalThis.MessageChannel
         ? new globalThis.MessageChannel()
         : new (require('worker_threads').MessageChannel)()
 


### PR DESCRIPTION
1. ~~Fixes #3480~~
As described in the issue, I wasn't sure how to tackle this, but I decided to go the "remove already detached buffers" route. This seems to work, I tested this with my app (see issue for more info). Thoughts?

2. Instead of passing of an Array to `postMessage`, we can just pass the Set iterable.
The only downside of this seems to be that Typescript doesn't like this 🤔 
Typescript expects an Array, not an iterable like it should.

3. ~~I just discovered there's a thing called `SharedArrayBuffer`, maybe we should use that instead? 🤔~~
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer