### PR TITLE
chore: fix rc publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,8 @@
     "publish": {
       "message": "chore: publish",
       "createRelease": "github",
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "verifyAccess": false
     },
     "version": {
       "private": false


### PR DESCRIPTION
Lerna doesn't work with npm automation tokens out of the box, need
to disable auth verification for the time being.

Refs: https://github.com/lerna/lerna/issues/2788