### PR TITLE
fix: ts types after multihashing-async release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -273,8 +273,6 @@ jobs:
       script:
         # Travis lets scripts continue even if previous steps fail so need to use &&: https://github.com/travis-ci/travis-ci/issues/1066
         - npm run configure-examples &&
-          cat lerna.json &&
-          npx lerna ls &&
           npm run test -- --scope=example* --concurrency=1
 
     - stage: release-rc

--- a/.travis.yml
+++ b/.travis.yml
@@ -273,6 +273,8 @@ jobs:
       script:
         # Travis lets scripts continue even if previous steps fail so need to use &&: https://github.com/travis-ci/travis-ci/issues/1066
         - npm run configure-examples &&
+          cat lerna.json &&
+          npx lerna ls &&
           npm run test -- --scope=example* --concurrency=1
 
     - stage: release-rc

--- a/examples/browser-add-readable-stream/package.json
+++ b/examples/browser-add-readable-stream/package.json
@@ -13,6 +13,6 @@
   "license": "MIT",
   "devDependencies": {
     "ipfs": "^0.54.1",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   }
 }

--- a/examples/browser-browserify/package.json
+++ b/examples/browser-browserify/package.json
@@ -20,7 +20,7 @@
     "http-server": "^0.12.3",
     "ipfs": "^0.54.1",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "browser": {
     "ipfs": "ipfs/dist/index.min.js"

--- a/examples/browser-create-react-app/package.json
+++ b/examples/browser-create-react-app/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/browser-exchange-files/package.json
+++ b/examples/browser-exchange-files/package.json
@@ -22,7 +22,7 @@
     "it-all": "^1.0.4",
     "libp2p-websockets": "^0.15.0",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "browser": {
     "ipfs": "ipfs/dist/index.min.js"

--- a/examples/browser-http-client-upload-file/package.json
+++ b/examples/browser-http-client-upload-file/package.json
@@ -23,7 +23,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "browserslist": [
     "last 2 versions and not dead and > 2%"

--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -31,7 +31,7 @@
     "go-ipfs": "0.8.0-rc2",
     "parcel-bundler": "^1.12.4",
     "path": "^0.12.7",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/examples/browser-mfs/package.json
+++ b/examples/browser-mfs/package.json
@@ -17,7 +17,7 @@
     "http-server": "^0.12.3",
     "rimraf": "^3.0.2",
     "terser-webpack-plugin": "^1.2.1",
-    "test-ipfs-example": "^2.0.3",
+    "test-ipfs-example": "^3.0.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   },

--- a/examples/browser-parceljs/package.json
+++ b/examples/browser-parceljs/package.json
@@ -30,6 +30,6 @@
     "parcel-bundler": "^1.12.4",
     "rimraf": "^3.0.2",
     "standard": "^13.1.0",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   }
 }

--- a/examples/browser-readablestream/package.json
+++ b/examples/browser-readablestream/package.json
@@ -17,7 +17,7 @@
     "http-server": "^0.12.3",
     "rimraf": "^3.0.2",
     "terser-webpack-plugin": "^1.2.1",
-    "test-ipfs-example": "^2.0.3",
+    "test-ipfs-example": "^3.0.0",
     "webpack": "^4.43.0"
   },
   "dependencies": {

--- a/examples/browser-script-tag/package.json
+++ b/examples/browser-script-tag/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "http-server": "^0.12.3",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "dependencies": {
     "ipfs": "^0.54.1"

--- a/examples/browser-service-worker/package.json
+++ b/examples/browser-service-worker/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-loader": "^8.0.5",
     "copy-webpack-plugin": "^5.0.4",
-    "test-ipfs-example": "^2.0.3",
+    "test-ipfs-example": "^3.0.0",
     "webpack": "5.4.0",
     "webpack-cli": "4.1.0",
     "webpack-dev-server": "3.11.0"

--- a/examples/browser-sharing-node-across-tabs/package.json
+++ b/examples/browser-sharing-node-across-tabs/package.json
@@ -17,7 +17,7 @@
     "babel-loader": "^8.0.5",
     "copy-webpack-plugin": "^5.0.4",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3",
+    "test-ipfs-example": "^3.0.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",

--- a/examples/browser-video-streaming/package.json
+++ b/examples/browser-video-streaming/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "http-server": "^0.12.3",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "dependencies": {
     "ipfs": "^0.54.1"

--- a/examples/browser-vue/package.json
+++ b/examples/browser-vue/package.json
@@ -22,7 +22,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^6.2.1",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3",
+    "test-ipfs-example": "^3.0.0",
     "vue-template-compiler": "^2.6.11"
   },
   "eslintConfig": {

--- a/examples/browser-webpack/package.json
+++ b/examples/browser-webpack/package.json
@@ -23,7 +23,7 @@
     "react-hot-loader": "^4.12.21",
     "rimraf": "^3.0.2",
     "stream-browserify": "^3.0.0",
-    "test-ipfs-example": "^2.0.3",
+    "test-ipfs-example": "^3.0.0",
     "webpack": "^5.18.0",
     "webpack-cli": "^4.4.0",
     "webpack-dev-server": "^3.11.0"

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -27,7 +27,7 @@
     "parcel-bundler": "^1.12.4",
     "rimraf": "^3.0.2",
     "tachyons": "^4.11.1",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "browserslist": [
     ">1%",

--- a/examples/custom-ipfs-repo/package.json
+++ b/examples/custom-ipfs-repo/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "execa": "^4.0.3",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   }
 }

--- a/examples/custom-ipld-formats/package.json
+++ b/examples/custom-ipld-formats/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "devDependencies": {
     "execa": "^4.0.3",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "dependencies": {
     "cids": "^1.1.5",

--- a/examples/custom-libp2p/package.json
+++ b/examples/custom-libp2p/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "execa": "^4.0.3",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   }
 }

--- a/examples/explore-ethereum-blockchain/package.json
+++ b/examples/explore-ethereum-blockchain/package.json
@@ -14,6 +14,6 @@
     "ipfs-http-client": "^49.0.1",
     "ipfsd-ctl": "^7.2.0",
     "ipld-ethereum": "^5.0.1",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   }
 }

