### PR TITLE
fix: reject requests when cors origin list is empty

### DIFF
--- a/packages/ipfs-http-server/src/index.js
+++ b/packages/ipfs-http-server/src/index.js
@@ -67,7 +67,13 @@ function isAllowedOrigin (str, allowedOrigins = []) {
     return false
   }
 
-  const { origin } = new URL(str)
+  let origin
+
+  try {
+    origin = (new URL(str)).origin
+  } catch {
+    return false
+  }
 
   for (const allowedOrigin of allowedOrigins) {
     if (allowedOrigin === '*') {

--- a/packages/ipfs-http-server/src/index.js
+++ b/packages/ipfs-http-server/src/index.js
@@ -59,16 +59,15 @@ async function serverCreator (serverAddrs, createServer, ipfs, cors) {
 }
 
 /**
- * @param {string} str
- * @param {string[]} allowedOrigins
+ * @param {string} [str]
+ * @param {string[]} [allowedOrigins]
  */
 function isAllowedOrigin (str, allowedOrigins = []) {
   if (!str) {
     return false
   }
 
-  const url = new URL(str)
-  const origin = url.protocol + '//' + url.host
+  const { origin } = new URL(str)
 
   for (const allowedOrigin of allowedOrigins) {
     if (allowedOrigin === '*') {

--- a/packages/ipfs-http-server/src/index.js
+++ b/packages/ipfs-http-server/src/index.js
@@ -58,6 +58,31 @@ async function serverCreator (serverAddrs, createServer, ipfs, cors) {
   return servers
 }
 
+/**
+ * @param {string} str
+ * @param {string[]} allowedOrigins
+ */
+function isAllowedOrigin (str, allowedOrigins = []) {
+  if (!str) {
+    return false
+  }
+
+  const url = new URL(str)
+  const origin = url.protocol + '//' + url.host
+
+  for (const allowedOrigin of allowedOrigins) {
+    if (allowedOrigin === '*') {
+      return true
+    }
+
+    if (allowedOrigin === origin) {
+      return true
+    }
+  }
+
+  return false
+}
+
 class HttpApi {
   /**
    * @param {IPFS} ipfs
@@ -175,11 +200,17 @@ class HttpApi {
 
         const headers = request.headers || {}
         const origin = headers.origin || ''
-        const referrer = headers.referrer || ''
+        const referer = headers.referer || ''
         const userAgent = headers['user-agent'] || ''
 
-        // If these are set, we leave up to CORS and CSRF checks.
-        if (origin || referrer) {
+        // If these are set, check them against the configured list
+        if (origin || referer) {
+          if (!isAllowedOrigin(origin || referer, cors.origin)) {
+            // Hapi will not allow an empty CORS origin list so we have to manually
+            // reject the request if CORS origins have not been configured
+            throw Boom.forbidden()
+          }
+
           return h.continue
         }
 

--- a/packages/ipfs-http-server/test/cors.js
+++ b/packages/ipfs-http-server/test/cors.js
@@ -180,6 +180,55 @@ describe('cors', () => {
       expect(res).to.have.property('statusCode', 403)
     })
 
+    it('rejects requests when cors origin list is empty and referer is sent', async () => {
+      const referer = 'http://localhost:8080/index.html'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          referer
+        }
+      }, {
+        ipfs,
+        cors: { origin: [] }
+      })
+
+      expect(res).to.have.property('statusCode', 403)
+    })
+
+    it('rejects requests when cors origin list is empty and referer and origin are sent', async () => {
+      const referer = 'http://localhost:8080/index.html'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          referer,
+          origin: 'http://localhost:8080'
+        }
+      }, {
+        ipfs,
+        cors: { origin: [] }
+      })
+
+      expect(res).to.have.property('statusCode', 403)
+    })
+
+    it('rejects requests when cors origin list is empty and origin is sent as "null" (e.g. data urls and sandboxed iframes)', async () => {
+      const origin = 'null'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin
+        }
+      }, {
+        ipfs,
+        cors: { origin: [] }
+      })
+
+      expect(res).to.have.property('statusCode', 403)
+    })
+
     it('rejects requests when cors origin list does not contain the correct origin and origin is sent', async () => {
       const origin = 'http://localhost:8080'
       const res = await http({

--- a/packages/ipfs-http-server/test/cors.js
+++ b/packages/ipfs-http-server/test/cors.js
@@ -32,7 +32,21 @@ describe('cors', () => {
         }
       }, { ipfs, cors: { origin: [origin] } })
 
+      expect(res).to.have.property('statusCode', 200)
       expect(res).to.have.nested.property('headers.access-control-allow-origin', origin)
+    })
+
+    it('allows request when referer is supplied in request', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          referer: origin + '/index.html'
+        }
+      }, { ipfs, cors: { origin: [origin] } })
+
+      expect(res).to.have.property('statusCode', 200)
     })
 
     it('does not allow credentials when omitted in config', async () => {
@@ -148,6 +162,54 @@ describe('cors', () => {
       })
 
       expect(res).to.have.property('statusCode', 404)
+    })
+
+    it('rejects requests when cors origin list is empty and origin is sent', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin
+        }
+      }, {
+        ipfs,
+        cors: { origin: [] }
+      })
+
+      expect(res).to.have.property('statusCode', 403)
+    })
+
+    it('rejects requests when cors origin list does not contain the correct origin and origin is sent', async () => {
+      const origin = 'http://localhost:8080'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          origin
+        }
+      }, {
+        ipfs,
+        cors: { origin: ['http://example.com:8080'] }
+      })
+
+      expect(res).to.have.property('statusCode', 403)
+    })
+
+    it('rejects requests when cors origin list does not contain the correct origin and referer is sent', async () => {
+      const referer = 'http://localhost:8080/index.html'
+      const res = await http({
+        method: 'POST',
+        url: '/api/v0/id',
+        headers: {
+          referer
+        }
+      }, {
+        ipfs,
+        cors: { origin: ['http://example.com:8080'] }
+      })
+
+      expect(res).to.have.property('statusCode', 403)
     })
   })
 })


### PR DESCRIPTION
If CORS origin list is empty, Hapi throws an error as it considers
that to be invalid configuration.

We want to reject requests that send and origin or a referer when
no allowed origins have been configured, so when these headers are
sent, reject the request if no allowed origins are present in the
config.