### PR TITLE
chore: run gh actions on node 16

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [16.x]
         project:
           - packages/ipfs
           - packages/ipfs-core

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         project:
           - packages/ipfs
           - packages/ipfs-cli


### PR DESCRIPTION
Node 16 is now current so use that.