### PR TITLE
Adapt HTTP client tests for React Native (iOS and Android)

### DIFF
--- a/packages/ipfs-http-client/.aegir.js
+++ b/packages/ipfs-http-client/.aegir.js
@@ -11,16 +11,18 @@ const server = createServer({
   ipfsBin: require('go-ipfs').path()
 })
 
-module.exports = {
-  bundlesize: { maxSize: '83kB' },
-  hooks: {
-    browser: {
-      pre: async () => {
-        await server.start()
-      },
-      post: async () => {
-        await server.stop()
-      }
-    }
-  }
-}
+server.start()
+
+// module.exports = {
+//   bundlesize: { maxSize: '83kB' },
+//   hooks: {
+//     browser: {
+//       pre: async () => {
+//         await server.start()
+//       },
+//       post: async () => {
+//         await server.stop()
+//       }
+//     }
+//   }
+// }

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -44,6 +44,8 @@
     "test:electron-renderer": "aegir test -t electron-renderer",
     "test:chrome": "aegir test -t browser -t webworker -- --browsers ChromeHeadless",
     "test:firefox": "aegir test -t browser -t webworker -- --browsers FirefoxHeadless",
+    "test:react-native:android": "aegir test -t react-native-android",
+    "test:react-native:ios": "aegir test -t react-native-ios",
     "lint": "aegir lint",
     "prepare": "aegir build --no-bundle",
     "coverage": "npx nyc -r html npm run test:node -- --bail",
@@ -76,6 +78,7 @@
     "nanoid": "^3.1.12",
     "native-abort-controller": "^1.0.3",
     "parse-duration": "^0.4.4",
+    "react-native-fetch-api": "^1.0.2",
     "stream-to-it": "^0.2.2",
     "uint8arrays": "^2.0.5"
   },
@@ -89,7 +92,11 @@
     "it-concat": "^1.0.1",
     "it-first": "^1.0.4",
     "nock": "^13.0.2",
-    "rimraf": "^3.0.2"
+    "react-native-polyfill-globals": "^3.0.0",
+    "react-native-test-runner": "^3.0.2",
+    "rimraf": "^3.0.2",
+    "text-encoding": "^0.7.0",
+    "typescript": "4.0.x"
   },
   "engines": {
     "node": ">=10.3.0",

--- a/packages/ipfs-http-client/rn-test.config.js
+++ b/packages/ipfs-http-client/rn-test.config.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const path = require('path')
+
+module.exports = {
+  require: path.join(__dirname, 'rn-test.require.js'),
+  runner: 'mocha',
+  modules: [
+    'react-native-get-random-values',
+    'react-native-url-polyfill',
+    'web-streams-polyfill'
+  ],
+  patches: [{
+    path: require.resolve('react-native-polyfill-globals/patches/react-native+0.63.3.patch')
+  }]
+}

--- a/packages/ipfs-http-client/rn-test.require.js
+++ b/packages/ipfs-http-client/rn-test.require.js
@@ -1,0 +1,10 @@
+'use strict'
+
+require('react-native-get-random-values')
+const { polyfill: polyfillReadableStream } = require('react-native-polyfill-globals/src/readable-stream')
+const { polyfill: polyfillEncoding } = require('react-native-polyfill-globals/src/encoding')
+const { polyfill: polyfillURL } = require('react-native-polyfill-globals/src/url')
+
+polyfillReadableStream()
+polyfillEncoding()
+polyfillURL()

--- a/packages/ipfs-http-client/src/log/tail.js
+++ b/packages/ipfs-http-client/src/log/tail.js
@@ -10,6 +10,7 @@ module.exports = configure(api => {
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
       headers: options.headers,
+      // Enables text streaming support for React Native when using https://github.com/react-native-community/fetch
       reactNative: {
         textStreaming: true
       }

--- a/packages/ipfs-http-client/src/log/tail.js
+++ b/packages/ipfs-http-client/src/log/tail.js
@@ -9,7 +9,10 @@ module.exports = configure(api => {
       timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams(options),
-      headers: options.headers
+      headers: options.headers,
+      reactNative: {
+        textStreaming: true
+      }
     })
 
     yield * res.ndjson()

--- a/packages/ipfs-http-client/src/pubsub/subscribe.js
+++ b/packages/ipfs-http-client/src/pubsub/subscribe.js
@@ -34,7 +34,11 @@ module.exports = configure((api, options) => {
           arg: topic,
           ...options
         }),
-        headers: options.headers
+        headers: options.headers,
+        // Enables text streaming support for React Native when using https://github.com/react-native-community/fetch
+        reactNative: {
+          textStreaming: true
+        }
       })
         .catch((err) => {
           // Initial subscribe fail, ensure we clean up

--- a/packages/ipfs-http-client/test/constructor.spec.js
+++ b/packages/ipfs-http-client/test/constructor.spec.js
@@ -7,11 +7,13 @@ const f = require('./utils/factory')()
 const ipfsClient = require('../src/index.js')
 const { isBrowser } = require('ipfs-utils/src/env')
 
+const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
+
 describe('ipfs-http-client constructor tests', () => {
   describe('parameter permuations', () => {
     it('none', () => {
       const ipfs = ipfsClient()
-      if (typeof self !== 'undefined') {
+      if (typeof self !== 'undefined' && !isReactNative) {
         const { hostname, port } = self.location
         expectConfig(ipfs, { host: hostname, port })
       } else {

--- a/packages/ipfs-http-client/test/files.spec.js
+++ b/packages/ipfs-http-client/test/files.spec.js
@@ -6,6 +6,8 @@ const uint8ArrayFromString = require('uint8arrays/from-string')
 const { expect } = require('aegir/utils/chai')
 const f = require('./utils/factory')()
 
+const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
+
 describe('.add', function () {
   this.timeout(20 * 1000)
 
@@ -18,7 +20,8 @@ describe('.add', function () {
   after(() => f.clean())
 
   it('should ignore metadata until https://github.com/ipfs/go-ipfs/issues/6920 is implemented', async () => {
-    const data = uint8ArrayFromString('some data')
+    const textData = 'some data'
+    const data = isReactNative ? textData : uint8ArrayFromString(textData)
     const result = await ipfs.add(data, {
       mode: 0o600,
       mtime: {

--- a/packages/ipfs-http-client/test/log.spec.js
+++ b/packages/ipfs-http-client/test/log.spec.js
@@ -7,6 +7,8 @@ const uint8ArrayFromString = require('uint8arrays/from-string')
 const f = require('./utils/factory')()
 const first = require('it-first')
 
+const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
+
 describe('.log', function () {
   this.timeout(100 * 1000)
 
@@ -21,7 +23,8 @@ describe('.log', function () {
   it('.log.tail', async () => {
     const i = setInterval(async () => {
       try {
-        await ipfs.add(uint8ArrayFromString('just adding some data to generate logs'))
+        const textData = 'just adding some data to generate logs'
+        await ipfs.add(isReactNative ? textData : uint8ArrayFromString(textData))
       } catch (_) {
         // this can error if the test has finished and we're shutting down the node
       }


### PR DESCRIPTION
### TODO

- [ ] Add types for `react-native-fetch-api`
- [ ] Integrate `rn-test` with `aegir` to run tests for both iOS and Android
- [ ] Finish CI and setup and ensure it runs to completion successfully

@hugomrdias, can you give me a hand on items above? 🙏 

Related: https://github.com/ipfs/js-ipfs/pull/3488
Depends on https://github.com/ipfs/js-ipfs-utils/pull/91