### PR TITLE
fix: pass an agent to delegate modules that allows http -> https upgrade

### DIFF
--- a/packages/ipfs-grpc-client/src/index.js
+++ b/packages/ipfs-grpc-client/src/index.js
@@ -22,7 +22,7 @@ function normaliseUrls (opts) {
 /**
  * @param {object} opts
  * @param {string} opts.url - The URL to connect to as a URL or Multiaddr
- * @param {import('http').Agent} [opts.agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * @property {Agent | function(string):Agent} [agent] - A [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) or a function that returns an agent, used to control connection persistence and reuse for HTTP clients (only supported in node.js)
  */
 module.exports = function createClient (opts = { url: '' }) {
   opts.url = toUrlString(opts.url)

--- a/packages/ipfs-http-client/src/lib/core.js
+++ b/packages/ipfs-http-client/src/lib/core.js
@@ -129,7 +129,7 @@ const parseTimeout = (value) => {
  * @property {object} [ipld]
  * @property {any[]} [ipld.formats] - An array of additional [IPLD formats](https://github.com/ipld/interface-ipld-format) to support
  * @property {(format: string) => Promise<any>} [ipld.loadFormat] - an async function that takes the name of an [IPLD format](https://github.com/ipld/interface-ipld-format) as a string and should return the implementation of that codec
- * @property {Agent} [agent] - A [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) used to control connection persistence and reuse for HTTP clients (only supported in node.js)
+ * @property {Agent | function(string):Agent} [agent] - A [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) or a function that returns an agent, used to control connection persistence and reuse for HTTP clients (only supported in node.js)
  */
 class Client extends HTTP {
   /**


### PR DESCRIPTION
If we make a http request that returns a `302` with the location at a https endpoint
by default the same `http.Agent` is used for the subsequent request, which then
fails because it needs an `https.Agent`.

This PR uses a function to return an agent appropriate for the request.

Fixes this sort of error:

```console
  libp2p:dht:QmU3tmEn findProviders bagcqceraf273nfx4oiew6h72dn2mbyscycxga6u6hllnd2kidscg3r7rsowa +0ms
  libp2p:dht:providers:QmU3tmEn getProviders bagcqceraf273nfx4oiew6h72dn2mbyscycxga6u6hllnd2kidscg3r7rsowa +0ms
  libp2p-delegated-content-routing findProviders starts: bagcqceraf273nfx4oiew6h72dn2mbyscycxga6u6hllnd2kidscg3r7rsowa +413ms
  libp2p-delegated-content-routing:error findProviders errored: TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
    at new ClientRequest (_http_client.js:152:11)
    at request (https.js:314:10)
    at /Users/alex/test/jose/node_modules/node-fetch/lib/index.js:1438:15
    at new Promise (<anonymous>)
    at fetch (/Users/alex/test/jose/node_modules/node-fetch/lib/index.js:1407:9)
    at fetch (/Users/alex/test/jose/node_modules/ipfs-utils/src/http/fetch.node.js:32:3)
    at Client.fetch (/Users/alex/test/jose/node_modules/ipfs-utils/src/http.js:132:36)
    at Client.fetch (/Users/alex/test/jose/node_modules/ipfs-http-client/src/lib/core.js:178:20)
    at Client.post (/Users/alex/test/jose/node_modules/ipfs-utils/src/http.js:174:17)
    at Object.findProvs (/Users/alex/test/jose/node_modules/ipfs-http-client/src/dht/find-provs.js:14:27) {
  code: 'ERR_INVALID_PROTOCOL'
} +0ms
```