### PR TITLE
docs: ipfs.object.get typo fix

### DIFF
--- a/docs/core-api/OBJECT.md
+++ b/docs/core-api/OBJECT.md
@@ -165,7 +165,7 @@ An optional object which may have the following keys:
 const multihash = 'QmPb5f92FxKPYdT3QNBd1GKiL4tZUXUrzF4Hkpdr3Gf1gK'
 
 const node = await ipfs.object.get(multihash)
-console.log(node.data)
+console.log(node.Data)
 // Logs:
 // some data
 ```


### PR DESCRIPTION
AFAIK it is `Data` and `Links`, not `data`