### PR TITLE
feat: support v2 ipns signatures

### DIFF
--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -17,7 +17,7 @@
     "ipfs": "^0.55.3",
     "ipfs-http-client": "^50.1.1",
     "ipfs-utils": "^8.1.2",
-    "ipns": "ipfs/js-ipns#feat/validate-v2-sigs",
+    "ipns": "^0.12.0",
     "it-last": "^1.0.4",
     "p-retry": "^4.2.0",
     "uint8arrays": "^2.1.3"

--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -17,7 +17,7 @@
     "ipfs": "^0.55.3",
     "ipfs-http-client": "^50.1.1",
     "ipfs-utils": "^8.1.2",
-    "ipns": "^0.11.0",
+    "ipns": "ipfs/js-ipns#feat/validate-v2-sigs",
     "it-last": "^1.0.4",
     "p-retry": "^4.2.0",
     "uint8arrays": "^2.1.3"

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -51,7 +51,7 @@
     "ipld-block": "^0.11.0",
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",
-    "ipns": "^0.11.0",
+    "ipns": "ipfs/js-ipns#feat/validate-v2-sigs",
     "is-ipfs": "^5.0.0",
     "iso-random-stream": "^2.0.0",
     "it-all": "^1.0.4",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -51,7 +51,7 @@
     "ipld-block": "^0.11.0",
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",
-    "ipns": "ipfs/js-ipns#feat/validate-v2-sigs",
+    "ipns": "^0.12.0",
     "is-ipfs": "^5.0.0",
     "iso-random-stream": "^2.0.0",
     "it-all": "^1.0.4",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -84,7 +84,7 @@
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",
     "ipld-raw": "^7.0.0",
-    "ipns": "ipfs/js-ipns#feat/validate-v2-sigs",
+    "ipns": "^0.12.0",
     "is-domain-name": "^1.0.1",
     "is-ipfs": "^5.0.0",
     "it-all": "^1.0.4",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -84,7 +84,7 @@
     "ipld-dag-cbor": "^1.0.0",
     "ipld-dag-pb": "^0.22.1",
     "ipld-raw": "^7.0.0",
-    "ipns": "^0.11.0",
+    "ipns": "ipfs/js-ipns#feat/validate-v2-sigs",
     "is-domain-name": "^1.0.1",
     "is-ipfs": "^5.0.0",
     "it-all": "^1.0.4",

--- a/packages/ipfs-core/src/ipns/publisher.js
+++ b/packages/ipfs-core/src/ipns/publisher.js
@@ -254,10 +254,10 @@ class IpnsPublisher {
     }
 
     // Determinate the record sequence number
-    let seqNumber = 0
+    let seqNumber = 0n
 
     if (record && record.sequence !== undefined) {
-      seqNumber = !uint8ArrayEquals(record.value, value) ? record.sequence + 1 : record.sequence
+      seqNumber = !uint8ArrayEquals(record.value, value) ? BigInt(record.sequence) + 1n : BigInt(record.sequence)
     }
 
     let entryData


### PR DESCRIPTION
Upgrades `ipns` to support v2 sigs. Should be a backwards-compatible change.

Depends on:

- [x] https://github.com/ipfs/js-ipns/pull/121