### PR TITLE
fix: add onError to pubsub.subscribe types

### DIFF
--- a/packages/ipfs-core-types/src/pubsub/index.d.ts
+++ b/packages/ipfs-core-types/src/pubsub/index.d.ts
@@ -13,7 +13,7 @@ export interface API<OptionExtension = {}> {
    * console.log(`subscribed to ${topic}`)
    * ```
    */
-  subscribe: (topic: string, handler: MessageHandlerFn, options?: AbortOptions & OptionExtension) => Promise<void>
+  subscribe: (topic: string, handler: MessageHandlerFn, options?: SubscribeOptions & OptionExtension) => Promise<void>
 
   /**
    * Unsubscribes from a pubsub topic
@@ -79,6 +79,14 @@ export interface Message {
   seqno: Uint8Array
   data: Uint8Array
   topicIDs: string[]
+}
+
+export interface SubscribeOptions extends AbortOptions {
+  /**
+   * A callback to receive an error if one occurs during processing
+   * subscription messages. Only supported by ipfs-http-client.
+   */
+  onError?: (err: Error) => void
 }
 
 export type MessageHandlerFn = (message: Message) => void

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -81,6 +81,7 @@
     "it-concat": "^2.0.0",
     "it-first": "^1.0.4",
     "nock": "^13.0.2",
+    "p-defer": "^3.0.0",
     "rimraf": "^3.0.2"
   },
   "engines": {

--- a/packages/ipfs-http-client/test/commands.spec.js
+++ b/packages/ipfs-http-client/test/commands.spec.js
@@ -7,6 +7,7 @@ const f = require('./utils/factory')()
 describe('.commands', function () {
   this.timeout(60 * 1000)
 
+  /** @type {import('ipfs-core-types').IPFS} */
   let ipfs
 
   before(async () => {

--- a/packages/ipfs-http-client/test/node/agent.js
+++ b/packages/ipfs-http-client/test/node/agent.js
@@ -5,6 +5,11 @@ const { expect } = require('aegir/utils/chai')
 const ipfsClient = require('../../src').create
 const delay = require('delay')
 
+/**
+ * @typedef {import('http').IncomingMessage} IncomingMessage
+ *
+ * @param {(message: IncomingMessage) => Promise<any>} handler
+ */
 function startServer (handler) {
   return new Promise((resolve) => {
     // spin up a test http server to inspect the requests made by the library
@@ -20,8 +25,10 @@ function startServer (handler) {
     })
 
     server.listen(0, () => {
+      const addressInfo = server.address()
+
       resolve({
-        port: server.address().port,
+        port: addressInfo && (typeof addressInfo === 'string' ? addressInfo : addressInfo.port),
         close: () => server.close()
       })
     })
@@ -29,6 +36,7 @@ function startServer (handler) {
 }
 
 describe('agent', function () {
+  /** @type {import('http').Agent} */
   let agent
 
   before(() => {
@@ -40,6 +48,7 @@ describe('agent', function () {
   })
 
   it('restricts the number of concurrent connections', async () => {
+    /** @type {((arg: any) => void)[]} */
     const responses = []
 
     const server = await startServer(() => {

--- a/packages/ipfs-http-client/test/utils/factory.js
+++ b/packages/ipfs-http-client/test/utils/factory.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-ignore no types
 const { createFactory } = require('ipfsd-ctl')
 const merge = require('merge-options')
 const { isNode } = require('ipfs-utils/src/env')
@@ -13,6 +14,7 @@ const commonOptions = {
 
 const commonOverrides = {
   go: {
+    // @ts-ignore go-ipfs has no types
     ipfsBin: isNode ? require('go-ipfs').path() : undefined
   }
 }

--- a/packages/ipfs-http-client/tsconfig.json
+++ b/packages/ipfs-http-client/tsconfig.json
@@ -4,7 +4,9 @@
     "outDir": "dist"
   },
   "include": [
-    "src"
+    "src",
+    "test/utils/factory.js",
+    "test/pubsub.spec.js"
   ],
   "references": [
     {


### PR DESCRIPTION
This was missed in #3468.  Also runs the type checker on the pubsub http client tests to ensure typing is correct.