### PR TITLE
feature: implement remote pinning API

### DIFF
--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -89,6 +89,7 @@
     "it-first": "^1.0.4",
     "it-last": "^1.0.4",
     "it-pipe": "^1.1.0",
+    "js-ipfs-pinning-service-client": "github:yusefnapora/js-ipfs-pinning-service-client#master",
     "libp2p": "^0.30.7",
     "libp2p-bootstrap": "^0.12.1",
     "libp2p-crypto": "^0.19.0",

--- a/packages/ipfs-core/src/components/pin/index.js
+++ b/packages/ipfs-core/src/components/pin/index.js
@@ -5,7 +5,6 @@ const createAddAll = require('./add-all')
 const createLs = require('./ls')
 const createRm = require('./rm')
 const createRmAll = require('./rm-all')
-const RemotePinAPI = require('./remote')
 
 class PinAPI {
   /**
@@ -13,8 +12,9 @@ class PinAPI {
    * @param {GCLock} config.gcLock
    * @param {DagReader} config.dagReader
    * @param {PinManager} config.pinManager
+   * @param {PinRemoteAPI} config.pinRemote
    */
-  constructor ({ gcLock, dagReader, pinManager }) {
+  constructor ({ gcLock, dagReader, pinManager, pinRemote }) {
     const addAll = createAddAll({ gcLock, dagReader, pinManager })
     this.addAll = addAll
     this.add = createAdd({ addAll })
@@ -22,7 +22,7 @@ class PinAPI {
     this.rmAll = rmAll
     this.rm = createRm({ rmAll })
     this.ls = createLs({ dagReader, pinManager })
-    this.remote = new RemotePinAPI()
+    this.remote = pinRemote
   }
 }
 module.exports = PinAPI
@@ -34,4 +34,5 @@ module.exports = PinAPI
  * @typedef {import('..').PinManager} PinManager
  * @typedef {import('..').AbortOptions} AbortOptions
  * @typedef {import('..').CID} CID
+ * @typedef {import('./remote')} PinRemoteAPI
  */

--- a/packages/ipfs-core/src/components/pin/index.js
+++ b/packages/ipfs-core/src/components/pin/index.js
@@ -5,6 +5,7 @@ const createAddAll = require('./add-all')
 const createLs = require('./ls')
 const createRm = require('./rm')
 const createRmAll = require('./rm-all')
+const RemotePinAPI = require('./remote')
 
 class PinAPI {
   /**
@@ -21,6 +22,7 @@ class PinAPI {
     this.rmAll = rmAll
     this.rm = createRm({ rmAll })
     this.ls = createLs({ dagReader, pinManager })
+    this.remote = new RemotePinAPI()
   }
 }
 module.exports = PinAPI

--- a/packages/ipfs-core/src/components/pin/remote/index.js
+++ b/packages/ipfs-core/src/components/pin/remote/index.js
@@ -1,0 +1,131 @@
+'use strict'
+
+/**
+ * @typedef {import('cids')} CID
+ *
+ * @typedef {'queued'|'pinning'|'pinned'|'failed'} PinStatus
+ * 
+ * @typedef {object} RemotePin
+ * @property {string} [cid]
+ * @property {PinStatus} [status]
+ * @property {?string} [name]
+ * @property {?object} [meta]
+ */
+
+class RemotePinAPI {
+
+  constructor() {
+    this.service = new RemotePinServiceAPI()
+  }
+
+  /**
+   * Asks a remote pinning service to pin an IPFS object from a given path
+   * 
+   * @typedef {object} RemotePinAddOptions
+   * @property {string} [service] name of a configured remote pinning service
+   * @property {?string} [name] optional descriptive name for pin
+   * @property {?Object<string, string>} [meta] optional metadata to attach to pin
+   * @property {?number} [timeout] request timeout (seconds)
+   * @property {?boolean} [background] If true, add returns remote a pin object as soon as the remote service responds.
+   *   The returned pin object may have a status of 'queued' or 'pinning'. 
+   *   If false, the add method will not resolve until the pin status is 'pinned' before returning.
+   *   When background==false and the remote service returns a status of 'failed', an Error will be thrown.
+   * 
+   * @param {string|CID} cid
+   * @param {RemotePinAddOptions} options
+   * @returns {Promise<RemotePin>}
+   */
+  async add(cid, options) {
+    throw new Error('not yet implemented')
+  }
+  
+  /**
+   * List objects that are pinned by a remote service.
+   * 
+   * @typedef {object} RemotePinLsOptions
+   * @property {string} [service] name of a configured remote pinning service
+   * @property {?Array<string|CID>} [cid] return pins for the specified CID(s)
+   * @property {?string} [name] return pins that contain the provided value (case-sensitive, exact match)
+   * @property {?Array<PinStatus>} [status] return pins with the specified statuses (queued, pinning, pinned, failed). Default: pinned
+   * @property {?number} [timeout] request timeout (seconds)
+
+   * @param {RemotePinLsOptions} options
+   * @returns {AsyncGenerator<RemotePin>} 
+   */
+  async * ls(options) {
+    throw new Error('not yet implemented')
+  }
+
+  /**
+   * Remove a single pin from a remote pinning service. 
+   * Fails if multiple pins match the specified criteria. Use rmAll to remove all pins that match.
+   * 
+   * @typedef {object} RemotePinRmOptions
+   * @property {string} [service] name of a configured remote pinning service
+   * @property {Array<string>} [cid] CID(s) to remove from remote pinning service
+   * @property {?Array<PinStatus>} [status] only remove pins that have one of the specified statuses (queued, pinning, pinned, failed). Default: pinned
+   * @property {?number} [timeout] request timeout (seconds)
+   * 
+   * @param {RemotePinRmOptions} options
+   * @returns {Promise<void>}
+   */
+  async rm(options) {
+    throw new Error('not yet implemented')
+  }
+
+  /**
+   * Remove all pins that match the given criteria from a remote pinning service. 
+   * 
+   * @param {RemotePinRmOptions} options
+   * @returns {Promise<void>}
+   */
+  async rmAll(options) {
+      throw new Error('not yet implemented')
+    }
+}
+
+/**
+ * RemotePinServiceAPI provides methods to add, remove, and list the configured
+ * remote pinning services that are used by the RemotePinAPI.
+ */
+class RemotePinServiceAPI {
+
+  /**
+   * Adds a new remote pinning service to the set of configured services.
+   * 
+   * @typedef {object} RemotePinServiceAddOptions
+   * @property {string|URL} [endpoint] the remote API endpoint URL
+   * @property {string} [key] an API key that authorizes use of the remote pinning service
+   * 
+   * @param {string} name the name of the pinning service. Used to identify the service in future remote pinning API calls.
+   * @param {RemotePinServiceAddOptions} options
+   */
+  async add(name, options) {
+    throw new Error('not yet implemented')
+  }
+
+  /**
+   * List the configured remote pinning services.
+   * 
+   * @typedef {object} RemotePinningServiceDescription
+   * @property {string} name
+   * @property {URL} endpoint
+   * 
+   * @return {Promise<Array<RemotePinningServiceDescription>>}
+   */
+  async ls() {
+    throw new Error('not yet implemented')
+  }
+
+  /**
+   * Remove a remote pinning service from the set of configured services.
+   * 
+   * @param {string} name the name of the pinning service to remove
+   * @returns {Promise<void>}
+   */
+  async rm(name) {
+    throw new Error('not yet implemented')
+  }
+}
+
+module.exports = RemotePinAPI


### PR DESCRIPTION
This is an implementation of the `ipfs.pin.remote` API as well as I can gather from reading the tests in `interface-ipfs-core`.

I haven't figured out how to actually run the tests yet, so we'll see 😄

Leaving as a draft for now, since I probably missed some stuff and am out of steam for the day. Also it's depending on an unpublished npm package (the `js-ipfs-pinning-service-client` I wrote earlier) so we should sort that out.

cc @Gozala :)