### PR TITLE
fix: fail to open the webui page in the browser

### DIFF
--- a/packages/ipfs-core/src/runtime/config-nodejs.js
+++ b/packages/ipfs-core/src/runtime/config-nodejs.js
@@ -52,5 +52,48 @@ module.exports = () => ({
   },
   Routing: {
     Type: 'none'
+  },
+  "Mounts": {
+    "IPFS": "/ipfs",
+    "IPNS": "/ipns",
+    "FuseAllowOther": false
+  },
+  "Gateway": {
+    "HTTPHeaders": {
+      "Access-Control-Allow-Headers": [
+        "X-Requested-With",
+        "Range",
+        "User-Agent"
+      ],
+      "Access-Control-Allow-Methods": [
+        "GET"
+      ],
+      "Access-Control-Allow-Origin": [
+        "*"
+      ]
+    },
+    "RootRedirect": "",
+    "Writable": false,
+    "PathPrefixes": [],
+    "APICommands": [],
+    "NoFetch": false,
+    "NoDNSLink": false,
+    "PublicGateways": null
+  },
+  "API": {
+    "HTTPHeaders": {}
+  },
+  "Peering": {
+    "Peers": null
+  },
+  "Provider": {
+    "Strategy": ""
+  },
+  "Reprovider": {
+    "Interval": "12h",
+    "Strategy": "all"
+  },
+  "Plugins": {
+    "Plugins": null
   }
 })


### PR DESCRIPTION
I met the same issue as #2796, then I added this piece of code and the problem was solved.
Environment: 
macOS 10.15.3
js-ipfs version: 0.4.2
System version: x64/darwin
Node.js version: 15.8.0