### PR TITLE
chore: remove sidetree test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ jobs:
     - name: external - service-worker-gateway
     - name: external - orbit-db
     - name: external - ipfs-log
-    - name: external - sidetree
 
   include:
     - stage: test
@@ -370,13 +369,6 @@ jobs:
       name: external - ipfs-log
       script:
         - npm run test:external -- -- -- https://github.com/orbitdb/ipfs-log.git --deps=ipfs@next
-
-    - stage: test-external
-      # only run on changes to master
-      if: branch = master AND type = push AND fork = false
-      name: external - sidetree
-      script:
-        - npm run test:external -- -- -- https://github.com/decentralized-identity/sidetree.git --deps=ipfs@next
 
 notifications:
   email: false


### PR DESCRIPTION
sidetree removed the direct dependency on js-ipfs in https://github.com/decentralized-identity/sidetree/commit/be481c002c8643d65e7203097338ddc94eca6cd6#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>