### PR TITLE
fix: use https agent for https requests

### DIFF
--- a/packages/ipfs-grpc-client/src/grpc/transport.node.js
+++ b/packages/ipfs-grpc-client/src/grpc/transport.node.js
@@ -7,6 +7,11 @@
 const WebSocket = require('ws')
 const debug = require('debug')('ipfs:grpc-client:websocket-transport')
 
+/**
+ * @typedef {import('http').Agent} HttpAgent
+ * @typedef {import('https').Agent} HttpsAgent
+ */
+
 const WebsocketSignal = {
   FINISH_SEND: 1
 }
@@ -15,7 +20,7 @@ const finishSendFrame = new Uint8Array([1])
 
 /**
  * @param {object} options
- * @param {import('http').Agent} [options.agent] - http.Agent used to control HTTP client behaviour
+ * @param {HttpAgent|HttpsAgent} [options.agent] - http.Agent used to control HTTP client behaviour
  */
 function WebsocketTransport (options) {
   /**
@@ -33,7 +38,7 @@ function WebsocketTransport (options) {
 
 /**
  * @typedef {object} NodeTransportOptions
- * @property {import('http').Agent} [options.agent]
+ * @property {HttpAgent|HttpsAgent} [options.agent]
  *
  * @typedef {NodeTransportOptions & import('@improbable-eng/grpc-web').grpc.TransportOptions} WebSocketTransportOptions
  *

--- a/packages/ipfs-grpc-client/src/index.js
+++ b/packages/ipfs-grpc-client/src/index.js
@@ -20,9 +20,12 @@ function normaliseUrls (opts) {
 }
 
 /**
+ * @typedef {import('http').Agent} HttpAgent
+ * @typedef {import('https').Agent} HttpsAgent
+ *
  * @param {object} opts
  * @param {string} opts.url - The URL to connect to as a URL or Multiaddr
- * @param {import('http').Agent} [opts.agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * @param {HttpAgent|HttpsAgent} [opts.agent] - http.Agent used to control HTTP client behaviour (node.js only)
  */
 module.exports = function createClient (opts = { url: '' }) {
   opts.url = toUrlString(opts.url)

--- a/packages/ipfs-grpc-client/src/utils/bidi-to-duplex.js
+++ b/packages/ipfs-grpc-client/src/utils/bidi-to-duplex.js
@@ -5,6 +5,11 @@ const errCode = require('err-code')
 const toHeaders = require('./to-headers')
 const transport = require('../grpc/transport')
 
+/**
+ * @typedef {import('http').Agent} HttpAgent
+ * @typedef {import('https').Agent} HttpsAgent
+ */
+
 async function sendMessages (service, client, source) {
   for await (const obj of source) {
     client.send({
@@ -24,7 +29,7 @@ async function sendMessages (service, client, source) {
  * @param {string} options.host - The remote host
  * @param {boolean} [options.debug] - Whether to print debug messages
  * @param {object} [options.metadata] - Metadata sent as headers
- * @param {import('http').Agent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * @param {HttpAgent|HttpsAgent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
  * @returns {{ source: AsyncIterable<object>, sink: { push: Function, end: Function } }}
  **/
 module.exports = function bidiToDuplex (grpc, service, options) {

--- a/packages/ipfs-grpc-client/src/utils/client-stream-to-promise.js
+++ b/packages/ipfs-grpc-client/src/utils/client-stream-to-promise.js
@@ -4,6 +4,11 @@ const first = require('it-first')
 const bidiToDuplex = require('./bidi-to-duplex')
 
 /**
+ * @typedef {import('http').Agent} HttpAgent
+ * @typedef {import('https').Agent} HttpsAgent
+ */
+
+/**
  * Client streaming methods are a many-to-one operation so this
  * function takes a source that can emit multiple messages and
  * returns a promise that resolves to the server response.
@@ -15,7 +20,7 @@ const bidiToDuplex = require('./bidi-to-duplex')
  * @param {string} options.host - The remote host
  * @param {boolean} [options.debug] - Whether to print debug messages
  * @param {object} [options.metadata] - Metadata sent as headers
- * @param {import('http').Agent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * @param {HttpAgent|HttpsAgent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
  * @returns {Promise<Object>} - A promise that resolves to a response object
  **/
 module.exports = async function clientStreamToPromise (grpc, service, source, options) {

--- a/packages/ipfs-grpc-client/src/utils/server-stream-to-iterator.js
+++ b/packages/ipfs-grpc-client/src/utils/server-stream-to-iterator.js
@@ -3,6 +3,11 @@
 const bidiToDuplex = require('./bidi-to-duplex')
 
 /**
+ * @typedef {import('http').Agent} HttpAgent
+ * @typedef {import('https').Agent} HttpsAgent
+ */
+
+/**
  * Server stream methods are one-to-many operations so this
  * function accepts a client message and returns a source
  * from which multiple server messages can be read.
@@ -14,7 +19,7 @@ const bidiToDuplex = require('./bidi-to-duplex')
  * @param {string} options.host - The remote host
  * @param {boolean} [options.debug] - Whether to print debug messages
  * @param {object} [options.metadata] - Metadata sent as headers
- * @param {import('http').Agent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * @param {HttpAgent|HttpsAgent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
  * @returns {AsyncIterable<object>}
  **/
 module.exports = function serverStreamToIterator (grpc, service, request, options) {

--- a/packages/ipfs-grpc-client/src/utils/unary-to-promise.js
+++ b/packages/ipfs-grpc-client/src/utils/unary-to-promise.js
@@ -4,6 +4,11 @@ const first = require('it-first')
 const bidiToDuplex = require('./bidi-to-duplex')
 
 /**
+ * @typedef {import('http').Agent} HttpAgent
+ * @typedef {import('https').Agent} HttpsAgent
+ */
+
+/**
  * Unary calls are one-to-one operations so this function
  * takes a client message and returns a promise that resolves
  * to the server response.
@@ -15,7 +20,7 @@ const bidiToDuplex = require('./bidi-to-duplex')
  * @param {string} options.host - The remote host
  * @param {boolean} [options.debug] - Whether to print debug messages
  * @param {object} [options.metadata] - Metadata sent as headers
- * @param {import('http').Agent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * @param {HttpAgent|HttpsAgent} [options.agent] - http.Agent used to control HTTP client behaviour (node.js only)
  * @returns {Promise<Object>} - A promise that resolves to a response object
  **/
 module.exports = function unaryToPromise (grpc, service, request, options) {

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -19,7 +19,8 @@
     "ipfs-utils/src/files/glob-source": false,
     "go-ipfs": false,
     "ipfs-core-utils/src/files/normalise-input": "ipfs-core-utils/src/files/normalise-input/index.browser.js",
-    "http": false
+    "http": false,
+    "https": false
   },
   "typesVersions": {
     "*": {

--- a/packages/ipfs-http-client/src/lib/core.js
+++ b/packages/ipfs-http-client/src/lib/core.js
@@ -8,6 +8,7 @@ const HTTP = require('ipfs-utils/src/http')
 const merge = require('merge-options')
 const toUrlString = require('ipfs-core-utils/src/to-url-string')
 const http = require('http')
+const https = require('https')
 
 const DEFAULT_PROTOCOL = isBrowser || isWebWorker ? location.protocol : 'http'
 const DEFAULT_HOST = isBrowser || isWebWorker ? location.hostname : 'localhost'
@@ -49,7 +50,9 @@ const normalizeOptions = (options = {}) => {
   }
 
   if (isNode) {
-    agent = opts.agent || new http.Agent({
+    const Agent = url.protocol.startsWith('https') ? https.Agent : http.Agent
+
+    agent = opts.agent || new Agent({
       keepAlive: true,
       // Similar to browsers which limit connections to six per host
       maxSockets: 6
@@ -116,7 +119,8 @@ const parseTimeout = (value) => {
 }
 
 /**
- * @typedef {import('http').Agent} Agent
+ * @typedef {import('http').Agent} HttpAgent
+ * @typedef {import('https').Agent} HttpsAgent
  *
  * @typedef {Object} ClientOptions
  * @property {string} [host]
@@ -129,7 +133,7 @@ const parseTimeout = (value) => {
  * @property {object} [ipld]
  * @property {any[]} [ipld.formats] - An array of additional [IPLD formats](https://github.com/ipld/interface-ipld-format) to support
  * @property {(format: string) => Promise<any>} [ipld.loadFormat] - an async function that takes the name of an [IPLD format](https://github.com/ipld/interface-ipld-format) as a string and should return the implementation of that codec
- * @property {Agent} [agent] - A [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) used to control connection persistence and reuse for HTTP clients (only supported in node.js)
+ * @property {HttpAgent|HttpsAgent} [agent] - A [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) used to control connection persistence and reuse for HTTP clients (only supported in node.js)
  */
 class Client extends HTTP {
   /**


### PR DESCRIPTION
Fixes regression introduced in #3474 - if we make https requests, use a https agent.