### PR TITLE
chore: fix docker images

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -5,13 +5,13 @@ ENV IPFS_MONITORING=1
 ENV IPFS_PATH=/root/.jsipfs
 ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 
-RUN apk add --no-cache git python build-base
+RUN apk add --no-cache git python3 build-base
 
-RUN npm install --unsafe-perm -g ipfs@"$IPFS_VERSION"
+RUN npm install -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
 RUN npm cache clear --force
-RUN apk del build-base python git
+RUN apk del build-base python3 git
 
 # Configure jsipfs
 RUN jsipfs init

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -7,7 +7,7 @@ ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 
 RUN apk add --no-cache git python3 build-base
 
-RUN npm install -g ipfs@"$IPFS_VERSION"
+RUN npm install --unsafe-perm -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
 RUN npm cache clear --force

--- a/Dockerfile.next
+++ b/Dockerfile.next
@@ -5,13 +5,13 @@ ENV IPFS_MONITORING=1
 ENV IPFS_PATH=/root/.jsipfs
 ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 
-RUN apk add --no-cache git python build-base
+RUN apk add --no-cache git python3 build-base
 
-RUN npm install --unsafe-perm -g ipfs@"$IPFS_VERSION"
+RUN npm install -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
 RUN npm cache clear --force
-RUN apk del build-base python git
+RUN apk del build-base python3 git
 
 # Configure jsipfs
 RUN jsipfs init

--- a/Dockerfile.next
+++ b/Dockerfile.next
@@ -7,7 +7,7 @@ ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 
 RUN apk add --no-cache git python3 build-base
 
-RUN npm install -g ipfs@"$IPFS_VERSION"
+RUN npm install --unsafe-perm -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
 RUN npm cache clear --force


### PR DESCRIPTION
The python package has gone, we need to use python3 instead.

There's a futher problem with npm not setting the $PATH properly so
it fails as it can't find pbjs, but this is only necessary with gh
dep versions which should go away with the next libp2p-kad-dht/libp2p-gossipsub
releases.