### PR TITLE
fix: use correct version IPFS version number

### DIFF
--- a/packages/ipfs-core/src/components/version.js
+++ b/packages/ipfs-core/src/components/version.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const pkg = require('../../package.json')
+const pkg = require('../../../ipfs/package.json')
 const withTimeoutOption = require('ipfs-core-utils/src/with-timeout-option')
 
 /**


### PR DESCRIPTION
The version number that `ipfs.version()` outputs should be the one
of the release.

Prior to this change it was the version of the `ipfs-core` package.

This change is powered by the hackweek :)