### PR TITLE
Enable text streaming support for React Native (iOS and Android) on pubsub.subscribe

### DIFF
--- a/packages/ipfs-http-client/src/pubsub/subscribe.js
+++ b/packages/ipfs-http-client/src/pubsub/subscribe.js
@@ -34,7 +34,11 @@ module.exports = configure((api, options) => {
           arg: topic,
           ...options
         }),
-        headers: options.headers
+        headers: options.headers,
+        // Enables text streaming support for React Native when using @react-native-community/fetch
+        reactNative: {
+          textStreaming: true
+        }
       })
         .catch((err) => {
           // Initial subscribe fail, ensure we clean up


### PR DESCRIPTION
React Native's Networking API accepts several arguments, two of which that:
- Drive the [native response type](https://github.com/facebook/react-native/blob/v0.63.4/Libraries/Network/NativeNetworkingIOS.js#L23) (one of `blob`, `base64` or `text`).
- Drive whether we want to subscribe to [incremental data events](https://github.com/facebook/react-native/blob/v0.63.4/Libraries/Network/NativeNetworkingIOS.js#L24).

The reception of incremental data is only [supported](https://github.com/facebook/react-native/blob/v0.63.4/Libraries/Network/RCTNetworking.mm#L544-L547) when the native response type is set to `'text'`. As such, [@react-native-community/fetch](https://github.com/react-native-community/fetch), the implementation of the fetch API that provides text streaming support for React Native, accepts a custom option to drive the arguments mentioned above.

In the [demo app](https://github.com/ipfs-shipyard/react-native-ipfs-demo), this option is currently included with a [patch](https://github.com/ipfs-shipyard/react-native-ipfs-demo/blob/master/patches/ipfs/ipfs-http-client%2B48.2.0.patch). 
