### PR TITLE
fix: loosen input type for swarm.connect and swarm.disconnect

### DIFF
--- a/packages/ipfs-core-types/src/bitswap/index.d.ts
+++ b/packages/ipfs-core-types/src/bitswap/index.d.ts
@@ -24,7 +24,7 @@ export interface API<OptionExtension = {}> {
    * // [ CID('QmHash') ]
    * ```
    */
-  wantlistForPeer: (peerId: CID | string, options?: AbortOptions & OptionExtension) => Promise<CID[]>
+  wantlistForPeer: (peerId: string, options?: AbortOptions & OptionExtension) => Promise<CID[]>
 
   /**
    * Removes one or more CIDs from the wantlist

--- a/packages/ipfs-core-types/src/dht/index.d.ts
+++ b/packages/ipfs-core-types/src/dht/index.d.ts
@@ -21,7 +21,7 @@ export interface API<OptionExtension = {}> {
      * // '/ip4/147.75.94.115/tcp/4001'
      * ```
      */
-  findPeer: (peerId: CID | string, options?: AbortOptions & OptionExtension) => Promise<PeerResult>
+  findPeer: (peerId: string, options?: AbortOptions & OptionExtension) => Promise<PeerResult>
 
   /**
      * Find peers in the DHT that can provide a specific value, given a CID.
@@ -59,7 +59,7 @@ export interface API<OptionExtension = {}> {
   /**
    * Find the closest peers to a given `PeerId`, by querying the DHT.
    */
-  query: (peerId: CID | string, options?: AbortOptions & OptionExtension) => AsyncIterable<PeerResult>
+  query: (peerId: string, options?: AbortOptions & OptionExtension) => AsyncIterable<PeerResult>
 }
 
 export interface PeerResult {

--- a/packages/ipfs-core-types/src/root.d.ts
+++ b/packages/ipfs-core-types/src/root.d.ts
@@ -82,7 +82,7 @@ export interface API<OptionExtension = {}> {
    * }
    * ```
    */
-  ping: (peerId: CID | string, options?: PingOptions & OptionExtension) => AsyncIterable<PingResult>
+  ping: (peerId: string, options?: PingOptions & OptionExtension) => AsyncIterable<PingResult>
 
   /**
    * Resolve the value of names to IPFS

--- a/packages/ipfs-core-types/src/stats/index.d.ts
+++ b/packages/ipfs-core-types/src/stats/index.d.ts
@@ -14,7 +14,7 @@ export interface API<OptionExtension = {}> {
 }
 
 export interface BWOptions extends AbortOptions {
-  peer?: CID | string
+  peer?: string
   proto?: string
   poll?: boolean
   interval?: number

--- a/packages/ipfs-core-types/src/swarm/index.d.ts
+++ b/packages/ipfs-core-types/src/swarm/index.d.ts
@@ -5,20 +5,20 @@ import type CID from 'cids'
 import type { Multiaddr } from 'multiaddr'
 
 export interface API<OptionExtension = {}> {
-    /**
+  /**
    * List of known addresses of each peer connected
    */
   addrs: (options?: AbortOptions & OptionExtension) => Promise<AddrsResult[]>
 
   /**
-   * Open a connection to a given address
+   * Open a connection to a given address or peer id
    */
-  connect: (addr: Multiaddr, options?: AbortOptions & OptionExtension) => Promise<void>
+  connect: (addr: Multiaddr | string, options?: AbortOptions & OptionExtension) => Promise<void>
 
   /**
-   * Close a connection to a given address
+   * Close a connection to a given address or peer id
    */
-  disconnect: (addr: Multiaddr, options?: AbortOptions & OptionExtension) => Promise<void>
+  disconnect: (addr: Multiaddr | string, options?: AbortOptions & OptionExtension) => Promise<void>
 
   /**
    * Local addresses this node is listening on

--- a/packages/ipfs-http-client/src/dht/find-peer.js
+++ b/packages/ipfs-http-client/src/dht/find-peer.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const CID = require('cids')
 const { Multiaddr } = require('multiaddr')
 const configure = require('../lib/configure')
 const toUrlSearchParams = require('../lib/to-url-search-params')
@@ -20,7 +19,7 @@ module.exports = configure(api => {
       timeout: options.timeout,
       signal: options.signal,
       searchParams: toUrlSearchParams({
-        arg: `${peerId instanceof Uint8Array ? new CID(peerId) : peerId}`,
+        arg: peerId,
         ...options
       }),
       headers: options.headers


### PR DESCRIPTION
Accept peer ids as strings or multiaddrs as Multiaddrs.

Also removes accepting peerIDs as CIDs for consistency as I don't think we actually return peerIDs as CIDs from the api anywhere (from `ipfs.swarm.peers`, for example), only ever as strings.

Fixes #3638