### PR TITLE
chore: reference only local files in package.json "browser" field

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -9,8 +9,7 @@
   "browser": {
     "fs": false,
     "os": false,
-    "path": false,
-    "ipfs-utils/src/files/glob-source": false
+    "path": false
   },
   "scripts": {
     "lint": "aegir lint",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -8,6 +8,9 @@
   "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",
   "main": "src/index.js",
   "types": "dist/src/index.d.ts",
+  "broswer": {
+    "./src/files/normalise-input": "./src/files/normalise-input/index.browser.js"
+  },
   "files": [
     "src",
     "dist",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -8,7 +8,7 @@
   "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",
   "main": "src/index.js",
   "types": "dist/src/index.d.ts",
-  "broswer": {
+  "browser": {
     "./src/files/normalise-input": "./src/files/normalise-input/index.browser.js"
   },
   "files": [

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -24,7 +24,7 @@
     "./src/runtime/libp2p-pubsub-routers-nodejs.js": "./src/runtime/libp2p-pubsub-routers-browser.js",
     "./src/runtime/preload-nodejs.js": "./src/runtime/preload-browser.js",
     "./src/runtime/repo-nodejs.js": "./src/runtime/repo-browser.js",
-    "./test/utils/create-repo-nodejs.js": "./test/utils/create-repo-browser.js",
+    "./test/utils/create-repo-nodejs.js": "./test/utils/create-repo-browser.js"
   },
   "typesVersions": {
     "*": {

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -25,7 +25,6 @@
     "./src/runtime/preload-nodejs.js": "./src/runtime/preload-browser.js",
     "./src/runtime/repo-nodejs.js": "./src/runtime/repo-browser.js",
     "./test/utils/create-repo-nodejs.js": "./test/utils/create-repo-browser.js",
-    "ipfs-utils/src/files/glob-source": false
   },
   "typesVersions": {
     "*": {

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -18,9 +18,7 @@
   "types": "./dist/src/index.d.ts",
   "browser": {
     "./src/lib/multipart-request.js": "./src/lib/multipart-request.browser.js",
-    "ipfs-utils/src/files/glob-source": false,
     "go-ipfs": false,
-    "ipfs-core-utils/src/files/normalise-input": "ipfs-core-utils/src/files/normalise-input/index.browser.js",
     "http": false,
     "https": false
   },


### PR DESCRIPTION
Fixes this issue: https://github.com/ipfs/js-ipfs/issues/3557

Related PR in `js-ipfs-utils`: https://github.com/ipfs/js-ipfs-utils/pull/121