### PR TITLE
fix(ipfs-core-types): better typescript for IPFSEntry

### DIFF
--- a/packages/ipfs-core-types/src/root.d.ts
+++ b/packages/ipfs-core-types/src/root.d.ts
@@ -166,6 +166,7 @@ export interface Directory {
    * Directory path
    */
   path: string
+  content?: undefined
   mode?: number
   mtime?: Mtime
   size: number


### PR DESCRIPTION
```ts
for await (const file of ipfs.get(cid))
			{
				if (file.path === cid && !file.content)
				{
					continue;
				}
```

# before

![image](https://user-images.githubusercontent.com/167966/126286628-c27146ea-1fbd-47a8-91ed-b15372d83244.png)


# after

![image](https://user-images.githubusercontent.com/167966/126286550-2b89fc92-515b-4632-ac04-3f4ea80d7ffd.png)
