### PR TITLE
fix: await pubsub unsubscribe to fix flaky test

### DIFF
--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -64,6 +64,7 @@
     "multiformats": "^9.4.1",
     "nanoid": "^3.1.12",
     "native-abort-controller": "^1.0.3",
+    "p-defer": "^3.0.0",
     "parse-duration": "^1.0.0",
     "stream-to-it": "^0.2.2",
     "uint8arrays": "^2.1.6"
@@ -77,7 +78,6 @@
     "it-concat": "^2.0.0",
     "it-first": "^1.0.4",
     "nock": "^13.0.2",
-    "p-defer": "^3.0.0",
     "rimraf": "^3.0.2"
   },
   "engines": {

--- a/packages/ipfs-http-client/src/pubsub/unsubscribe.js
+++ b/packages/ipfs-http-client/src/pubsub/unsubscribe.js
@@ -15,7 +15,7 @@ module.exports = (options, subsTracker) => {
    * @type {PubsubAPI["unsubscribe"]}
    */
   async function unsubscribe (topic, handler) {
-    subsTracker.unsubscribe(topic, handler)
+    await subsTracker.unsubscribe(topic, handler)
   }
   return unsubscribe
 }


### PR DESCRIPTION
We manage pubsub subscriptions locally in the http client, when we unsubscribe from a given topic, we abort the long-lived connection we're holding open but do not wait for it to actually close.

In our tests we unsubscribe then check the subscription list - if we do this before the subscription is torn down it can report that we are still subscribed to the topic we just unsubscribed from.

The fix here is to wait for the connection to be torn down before returning from the unsubscribe call, by which point we should no longer have the topic in our subs list.