### PR TITLE
chore: fix docker images

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:15
+FROM node:16-alpine
 
 ENV IPFS_VERSION=latest
 ENV IPFS_MONITORING=1
@@ -7,9 +7,12 @@ ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 
 RUN apk add --no-cache git python3 build-base
 
-RUN npm install --unsafe-perm -g ipfs@"$IPFS_VERSION"
+# Hopefully remove when https://github.com/node-webrtc/node-webrtc/pull/694 is merged
+RUN npm install -g @mapbox/node-pre-gyp
+RUN npm install -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
+RUN npm uninstall -g @mapbox/node-pre-gyp
 RUN npm cache clear --force
 RUN apk del build-base python3 git
 

--- a/Dockerfile.next
+++ b/Dockerfile.next
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:15
+FROM node:16-alpine
 
 ENV IPFS_VERSION=next
 ENV IPFS_MONITORING=1
@@ -7,9 +7,12 @@ ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 
 RUN apk add --no-cache git python3 build-base
 
-RUN npm install --unsafe-perm -g ipfs@"$IPFS_VERSION"
+# Hopefully remove when https://github.com/node-webrtc/node-webrtc/pull/694 is merged
+RUN npm install -g @mapbox/node-pre-gyp
+RUN npm install -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
+RUN npm uninstall -g @mapbox/node-pre-gyp
 RUN npm cache clear --force
 RUN apk del build-base python3 git
 


### PR DESCRIPTION
Install node-pre-gyp before IPFS and switch to official node image as the size difference is now quite small.

`--unsafe-perm` seems unnecessary too.