### PR TITLE
fix: only accept cid for ipfs.dag.get

### DIFF
--- a/examples/traverse-ipld-graphs/eth.js
+++ b/examples/traverse-ipld-graphs/eth.js
@@ -34,14 +34,14 @@ async function main () {
     await ipfs.block.put(new Block(data, cid))
   }
 
-  const block302516 = 'z43AaGEywSDX5PUJcrn5GfZmb6FjisJyR7uahhWPk456f7k7LDA'
-  const block302517 = 'z43AaGF42R2DXsU65bNnHRCypLPr9sg6D7CUws5raiqATVaB1jj'
+  const block302516 = new CID('z43AaGEywSDX5PUJcrn5GfZmb6FjisJyR7uahhWPk456f7k7LDA')
+  const block302517 = new CID('z43AaGF42R2DXsU65bNnHRCypLPr9sg6D7CUws5raiqATVaB1jj')
   let res
 
-  res = await ipfs.dag.get(block302516 + '/number')
+  res = await ipfs.dag.get(block302516, { path: 'number' })
   console.log(uint8ArrayToString(res.value, 'base16'))
 
-  res = await ipfs.dag.get(block302517 + '/parent/number')
+  res = await ipfs.dag.get(block302517, { path: 'parent/number' })
   console.log(uint8ArrayToString(res.value, 'base16'))
 }
 

--- a/examples/traverse-ipld-graphs/get-path.js
+++ b/examples/traverse-ipld-graphs/get-path.js
@@ -15,13 +15,13 @@ async function main () {
   const cid = await ipfs.dag.put(myData, { format: 'dag-cbor', hashAlg: 'sha2-256' })
   let result
 
-  result = await ipfs.dag.get(cid, 'name')
+  result = await ipfs.dag.get(cid, { path: 'name' })
   console.log(result.value)
 
-  result = await ipfs.dag.get(cid, 'likes')
+  result = await ipfs.dag.get(cid, { path: 'likes' })
   console.log(result.value)
 
-  result = await ipfs.dag.get(cid + '/likes/0')
+  result = await ipfs.dag.get(cid, { path: '/likes/0' })
   console.log(result.value)
 }
 

--- a/examples/traverse-ipld-graphs/git.js
+++ b/examples/traverse-ipld-graphs/git.js
@@ -56,11 +56,11 @@ async function main () {
     console.log(result.value)
   }
 
-  await logResult(() => ipfs.dag.get(v1tag + '/'), 'Tag object:')
-  await logResult(() => ipfs.dag.get(v1tag + '/object/message'), 'Tagged commit message:')
-  await logResult(() => ipfs.dag.get(v1tag + '/object/parents/0/message'), 'Parent of tagged commit:')
-  await logResult(() => ipfs.dag.get(v1tag + '/object/tree/src/hash/hello/hash'), '/src/hello file:')
-  await logResult(() => ipfs.dag.get(v1tag + '/object/parents/0/tree/src/hash/hello/hash'), 'previous version of /src/hello file:')
+  await logResult(() => ipfs.dag.get(v1tag), 'Tag object:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/message' }), 'Tagged commit message:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/parents/0/message' }), 'Parent of tagged commit:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/tree/src/hash/hello/hash' }), '/src/hello file:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/parents/0/tree/src/hash/hello/hash' }), 'previous version of /src/hello file:')
 }
 
 main()

--- a/examples/traverse-ipld-graphs/git.js
+++ b/examples/traverse-ipld-graphs/git.js
@@ -42,7 +42,7 @@ async function main () {
     await ipfs.block.put(new Block(data, cid))
   }))
 
-  const v1tag = 'z8mWaGfwSWLMPJ6Q2JdsAjGiXTf61Nbue'
+  const v1tag = new CID('z8mWaGfwSWLMPJ6Q2JdsAjGiXTf61Nbue')
 
   async function logResult (fn, comment) {
     const result = await fn()

--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -189,7 +189,7 @@ module.exports = (common, options) => {
         foo: 'dag-cbor-bar'
       }
 
-      let cid = await ipfs.dag.put(cbor, { format: 'dag-cbor', hashAlg: 'sha2-256' })
+      const cid = await ipfs.dag.put(cbor, { format: 'dag-cbor', hashAlg: 'sha2-256' })
       expect(cid.codec).to.equal('dag-cbor')
       expect(cid.toBaseEncodedString('base32')).to.equal('bafyreic6f672hnponukaacmk2mmt7vs324zkagvu4hcww6yba6kby25zce')
 

--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -135,17 +135,6 @@ module.exports = (common, options) => {
       expect(result.value).to.eql(uint8ArrayFromString('I am inside a Protobuf'))
     })
 
