### PR TITLE
chore: fix flaky test

### DIFF
--- a/packages/ipfs-http-client/test/node/agent.js
+++ b/packages/ipfs-http-client/test/node/agent.js
@@ -102,14 +102,16 @@ describe('agent', function () {
     }
 
     const results = await requests
-
-    expect(results).to.deep.equal([{
+    expect(results).to.have.lengthOf(3)
+    expect(results).to.deep.include({
       res: 0
-    }, {
+    })
+    expect(results).to.deep.include({
       res: 1
-    }, {
+    })
+    expect(results).to.deep.include({
       res: 2
-    }])
+    })
 
     server.close()
   })


### PR DESCRIPTION
Because the requests are initiated with `Promise.all`, there's no
guarantee which order they arrive at the server in so when we check
the responses, just make sure the length and contents are correct
instead of the order.