### PR TITLE
fix: only use public api in http api server

### DIFF
--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -43,6 +43,7 @@
     "ipfs-core-utils": "^0.7.2",
     "ipfs-http-gateway": "^0.3.2",
     "ipfs-unixfs": "^4.0.3",
+    "ipld-block": "^0.11.1",
     "ipld-dag-pb": "^0.22.1",
     "it-all": "^1.0.4",
     "it-drain": "^1.0.3",

--- a/packages/ipfs-http-server/src/index.js
+++ b/packages/ipfs-http-server/src/index.js
@@ -17,7 +17,6 @@ const LOG_ERROR = 'ipfs:http-api:error'
  * @typedef {import('./types').Server} Server
  * @typedef {import('ipld')} IPLD
  * @typedef {import('libp2p')} libp2p
- * @typedef {IPFS & { ipld: IPLD, libp2p: libp2p }} JSIPFS
  */
 
 /**
@@ -38,8 +37,8 @@ function hapiInfoToMultiaddr (info) {
 
 /**
  * @param {string | string[]} serverAddrs
- * @param {(host: string, port: string, ipfs: JSIPFS, cors: Record<string, any>) => Promise<Server>} createServer
- * @param {JSIPFS} ipfs
+ * @param {(host: string, port: string, ipfs: IPFS, cors: Record<string, any>) => Promise<Server>} createServer
+ * @param {IPFS} ipfs
  * @param {Record<string, any>} cors
  */
 async function serverCreator (serverAddrs, createServer, ipfs, cors) {
@@ -61,7 +60,7 @@ async function serverCreator (serverAddrs, createServer, ipfs, cors) {
 
 class HttpApi {
   /**
-   * @param {JSIPFS} ipfs
+   * @param {IPFS} ipfs
    */
   constructor (ipfs) {
     this._ipfs = ipfs
@@ -98,7 +97,7 @@ class HttpApi {
   /**
    * @param {string} host
    * @param {string} port
-   * @param {JSIPFS} ipfs
+   * @param {IPFS} ipfs
    * @param {Record<string, any>} cors
    */
   async _createApiServer (host, port, ipfs, cors) {

--- a/packages/ipfs-http-server/src/types.d.ts
+++ b/packages/ipfs-http-server/src/types.d.ts
@@ -7,7 +7,7 @@ import libp2p from 'libp2p'
 
 declare module '@hapi/hapi' {
   interface ServerApplicationState {
-    ipfs: IPFS & { ipld: IPLD, libp2p: libp2p }
+    ipfs: IPFS
   }
   interface RequestApplicationState {
     signal: AbortSignal

--- a/packages/ipfs-http-server/test/inject/dag.js
+++ b/packages/ipfs-http-server/test/inject/dag.js
@@ -38,8 +38,8 @@ describe('/dag', () => {
         put: sinon.stub(),
         resolve: sinon.stub()
       },
-      ipld: {
-        getFormat: sinon.stub()
+      block: {
+        put: sinon.stub()
       }
     }
   })
@@ -295,16 +295,14 @@ describe('/dag', () => {
       expect(res).to.have.deep.nested.property('result.Cid', { '/': cid.toString() })
     })
 
-    it('should attempt to load an unsupported format', async () => {
+    it('adds a node with an esoteric format', async () => {
+      const cid = new CID('baf4beiata6mq425fzikf5m26temcvg7mizjrxrkn35swuybmpah2ajan5y')
       const data = Buffer.from('some data')
       const codec = 'git-raw'
-      const format = {
-        util: {
-          deserialize: (buf) => buf
-        }
-      }
-      ipfs.ipld.getFormat.withArgs(codec).returns(format)
 
+      ipfs.dag.get.withArgs(cid).returns({
+        value: data
+      })
       ipfs.dag.put.withArgs(data, {
         ...defaultOptions,
         format: codec
@@ -316,7 +314,7 @@ describe('/dag', () => {
         ...await toHeadersAndPayload(data)
       }, { ipfs })
 
-      expect(ipfs.ipld.getFormat.calledWith(codec)).to.be.true()
+      expect(ipfs.block.put.called).to.be.true()
       expect(res).to.have.property('statusCode', 200)
       expect(res).to.have.deep.nested.property('result.Cid', { '/': cid.toString() })
     })


### PR DESCRIPTION
We needed to reach into ipld in order to get at the formats so we can deserialize the data.

Instead, put the data as a block and then read it out using ipfs.dag.get.

Slightly inefficient but better to use the public API.

Fixes #3639