-    it('should get by CID string', async () => {
-      const cidCborStr = cidCbor.toBaseEncodedString()
-
-      const result = await ipfs.dag.get(cidCborStr)
-
-      const node = result.value
-
-      const cid = await dagCBOR.util.cid(dagCBOR.util.serialize(node))
-      expect(cid).to.eql(cidCbor)
-    })
-
     it('should get by CID with path option', async function () {
       const result = await ipfs.dag.get(cidCbor, { path: '/pb/Data' })
       expect(result.value).to.eql(uint8ArrayFromString('I am inside a Protobuf'))

--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -191,8 +191,7 @@ module.exports = (common, options) => {
 
       let cid = await ipfs.dag.put(cbor, { format: 'dag-cbor', hashAlg: 'sha2-256' })
       expect(cid.codec).to.equal('dag-cbor')
-      cid = cid.toBaseEncodedString('base32')
-      expect(cid).to.equal('bafyreic6f672hnponukaacmk2mmt7vs324zkagvu4hcww6yba6kby25zce')
+      expect(cid.toBaseEncodedString('base32')).to.equal('bafyreic6f672hnponukaacmk2mmt7vs324zkagvu4hcww6yba6kby25zce')
 
       const result = await ipfs.dag.get(cid, {
         path: 'foo'

--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -146,10 +146,8 @@ module.exports = (common, options) => {
       expect(cid).to.eql(cidCbor)
     })
 
-    it('should get by CID string + path', async function () {
-      const cidCborStr = cidCbor.toBaseEncodedString()
-
-      const result = await ipfs.dag.get(cidCborStr + '/pb/Data')
+    it('should get by CID with path option', async function () {
+      const result = await ipfs.dag.get(cidCbor, { path: '/pb/Data' })
       expect(result.value).to.eql(uint8ArrayFromString('I am inside a Protobuf'))
     })
 

--- a/packages/ipfs-core/src/components/dag/get.js
+++ b/packages/ipfs-core/src/components/dag/get.js
@@ -3,7 +3,6 @@
 const withTimeoutOption = require('ipfs-core-utils/src/with-timeout-option')
 const first = require('it-first')
 const last = require('it-last')
-const toCidAndPath = require('ipfs-core-utils/src/to-cid-and-path')
 
 /**
  * @param {Object} config

--- a/packages/ipfs-core/src/components/dag/get.js
+++ b/packages/ipfs-core/src/components/dag/get.js
@@ -14,16 +14,7 @@ module.exports = ({ ipld, preload }) => {
   /**
    * @type {import('ipfs-core-types/src/dag').API["get"]}
    */
-  const get = async function get (ipfsPath, options = {}) {
-    const {
-      cid,
-      path
-    } = toCidAndPath(ipfsPath)
-
-    if (path) {
-      options.path = path
-    }
-
+  const get = async function get (cid, options = {}) {
     if (options.preload !== false) {
       preload(cid)
     }

--- a/packages/ipfs/test/interface-http-go.js
+++ b/packages/ipfs/test/interface-http-go.js
@@ -138,7 +138,7 @@ describe('interface-ipfs-core over ipfs-http-client tests against go-ipfs', () =
         reason: 'FIXME vmx 2018-02-22: Currently not supported in go-ipfs, it might be possible once https://github.com/ipfs/go-ipfs/issues/4728 is done'
       },
       {
-        name: 'should get by CID string + path',
+        name: 'should get by CID with path option',
         reason: 'FIXME vmx 2018-02-22: Currently not supported in go-ipfs, it might be possible once https://github.com/ipfs/go-ipfs/issues/4728 is done'
       },
       {


### PR DESCRIPTION
If you have a path within the DAG to resolve, pass it as `path` in the options object.

Makes the API conform to the documentation.

Fixes #3637