### PR TITLE
fix: do not republish self key twice

### DIFF
--- a/packages/ipfs-core/src/ipns/republisher.js
+++ b/packages/ipfs-core/src/ipns/republisher.js
@@ -138,6 +138,9 @@ class IpnsRepublisher {
         const keys = await this._keychain.listKeys()
 
         for (const key of keys) {
+          if (key.name === 'self') {
+            continue
+          }
           const pem = await this._keychain.exportKey(key.name, pass)
           const privKey = await crypto.keys.import(pem, pass)
 

--- a/packages/ipfs-core/test/name.spec.js
+++ b/packages/ipfs-core/test/name.spec.js
@@ -50,6 +50,26 @@ describe('name', function () {
       expect(republisher._republishEntries.calledTwice).to.equal(true)
     })
 
+    it('should not republish self key twice', async function () {
+      const mockKeychain = {
+        listKeys: () => Promise.resolve([{ name: 'self' }])
+      }
+      republisher = new IpnsRepublisher(sinon.stub(), sinon.stub(), sinon.stub(), mockKeychain, {
+        initialBroadcastInterval: 500,
+        broadcastInterval: 1000,
+        pass: 'pass'
+      })
+      republisher._republishEntry = sinon.stub()
+
+      await republisher.start()
+
+      expect(republisher._republishEntry.calledOnce).to.equal(false)
+
+      // Initial republish should happen after ~500ms
+      await delay(750)
+      expect(republisher._republishEntry.calledOnce).to.equal(true)
+    })
+
     it('should error if run republish again', async () => {
       republisher = new IpnsRepublisher(sinon.stub(), sinon.stub(), sinon.stub(), sinon.stub(), {
         initialBroadcastInterval: 50,

--- a/packages/ipfs-core/test/name.spec.js
+++ b/packages/ipfs-core/test/name.spec.js
@@ -55,7 +55,7 @@ describe('name', function () {
         listKeys: () => Promise.resolve([{ name: 'self' }])
       }
       republisher = new IpnsRepublisher(sinon.stub(), sinon.stub(), sinon.stub(), mockKeychain, {
-        initialBroadcastInterval: 500,
+        initialBroadcastInterval: 100,
         broadcastInterval: 1000,
         pass: 'pass'
       })
@@ -65,8 +65,8 @@ describe('name', function () {
 
       expect(republisher._republishEntry.calledOnce).to.equal(false)
 
-      // Initial republish should happen after ~500ms
-      await delay(750)
+      // Initial republish should happen after ~100ms
+      await delay(200)
       expect(republisher._republishEntry.calledOnce).to.equal(true)
     })
 

--- a/packages/ipfs-core/test/name.spec.js
+++ b/packages/ipfs-core/test/name.spec.js
@@ -32,8 +32,8 @@ describe('name', function () {
 
     it('should republish entries', async function () {
       republisher = new IpnsRepublisher(sinon.stub(), sinon.stub(), sinon.stub(), sinon.stub(), {
-        initialBroadcastInterval: 500,
-        broadcastInterval: 1000
+        initialBroadcastInterval: 200,
+        broadcastInterval: 500
       })
       republisher._republishEntries = sinon.stub()
 
@@ -41,12 +41,12 @@ describe('name', function () {
 
       expect(republisher._republishEntries.calledOnce).to.equal(false)
 
-      // Initial republish should happen after ~500ms
-      await delay(750)
+      // Initial republish should happen after ~200ms
+      await delay(300)
       expect(republisher._republishEntries.calledOnce).to.equal(true)
 
-      // Subsequent republishes should happen after ~1500ms
-      await delay(1000)
+      // Subsequent republishes should happen after ~700
+      await delay(600)
       expect(republisher._republishEntries.calledTwice).to.equal(true)
     })
 


### PR DESCRIPTION
IPNS Republish was republishing self private key twice, first as part of the root IPNS Record published when creating the IPFS Repo and then as part of keychain keys.

This was specially problematic when doing a flow such as:

```sh
node packages/ipfs/src/cli.js init
DEBUG=ipfs:i* node packages/ipfs/src/cli.js daemon --pass 12345678901234567890
```

As we provided a keychain password for the daemon, this password was going to be used for creating the keychain dek. However, self was created as part of the PeerId in the init command (without password).