### PR TITLE
chore: automate updating example dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "release:post:remove-hoisted-modules": "json -I -f ./lerna.json -e \"delete this.command.bootstrap.nohoist\"",
     "release:post:remove-examples": "json -I -f ./lerna.json -e \"this.packages = this.packages.filter(p => !p.includes('examples'))\"",
     "release:post:revert-ignore-changes-to-lerna-config": "git update-index --no-assume-unchanged ./lerna.json",
+    "release:post:update-example-dependencies": "node scripts/update-example-deps.js && git add examples && git commit -m 'chore: updated example dependencies' && git push",
     "release:rc": "run-s release:pre:* release:canary release:post:*",
     "release:canary": "lerna publish --canary --preid rc --dist-tag next --force-publish --yes",
     "docker:rc": "run-s docker:rc:*",

--- a/scripts/update-example-deps.js
+++ b/scripts/update-example-deps.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+
+// Where an example depends on `"ipfs": "^0.51.0"` and we've just released `ipfs@0.52.0`,
+// go through all of the examples and update the version to `"ipfs": "^0.52.0"` - do
+// that with every module under /packages
+
+const PACKAGES_DIR = path.resolve(__dirname, '../packages')
+const EXAMPLES_DIR = path.resolve(__dirname, '../examples')
+const DEP_TYPES = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']
+
+async function main () {
+  for (const dir of fs.readdirSync(PACKAGES_DIR)) {
+    const projectPkgPath = path.resolve(PACKAGES_DIR, dir, 'package.json')
+
+    if (!fs.existsSync(projectPkgPath)) {
+      continue
+    }
+
+    const projectPkg = JSON.parse(fs.readFileSync(projectPkgPath, { encoding: 'utf8' }))
+    const projectDepVersion = `^${projectPkg.version}`
+
+    for (const dir of fs.readdirSync(EXAMPLES_DIR)) {
+      const examplePkgPath = path.resolve(EXAMPLES_DIR, dir, 'package.json')
+
+      if (!fs.existsSync(examplePkgPath)) {
+        continue
+      }
+
+      const examplePkg = JSON.parse(fs.readFileSync(examplePkgPath, { encoding: 'utf8' }))
+      let dirty = false
+
+      for (const depType of DEP_TYPES) {
+        if (examplePkg[depType] && examplePkg[depType][projectPkg.name] && examplePkg[depType][projectPkg.name] !== projectDepVersion) {
+          console.info(`Updating ${examplePkg.name} ${projectPkg.name}: ${examplePkg[depType][projectPkg.name]} -> ${projectDepVersion}`)
+          examplePkg[depType][projectPkg.name] = projectDepVersion
+          dirty = true
+        }
+      }
+
+      if (dirty) {
+        fs.writeFileSync(examplePkgPath, JSON.stringify(examplePkg, null, 2) + '\n', { encoding: 'utf8' })
+      }
+    }
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Due to not wanting to publish versions of examples on GH or npm we
don't include the examples in our lerna workspace during publishing.

Consequently the `package.json` of examples doesn't get updated with
new `ipfs` etc modules during the publish process, which means they
depend on old versions and can break, so we need to update the versions
manually which is tiresome and error prone.

I've added a script to do it at the end of the publish process.