### PR TITLE
fix: mark ipld options as partial

### DIFF
--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -16,7 +16,7 @@
     "human-crypto-keys": "^0.1.4",
     "ipfs": "^0.54.4",
     "ipfs-http-client": "^49.0.4",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "ipns": "^0.11.0",
     "it-last": "^1.0.4",
     "p-retry": "^4.2.0",

--- a/examples/custom-ipfs-repo/package.json
+++ b/examples/custom-ipfs-repo/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "datastore-fs": "4.0.0",
     "ipfs": "^0.54.4",
-    "ipfs-repo": "^9.1.3",
+    "ipfs-repo": "^9.1.4",
     "it-all": "^1.0.4"
   },
   "devDependencies": {

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -47,7 +47,7 @@
     "err-code": "^3.0.1",
     "ipfs-unixfs": "^4.0.3",
     "ipfs-unixfs-importer": "^7.0.3",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "ipld-block": "^0.11.0",
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -42,7 +42,7 @@
     "ipfs-core-utils": "^0.7.2",
     "ipfs-daemon": "^0.5.4",
     "ipfs-http-client": "^49.0.4",
-    "ipfs-repo": "^9.1.3",
+    "ipfs-repo": "^9.1.4",
     "ipfs-utils": "^6.0.4",
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -43,7 +43,7 @@
     "ipfs-daemon": "^0.5.4",
     "ipfs-http-client": "^49.0.4",
     "ipfs-repo": "^9.1.4",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",
     "it-all": "^1.0.4",

--- a/packages/ipfs-core-types/src/config/index.d.ts
+++ b/packages/ipfs-core-types/src/config/index.d.ts
@@ -109,7 +109,7 @@ export interface IdentityConfig {
   /**
    * The base64 encoded protobuf describing (and containing) the nodes private key.
    */
-  PrivateKey: string
+  PrivKey: string
 }
 
 export interface KeychainConfig {

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -48,7 +48,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.3.1",
     "ipfs-unixfs": "^4.0.3",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "it-all": "^1.0.4",
     "it-map": "^1.0.4",
     "it-peekable": "^1.0.1",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -74,7 +74,7 @@
     "ipfs-block-service": "^0.19.0",
     "ipfs-core-types": "^0.3.1",
     "ipfs-core-utils": "^0.7.2",
-    "ipfs-repo": "^9.1.3",
+    "ipfs-repo": "^9.1.4",
     "ipfs-unixfs": "^4.0.3",
     "ipfs-unixfs-exporter": "^5.0.3",
     "ipfs-unixfs-importer": "^7.0.3",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -78,7 +78,7 @@
     "ipfs-unixfs": "^4.0.3",
     "ipfs-unixfs-exporter": "^5.0.3",
     "ipfs-unixfs-importer": "^7.0.3",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "ipld": "^0.30.0",
     "ipld-block": "^0.11.0",
     "ipld-dag-cbor": "^1.0.0",

--- a/packages/ipfs-core/src/components/cat.js
+++ b/packages/ipfs-core/src/components/cat.js
@@ -3,6 +3,7 @@
 const { exporter } = require('ipfs-unixfs-exporter')
 const { normalizeCidPath } = require('../utils')
 const withTimeoutOption = require('ipfs-core-utils/src/with-timeout-option')
+const CID = require('cids')
 
 /**
  * @typedef {Object} Context
@@ -20,7 +21,7 @@ module.exports = function ({ ipld, preload }) {
 
     if (options.preload !== false) {
       const pathComponents = ipfsPath.split('/')
-      preload(pathComponents[0])
+      preload(new CID(pathComponents[0]))
     }
 
     const file = await exporter(ipfsPath, ipld, options)

--- a/packages/ipfs-core/src/components/get.js
+++ b/packages/ipfs-core/src/components/get.js
@@ -4,6 +4,7 @@ const exporter = require('ipfs-unixfs-exporter')
 const errCode = require('err-code')
 const { normalizeCidPath, mapFile } = require('../utils')
 const withTimeoutOption = require('ipfs-core-utils/src/with-timeout-option')
+const CID = require('cids')
 
 /**
  * @typedef {Object} Context
@@ -26,7 +27,7 @@ module.exports = function ({ ipld, preload }) {
         throw errCode(err, 'ERR_INVALID_PATH')
       }
 
-      preload(pathComponents[0])
+      preload(new CID(pathComponents[0]))
     }
 
     for await (const file of exporter.recursive(ipfsPath, ipld, options)) {

--- a/packages/ipfs-core/src/components/ipld.js
+++ b/packages/ipfs-core/src/components/ipld.js
@@ -6,7 +6,7 @@ const Ipld = require('ipld')
 /**
  * @param {Object} config
  * @param {import('ipfs-block-service')} config.blockService
- * @param {import('ipld').Options} [config.options]
+ * @param {Partial<import('ipld').Options>} [config.options]
  */
 const createIPLD = ({ blockService, options }) => {
   return new Ipld(getDefaultIpldOptions(blockService, options))

--- a/packages/ipfs-core/src/components/ls.js
+++ b/packages/ipfs-core/src/components/ls.js
@@ -4,6 +4,7 @@ const { exporter, recursive } = require('ipfs-unixfs-exporter')
 const errCode = require('err-code')
 const { normalizeCidPath, mapFile } = require('../utils')
 const withTimeoutOption = require('ipfs-core-utils/src/with-timeout-option')
+const CID = require('cids')
 
 /**
  * @typedef {Object} Context
@@ -21,7 +22,7 @@ module.exports = function ({ ipld, preload }) {
     const pathComponents = path.split('/')
 
     if (options.preload !== false) {
-      preload(pathComponents[0])
+      preload(new CID(pathComponents[0]))
     }
 
     const file = await exporter(ipfsPath, ipld, options)

--- a/packages/ipfs-core/src/preload.js
+++ b/packages/ipfs-core/src/preload.js
@@ -3,7 +3,6 @@
 // @ts-ignore no types
 const toUri = require('multiaddr-to-uri')
 const debug = require('debug')
-const CID = require('cids')
 const shuffle = require('array-shuffle')
 const { AbortController } = require('native-abort-controller')
 const preload = require('./runtime/preload-nodejs')
@@ -44,13 +43,13 @@ const createPreloader = (options = {}) => {
   /**
    * @type {import('./types').Preload}
    */
-  const api = async path => {
+  const api = async cid => {
     try {
-      if (stopped) throw new Error(`preload ${path} but preloader is not started`)
-
-      if (typeof path !== 'string') {
-        path = new CID(path).toString()
+      if (stopped) {
+        throw new Error(`preload ${cid} but preloader is not started`)
       }
+
+      const path = cid.toString()
 
       if (cache.has(path)) {
         // we've preloaded this recently, don't preload it again

--- a/packages/ipfs-core/src/runtime/ipld.js
+++ b/packages/ipfs-core/src/runtime/ipld.js
@@ -5,6 +5,7 @@ const multicodec = require('multicodec')
 
 /**
  * @typedef {import('interface-ipld-format').Format<?>} IPLDFormat
+ * @typedef {import('ipld').Options} IPLDOptions
  */
 
 /**
@@ -26,7 +27,7 @@ const IpldFormats = {
 
 /**
  * @param {import('ipfs-block-service')} blockService
- * @param {import('ipld').Options} [options]
+ * @param {Partial<IPLDOptions>} [options]
  */
 module.exports = (blockService, options) => {
   return mergeOptions.call(

--- a/packages/ipfs-core/src/types.d.ts
+++ b/packages/ipfs-core/src/types.d.ts
@@ -100,7 +100,7 @@ export interface Options {
  * (https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs/src/core/runtime/ipld.js)
  * in browsers)
    */
-  ipld?: IPLDOptions
+  ipld?: Partial<IPLDOptions>
 
   /**
    * The libp2p option allows you to build

--- a/packages/ipfs-core/src/types.d.ts
+++ b/packages/ipfs-core/src/types.d.ts
@@ -1,16 +1,15 @@
 import type { KeyType } from 'libp2p-crypto'
 import type PeerId from 'peer-id'
-import type { IPFSConfig } from 'ipfs-core-types/src/config'
-import type { ProfileNames } from 'ipfs-core-types/src/config/profiles'
-import type IPLD from 'ipld'
+import type { Config as IPFSConfig } from 'ipfs-core-types/src/config'
 import type { Options as IPLDOptions } from 'ipld'
 import type Libp2p from 'libp2p'
 import type { Libp2pOptions } from 'libp2p'
 import type IPFSRepo from 'ipfs-repo'
 import type { ProgressCallback as MigrationProgressCallback } from 'ipfs-repo-migrations'
-import type { Datastore } from 'interface-datastore'
-import type Network, { Options as NetworkOptions } from './components/network'
+import type Network from './components/network'
+import type { Options as NetworkOptions } from './components/network'
 import type Service from './utils/service'
+import CID from 'cids'
 
 export interface Options {
   /**
@@ -152,7 +151,7 @@ export interface InitOptions {
   /**
    * Apply profile settings to config
    */
-  profiles?: ProfileNames[]
+  profiles?: string[]
 
   /**
    * Set to `false` to disallow initialization if the repo does not already exist

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -38,7 +38,7 @@
     "ipfs-http-client": "^49.0.4",
     "ipfs-http-gateway": "^0.3.2",
     "ipfs-http-server": "^0.3.4",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "just-safe-set": "^2.2.1",
     "libp2p": "^0.31.2",
     "libp2p-delegated-content-routing": "^0.10.0",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -52,7 +52,7 @@
     "ipfs-core-types": "^0.3.1",
     "ipfs-core-utils": "^0.7.2",
     "ipfs-unixfs": "^4.0.3",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "ipld-block": "^0.11.0",
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",

--- a/packages/ipfs-http-client/src/lib/core.js
+++ b/packages/ipfs-http-client/src/lib/core.js
@@ -15,8 +15,6 @@ const DEFAULT_HOST = isBrowser || isWebWorker ? location.hostname : 'localhost'
 const DEFAULT_PORT = isBrowser || isWebWorker ? location.port : '5001'
 
 /**
- * @typedef {import('ipfs-utils/dist/types/native-fetch').Response} Response
- * @typedef {import('ipfs-utils/dist/types/native-fetch').Request} Request
  * @typedef {import('ipfs-utils/src/types').HTTPOptions} HTTPOptions
  * @typedef {import('../types').Options} Options
  */

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -57,7 +57,7 @@
     "ipfs-core-types": "^0.3.1",
     "ipfs-http-client": "^49.0.4",
     "ipfs-interop": "^5.0.2",
-    "ipfs-utils": "^6.0.4",
+    "ipfs-utils": "^7.0.0",
     "ipfsd-ctl": "^8.0.1",
     "iso-url": "^1.0.0",
     "libp2p-webrtc-star": "^0.22.2",


### PR DESCRIPTION
Otherwise the user has to specify a blockstore etc.

We make the options object whole before instantiating ipld.