### PR TITLE
fix: move wrtc to optional deps

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
-      - run: npm install -g @mapbox/node-pre-gyp && npm install
+      - run: npm install
       - name: Bundlesize ${{ matrix.project }}
         uses: ipfs/aegir/actions/bundle-size@v32.1.0
         continue-on-error: true

--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [14.x]
         project:
           - packages/ipfs
           - packages/ipfs-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,6 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export PATH=/c/PROGRA~1/Git/usr/bin:/c/PROGRA~1/Git/mingw64/libexec/git-core:$PATH ; fi
   # only run jobs in packages that have changed since master in PR builds
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export RUN_SINCE='--since master' ; fi
-  # modules with pre-built binaries may not have deployed versions for bleeding-edge node so this lets us fall back to building from source
-  - npm install -g @mapbox/node-pre-gyp
 
 script:
   - npm run test:node -- $RUN_SINCE -- -- --timeout 10000 --bail -- --exit # TODO remove --exit https://mochajs.org/#-exit

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -8,11 +8,9 @@ ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 RUN apk add --no-cache git python3 build-base
 
 # Hopefully remove when https://github.com/node-webrtc/node-webrtc/pull/694 is merged
-RUN npm install -g @mapbox/node-pre-gyp
 RUN npm install -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
-RUN npm uninstall -g @mapbox/node-pre-gyp
 RUN npm cache clear --force
 RUN apk del build-base python3 git
 

--- a/Dockerfile.next
+++ b/Dockerfile.next
@@ -8,11 +8,9 @@ ENV BUILD_DEPS='libnspr4 libnspr4-dev libnss3'
 RUN apk add --no-cache git python3 build-base
 
 # Hopefully remove when https://github.com/node-webrtc/node-webrtc/pull/694 is merged
-RUN npm install -g @mapbox/node-pre-gyp
 RUN npm install -g ipfs@"$IPFS_VERSION"
 
 # Make the image a bit smaller
-RUN npm uninstall -g @mapbox/node-pre-gyp
 RUN npm cache clear --force
 RUN apk del build-base python3 git
 

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -30,6 +30,7 @@
     "build": "aegir build --no-bundle"
   },
   "dependencies": {
+    "@mapbox/node-pre-gyp": "^1.0.5",
     "debug": "^4.1.1",
     "dlv": "^1.1.3",
     "ipfs-core": "^0.7.0",

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -53,9 +53,7 @@
   },
   "optionalDependencies": {
     "prom-client": "^12.0.0",
-    "prometheus-gc-stats": "^0.6.0"
-  },
-  "peerDependencies": {
+    "prometheus-gc-stats": "^0.6.0",
     "electron-webrtc": "^0.3.0",
     "wrtc": "^0.4.6"
   }

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -26,7 +26,7 @@
     "test:node": "aegir test -t node",
     "coverage": "nyc --reporter=text --reporter=lcov npm run test:node",
     "clean": "rimraf ./dist",
-    "dep-check": "aegir dep-check -i ipfs-core-types",
+    "dep-check": "aegir dep-check -i ipfs-core-types -i @mapbox/node-pre-gyp",
     "build": "aegir build --no-bundle"
   },
   "dependencies": {


### PR DESCRIPTION
npm7 has started installing peer deps by default, which means if you
are running a future tech node.js version you may end up compiling
native addons that may fail.  These addons should be opt-in so move
them to optional deps which means if they fail to install, the whole
installation does not fail.

Also adds `@mapbox/node-pre-gyp` as a dependency so we can attempt to 
compile modules that have native addons where no prebuilt binary is
available instead of requiring users to install it globally which is
required due to a misconfiguration in the `webrtc` module.