### PR TITLE
chore: allow bundlesize gh action to fail

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -28,6 +28,7 @@ jobs:
       - run: npm install -g @mapbox/node-pre-gyp && npm install
       - name: Bundlesize ${{ matrix.project }}
         uses: ipfs/aegir/actions/bundle-size@v32.1.0
+        continue-on-error: true
         with:
           project: ${{ matrix.project }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sometimes it's because there's a duplicate dep version that needs to
be fixed.

Usually it's because some transitive dep increases it's bundle size
by a kilobyte or two and has nothing to do with the current PR, so all
we do is increase the `bundlesizeMax` value to make it pass.

Let's just make the check informational instead.