### PR TITLE
fix: export ipfs http client type and use option extension for client

### DIFF
--- a/packages/ipfs-core-types/src/index.d.ts
+++ b/packages/ipfs-core-types/src/index.d.ts
@@ -26,25 +26,25 @@ interface RefsAPI extends Refs {
   local: Local
 }
 
-export interface IPFS extends RootAPI {
-  bitswap: BitswapAPI
-  block: BlockAPI
-  bootstrap: BootstrapAPI
-  config: ConfigAPI
-  dag: DAGAPI
-  dht: DHTAPI
-  diag: DiagAPI
-  files: FilesAPI
-  key: KeyAPI
-  log: LogAPI
-  name: NameAPI
-  object: ObjectAPI
-  pin: PinAPI
-  pubsub: PubsubAPI
-  refs: RefsAPI
-  repo: RepoAPI
-  stats: StatsAPI
-  swarm: SwarmAPI
+export interface IPFS<OptionExtension = {}> extends RootAPI<OptionExtension> {
+  bitswap: BitswapAPI<OptionExtension>
+  block: BlockAPI<OptionExtension>
+  bootstrap: BootstrapAPI<OptionExtension>
+  config: ConfigAPI<OptionExtension>
+  dag: DAGAPI<OptionExtension>
+  dht: DHTAPI<OptionExtension>
+  diag: DiagAPI<OptionExtension>
+  files: FilesAPI<OptionExtension>
+  key: KeyAPI<OptionExtension>
+  log: LogAPI<OptionExtension>
+  name: NameAPI<OptionExtension>
+  object: ObjectAPI<OptionExtension>
+  pin: PinAPI<OptionExtension>
+  pubsub: PubsubAPI<OptionExtension>
+  refs: RefsAPI<OptionExtension>
+  repo: RepoAPI<OptionExtension>
+  stats: StatsAPI<OptionExtension>
+  swarm: SwarmAPI<OptionExtension>
   bases: Bases
   codecs: Codecs
   hashers: Hashers

--- a/packages/ipfs-http-client/src/index.js
+++ b/packages/ipfs-http-client/src/index.js
@@ -20,6 +20,7 @@ const { base58btc } = require('multiformats/bases/base58')
  * @typedef {import('./types').EndpointConfig} EndpointConfig
  * @typedef {import('./types').Options} Options
  * @typedef {import('multiformats/codecs/interface').BlockCodec<any, any>} BlockCodec
+ * @typedef {import('./types').IPFSHTTPClient} IPFSHTTPClient
  */
 
 /**
@@ -49,7 +50,7 @@ function create (options = {}) {
     loadHasher: options.ipld && options.ipld.loadHasher
   })
 
-  /** @type {import('ipfs-core-types').IPFS & { getEndpointConfig: () => EndpointConfig }} */
+  /** @type {IPFSHTTPClient} */
   const client = {
     add: require('./add')(options),
     addAll: require('./add-all')(options),

--- a/packages/ipfs-http-client/src/types.d.ts
+++ b/packages/ipfs-http-client/src/types.d.ts
@@ -2,6 +2,7 @@ import { Agent as HttpAgent } from 'http'
 import { Agent as HttpsAgent } from 'https'
 import { Multiaddr } from 'multiaddr'
 import type { BlockCodec } from 'multiformats/codecs/interface'
+import type { IPFS } from 'ipfs-core-types'
 
 export interface Options {
   host?: string
@@ -39,4 +40,8 @@ export interface EndpointConfig {
   protocol: string
   pathname: string
   'api-path': string
+}
+
+export interface IPFSHTTPClient extends IPFS<HTTPClientExtraOptions> {
+  getEndpointConfig: () => EndpointConfig
 }


### PR DESCRIPTION
Bubbles the `OptionExtension` up to the root type for use by the HTTP client and exports an interface for use by consuming modules.

Supersedes #3749 and #3736