### PR TITLE
fix: add bignumber.js dependency to core types

### DIFF
--- a/packages/ipfs-core-types/package.json
+++ b/packages/ipfs-core-types/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
+    "bignumber.js": "^9.0.1",
     "cids": "^1.1.5",
     "multiaddr": "^8.0.0",
     "peer-id": "^0.14.1"


### PR DESCRIPTION
The Bitswap types need bignumber.js. Without this dependency you could get an
error like

    ../../node_modules/ipfs-core-types/src/bitswap.ts:1:29 - error TS2307: Cannot find module 'bignumber.js' or its corresponding type declarations.

    1 import type BigInteger from 'bignumber.js'
                                  ~~~~~~~~~~~~~~