--- a/examples/http-client-browser-pubsub/package.json
+++ b/examples/http-client-browser-pubsub/package.json
@@ -23,6 +23,6 @@
     "ipfs": "^0.54.1",
     "ipfsd-ctl": "^7.2.0",
     "parcel-bundler": "^1.12.4",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   }
 }

--- a/examples/http-client-bundle-webpack/package.json
+++ b/examples/http-client-bundle-webpack/package.json
@@ -28,7 +28,7 @@
     "ipfsd-ctl": "^7.2.0",
     "react-hot-loader": "^4.12.21",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3",
+    "test-ipfs-example": "^3.0.0",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.11.0"
   },

--- a/examples/http-client-name-api/package.json
+++ b/examples/http-client-name-api/package.json
@@ -21,7 +21,7 @@
     "ipfsd-ctl": "^7.2.0",
     "parcel-bundler": "^1.12.4",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "browserslist": [
     "last 2 versions and not dead and > 2%"

--- a/examples/ipfs-101/package.json
+++ b/examples/ipfs-101/package.json
@@ -15,6 +15,6 @@
     "uint8arrays": "^2.0.5"
   },
   "devDependencies": {
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   }
 }

--- a/examples/ipfs-client-add-files/package.json
+++ b/examples/ipfs-client-add-files/package.json
@@ -19,7 +19,7 @@
     "ipfsd-ctl": "^7.2.0",
     "parcel-bundler": "^1.12.4",
     "rimraf": "^3.0.2",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "browserslist": [
     "last 2 versions and not dead and > 2%"

--- a/examples/run-in-electron/package.json
+++ b/examples/run-in-electron/package.json
@@ -19,7 +19,7 @@
     "electron": "^11.2.1",
     "electron-rebuild": "^2.3.4",
     "ipfs": "^0.54.1",
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/examples/running-multiple-nodes/package.json
+++ b/examples/running-multiple-nodes/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "dependencies": {
     "ipfs": "^0.54.1"

--- a/examples/traverse-ipld-graphs/package.json
+++ b/examples/traverse-ipld-graphs/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "test-ipfs-example": "^2.0.3"
+    "test-ipfs-example": "^3.0.0"
   },
   "dependencies": {
     "cids": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "lerna run lint",
     "dep-check": "lerna run dep-check",
     "configure-examples": "run-s configure-examples:* release:pre:reinstall release:pre:bundle",
-    "configure-examples:pre:add-examples": "json -I -f ./lerna.json -e \"this.packages.push('examples/*'); this.packages = [...new Set(this.packages)]\"",
+    "configure-examples:add-examples": "json -I -f ./lerna.json -e \"this.packages.push('examples/*'); this.packages = [...new Set(this.packages)]\"",
     "configure-examples:add-hoisted-modules": "json -I -f ./lerna.json -e \"this.command.bootstrap.nohoist = ['ipfs-css', 'tachyons']; this.command.bootstrap.nohoist = [...new Set(this.command.bootstrap.nohoist)]\"",
     "release": "run-s release:pre:* release:publish docker:release release:post:*",
     "release:pre:non-dirty-repo": "git diff --quiet",

--- a/packages/ipfs-core/src/components/block/put.js
+++ b/packages/ipfs-core/src/components/block/put.js
@@ -82,7 +82,7 @@ module.exports = ({ blockService, pin, gcLock, preload }) => {
           cidVersion = options.version
         }
 
-        const multihash = await multihashing(block, mhtype)
+        const multihash = await multihashing(bytes, mhtype)
         const cid = new CID(cidVersion, format, multihash)
 
         block = new Block(bytes, cid)
@@ -120,7 +120,7 @@ module.exports = ({ blockService, pin, gcLock, preload }) => {
  * @typedef {Object} PutOptions
  * @property {CID} [cid] - A CID to store the block under (default: `undefined`)
  * @property {string} [format='dag-pb'] - The codec to use to create the CID (default: `'dag-pb'`)
- * @property {string} [mhtype='sha2-256'] - The hashing algorithm to use to create the CID (default: `'sha2-256'`)
+ * @property {import('multihashes').HashName} [mhtype='sha2-256'] - The hashing algorithm to use to create the CID (default: `'sha2-256'`)
  * @property {number} [mhlen]
  * @property {CIDVersion} [version=0] - The version to use to create the CID (default: `0`)
  * @property {boolean} [pin=false] - If true, pin added blocks recursively (default: `false`)

--- a/scripts/update-example-deps.js
+++ b/scripts/update-example-deps.js
@@ -29,6 +29,9 @@ async function main () {
 
   console.info('Running on branch', branch)
 
+  // list all of the package.json files we may have just updated
+  const potentiallyUpdatedProjects = []
+
   for (const dir of fs.readdirSync(PACKAGES_DIR)) {
     const projectPkgPath = path.resolve(PACKAGES_DIR, dir, 'package.json')
 
@@ -36,9 +39,17 @@ async function main () {
       continue
     }
 
+    potentiallyUpdatedProjects.push(projectPkgPath)
+  }
+
+  // add the example test runner
+  potentiallyUpdatedProjects.push(path.resolve(EXAMPLES_DIR, 'test-ipfs-example', 'package.json'))
+
+  for (const projectPkgPath of potentiallyUpdatedProjects) {
     const projectPkg = JSON.parse(fs.readFileSync(projectPkgPath, { encoding: 'utf8' }))
     const projectDepVersion = `^${projectPkg.version}`
 
+    // look through all the example projects and update their deps
     for (const dir of fs.readdirSync(EXAMPLES_DIR)) {
       const examplePkgPath = path.resolve(EXAMPLES_DIR, dir, 'package.json')
 


### PR DESCRIPTION
The new types in multihashing-async are unsurprisingly stricter than using no types at all.

fixes #3527