### PR TITLE
fix: interface core test swarm peers with webrtc does not dial the correct address

### DIFF
--- a/packages/interface-ipfs-core/src/swarm/peers.js
+++ b/packages/interface-ipfs-core/src/swarm/peers.js
@@ -126,10 +126,7 @@ module.exports = (common, options) => {
         }
       })).api
 
-      // TODO: the webrtc-star transport only keeps the last listened on address around
-      // so the browser has to use 1 as the array index
-      // await nodeA.swarm.connect(nodeB.peerId.addresses[0])
-      await nodeA.swarm.connect(nodeB.peerId.addresses[isBrowser ? 1 : 0])
+      await nodeB.swarm.connect(nodeA.peerId.addresses[0])
 
       await delay(1000)
       const peersA = await nodeA.swarm.peers()

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -105,7 +105,7 @@
     "libp2p-noise": "^2.0.5",
     "libp2p-record": "^0.10.3",
     "libp2p-tcp": "^0.15.4",
-    "libp2p-webrtc-star": "^0.22.0",
+    "libp2p-webrtc-star": "^0.22.2",
     "libp2p-websockets": "^0.15.6",
     "mafmt": "^9.0.0",
     "merge-options": "^3.0.4",

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -43,7 +43,7 @@
     "libp2p": "^0.31.0-rc.6",
     "libp2p-delegated-content-routing": "^0.10.0",
     "libp2p-delegated-peer-routing": "^0.9.0",
-    "libp2p-webrtc-star": "^0.22.0",
+    "libp2p-webrtc-star": "^0.22.2",
     "multiaddr": "^9.0.1"
   },
   "devDependencies": {

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -60,7 +60,7 @@
     "ipfs-utils": "^6.0.4",
     "ipfsd-ctl": "^8.0.1",
     "iso-url": "^1.0.0",
-    "libp2p-webrtc-star": "^0.22.0",
+    "libp2p-webrtc-star": "^0.22.2",
     "merge-options": "^3.0.4",
     "mock-ipfs-pinning-service": "^0.1.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Error in CI: https://travis-ci.com/github/ipfs/js-ipfs/jobs/500525900

In the past webrtc did not proper support multiple listeners. This basically mean that if trying to listen on multiple addresses the webrtc sdp offers could end up with wrong signal server address throwing random errors in CI.

https://github.com/libp2p/js-libp2p-webrtc-star/pull/330 fixed this and now a libp2p node allows multiple listeners. When a peer with multiple webrtc-star listeners attempts to dial another peer via a star signalling server, the signal server of the target peers is identified among the listeners and used for starting the dial.

In the test changed in this PR (note that ports might change):

```
nodeA: ['/ip4/127.0.0.1/tcp/53466/ws/p2p-webrtcstar/p2p/QmPqSo3Kqf9XtWG6g3WKVrx2PZ2q3BoFZssVjixaweABNW']
nodeB: [
          '/ip4/127.0.0.1/tcp/53466/ws/p2p-webrtc-star/p2p/QmNLojvkVdRTD2bmy7Yzpc7vUBv6bUDEpamrgQeRwPQAg1',
          '/ip4/127.0.0.1/tcp/53467/ws/p2p-webrtc-star/p2p/QmNLojvkVdRTD2bmy7Yzpc7vUBv6bUDEpamrgQeRwPQAg1'
]
```

and the test did:

```
await nodeA.swarm.connect(nodeB.peerId.addresses[isBrowser ? 1 : 0])
```

We were using nodeA to dial nodeB with an address of a signalServer it does not use, which obviously failed. The solution here is to either have nodeB dial nodeA address (has same signalServer), or we need to do in the test a match function to understand what address of nodeB we should use (with the same signalServer).

The error in CI is poor and webrtc-star should validate we actually have the listener for the signalServer and throw a proper error if not instead of the Cannot read property 'listener' of undefined. This will be fixed shortly in a new PR