### PR TITLE
chore: fix pkg.homepage for ipfs-core-types

### DIFF
--- a/packages/ipfs-core-types/package.json
+++ b/packages/ipfs-core-types/package.json
@@ -4,7 +4,7 @@
   "description": "IPFS interface definitions used by implementations for API compatibility.",
   "leadMaintainer": "Alex Potsides <alex@achingbrain.net>",
   "types": "src/index.d.ts",
-  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/interface-ipfs-core#readme",
+  "homepage": "https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-core-types#readme",
   "bugs": "https://github.com/ipfs/js-ipfs/issues",
   "scripts": {
     "lint": "aegir lint",


### PR DESCRIPTION
I linked from the npm package listing and was suprised to end up at the interface-ipfs-core package.