### PR TITLE
fix: issue with isolateModules flag

### DIFF
--- a/packages/ipfs-client/package.json
+++ b/packages/ipfs-client/package.json
@@ -22,6 +22,9 @@
       ]
     }
   },
+  "eslintConfig": {
+    "extends": "ipfs"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfs/js-ipfs.git"

--- a/packages/ipfs-client/src/index.js
+++ b/packages/ipfs-client/src/index.js
@@ -4,16 +4,12 @@ const httpClient = require('ipfs-http-client')
 const grpcClient = require('ipfs-grpc-client')
 const mergeOptions = require('merge-options')
 
-
 /**
  * @typedef {import('ipfs-http-client/src/lib/core').ClientOptions} HTTPOptions
  * @typedef {import('ipfs-grpc-client/src/index').Options} GRPCOptions
- * @typedef {Partial<HTTPOptions & GRPCOptions> & {
- *   url?: string
- *   http?: string,
- *   grpc?: string
- * }} Options
- * 
+ * @typedef {string|URL|import('multiaddr')} Address
+ * @typedef {{http?: Address, grpc?: Address} & Partial<HTTPOptions & GRPCOptions>} Options
+ *
  * @param {Options} [opts]
  */
 module.exports = function createClient (opts = {}) {

--- a/packages/ipfs-client/src/index.js
+++ b/packages/ipfs-client/src/index.js
@@ -4,6 +4,18 @@ const httpClient = require('ipfs-http-client')
 const grpcClient = require('ipfs-grpc-client')
 const mergeOptions = require('merge-options')
 
+
+/**
+ * @typedef {import('ipfs-http-client/src/lib/core').ClientOptions} HTTPOptions
+ * @typedef {import('ipfs-grpc-client/src/index').Options} GRPCOptions
+ * @typedef {Partial<HTTPOptions & GRPCOptions> & {
+ *   url?: string
+ *   http?: string,
+ *   grpc?: string
+ * }} Options
+ * 
+ * @param {Options} [opts]
+ */
 module.exports = function createClient (opts = {}) {
   const clients = []
 

--- a/packages/ipfs-client/tsconfig.json
+++ b/packages/ipfs-client/tsconfig.json
@@ -3,6 +3,14 @@
   "compilerOptions": {
     "outDir": "dist"
   },
+  "references": [
+    {
+      "path": "../ipfs-http-client"
+    },
+    {
+      "path": "../ipfs-grpc-client"
+    }
+  ],
   "include": [
     "src",
     "package.json"

--- a/packages/ipfs-core-types/src/index.ts
+++ b/packages/ipfs-core-types/src/index.ts
@@ -1,7 +1,7 @@
 import { RootAPI } from './root'
 import { AbortOptions, Await, AwaitIterable } from './basic'
 
-export {
+export type {
   RootAPI,
 
   AbortOptions,

--- a/packages/ipfs-grpc-client/package.json
+++ b/packages/ipfs-grpc-client/package.json
@@ -60,5 +60,8 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
     "typescript": "4.0.x"
+  },
+  "eslintConfig": {
+    "extends": "ipfs"
   }
 }

--- a/packages/ipfs-grpc-client/src/index.js
+++ b/packages/ipfs-grpc-client/src/index.js
@@ -23,9 +23,11 @@ function normaliseUrls (opts) {
  * @typedef {import('http').Agent} HttpAgent
  * @typedef {import('https').Agent} HttpsAgent
  *
- * @param {object} opts
- * @param {string} opts.url - The URL to connect to as a URL or Multiaddr
- * @param {HttpAgent|HttpsAgent} [opts.agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * @typedef {Object} Options
+ * @property {string} url - The URL to connect to as a URL or Multiaddr
+ * @property {HttpAgent|HttpsAgent} [agent] - http.Agent used to control HTTP client behaviour (node.js only)
+ * 
+ * @param {Options} [opts]
  */
 module.exports = function createClient (opts = { url: '' }) {
   opts.url = toUrlString(opts.url)

--- a/packages/ipfs-grpc-client/src/index.js
+++ b/packages/ipfs-grpc-client/src/index.js
@@ -24,9 +24,9 @@ function normaliseUrls (opts) {
  * @typedef {import('https').Agent} HttpsAgent
  *
  * @typedef {Object} Options
- * @property {string} url - The URL to connect to as a URL or Multiaddr
+ * @property {string|URL|import('multiaddr')} url - The URL to connect to as a URL or Multiaddr
  * @property {HttpAgent|HttpsAgent} [agent] - http.Agent used to control HTTP client behaviour (node.js only)
- * 
+ *
  * @param {Options} [opts]
  */
 module.exports = function createClient (opts = { url: '' }) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "stripInternal": true,
     "resolveJsonModule": true,
     "incremental": true,
+    "isolatedModules": true,
     "baseUrl": ".",
     "paths": {
       "interface-ipfs-core/*": [


### PR DESCRIPTION
Fixes #3494

It appears that `react-scripts` swaps `isolateModules` which [causes problems in webui](https://github.com/ipfs-shipyard/ipfs-webui/pull/1655#issuecomment-763846124) because according to TS:

> Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.  TS1205

Changes here address that problem as follows:

- `export type {...}` is used as per TS error.
- `isolateModules` flag is set to `true` so that such issues can be caught locally.
- Setting flags seems to have triggered problems in `ipfs-client`, so I had to add some type annotations to fix that.
- Added `references` in `ipfs-client/tsconfig.json`, otherwise it does not pick up changes in the dependencies unless they are manually rebuild.