### PR TITLE
fix: remove optional chaining from code that will be transpiled

### DIFF
--- a/packages/ipfs-core/src/components/add-all/index.js
+++ b/packages/ipfs-core/src/components/add-all/index.js
@@ -189,7 +189,7 @@ function pinFile (pin, opts) {
     for await (const file of source) {
       // Pin a file if it is the root dir of a recursive add or the single file
       // of a direct add.
-      const isRootDir = !file.path?.includes('/')
+      const isRootDir = !(file.path && file.path.includes('/'))
       const shouldPin = (opts.pin == null ? true : opts.pin) && isRootDir && !opts.onlyHash
 
       if (shouldPin) {


### PR DESCRIPTION
Optional chaining is supported in node and in browsers but tools that
transpile code to run in older browsers doesn't understand the syntax.

Specifically the version of acorn that at least vue uses via a dependency
on webpack 4 does not support this.

It'll be fixed by them upgrading to webpack 5 but the timescale on that
is unclear, which is why we're using a prerelease version in our examples.

The short term fix is to just remove optional chaining from where we
are using it in code that will be transpiled for browser use.