### PR TITLE
feat: add `error.response` for better error handling

### DIFF
--- a/packages/ipfs-http-client/src/lib/core.js
+++ b/packages/ipfs-http-client/src/lib/core.js
@@ -102,11 +102,15 @@ const errorHandler = async (response) => {
   // This is what go-ipfs returns where there's a timeout
   if (msg && msg.includes('context deadline exceeded')) {
     error = new HTTP.TimeoutError('Request timed out')
+    // @ts-ignore
+    error.response = response
   }
 
   // This also gets returned
   if (msg && msg.includes('request timed out')) {
     error = new HTTP.TimeoutError('Request timed out')
+    // @ts-ignore
+    error.response = response
   }
 
   // If we managed to extract a message from the response, use it


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/167966/127086334-a19685d1-2eee-4af5-8c7a-e178db98fea3.png)

really bad and useless