### PR TITLE
fix: flaky timeout test

### DIFF
--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -65,7 +65,7 @@ module.exports = (common, options) => {
     })
 
     it('should respect timeout option when getting a DAG node', () => {
-      return testTimeout(() => ipfs.dag.get(CID.parse('QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ'), {
+      return testTimeout(() => ipfs.dag.get(CID.parse('QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAd'), {
         timeout: 1
       }))
     })

--- a/packages/ipfs-message-port-client/test/util/worker.js
+++ b/packages/ipfs-message-port-client/test/util/worker.js
@@ -4,7 +4,7 @@ const IPFS = require('ipfs-core')
 const { IPFSService, Server } = require('ipfs-message-port-server')
 
 const main = async connections => {
-  const ipfs = await IPFS.create({ offline: true, start: false })
+  const ipfs = await IPFS.create()
   const service = new IPFSService(ipfs)
   const server = new Server(service)
 


### PR DESCRIPTION
If we run a node in offline mode only, it'll never go to the network to fetch a CID it doesn't have, so we can't really test timeouts properly.