### PR TITLE
chore: update libp2p noise

### DIFF
--- a/packages/ipfs-core/.aegir.js
+++ b/packages/ipfs-core/.aegir.js
@@ -70,7 +70,7 @@ module.exports = {
     }
   },
   build: {
-    bundlesizeMax: '549KB',
+    bundlesizeMax: '500KB',
     config: esbuild
   }
 }

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -102,7 +102,7 @@
     "libp2p-kad-dht": "^0.22.0",
     "libp2p-mdns": "^0.16.0",
     "libp2p-mplex": "^0.10.2",
-    "libp2p-noise": "^3.0.0",
+    "libp2p-noise": "^3.1.0",
     "libp2p-record": "^0.10.3",
     "libp2p-tcp": "^0.15.4",
     "libp2p-webrtc-star": "^0.22.2",

--- a/packages/ipfs/.aegir.js
+++ b/packages/ipfs/.aegir.js
@@ -118,7 +118,7 @@ module.exports = {
     }
   },
   build: {
-    bundlesizeMax: '549KB',
+    bundlesizeMax: '500KB',
     config: esbuild
   },
   dependencyCheck: {


### PR DESCRIPTION
With https://github.com/NodeFactoryIo/js-libp2p-noise/pull/100 in, we can now have a smaller bundle size. Also fixes node build

`libp2p-noise`: ~27% decrease on its bundle size, from 191.5kb to 141.2kb (minified+gzipped)
`ipfs`: ~10% decrease on its bundle size.

Closes https://github.com/ipfs/js-ipfs/issues/3704