### PR TITLE
fix: ignore the ts error caused by the recent protobufjs type change

### DIFF
--- a/packages/ipfs-grpc-client/src/utils/load-services.js
+++ b/packages/ipfs-grpc-client/src/utils/load-services.js
@@ -19,6 +19,7 @@ const CONVERSION_OPTS = {
  * service definition on both the server and the client.
  */
 module.exports = function loadServices () {
+  // @ts-ignore - recent protobufjs release changed the types
   const root = protobuf.Root.fromJSON(protocol)
   /** @type {Record<string, any>} */
   const output = {}

--- a/packages/ipfs-grpc-server/src/utils/load-services.js
+++ b/packages/ipfs-grpc-server/src/utils/load-services.js
@@ -14,6 +14,7 @@ const CONVERSION_OPTS = {
 }
 
 module.exports = function loadServices () {
+  // @ts-ignore - recent protobufjs release changed the types
   const root = protobuf.Root.fromJSON(protocol)
 
   /** @type {Record<string, any>} */


### PR DESCRIPTION
The json generated by protobufjs is now not compatible with the types on protobufjs's `fromJSON` method.
