### PR TITLE
chore: restore git and eth graph traversal examples

### DIFF
--- a/examples/traverse-ipld-graphs/README.md
+++ b/examples/traverse-ipld-graphs/README.md
@@ -50,6 +50,13 @@ See [ipld/interface-ipld-format](https://github.com/ipld/interface-ipld-format) 
 
 ## [resolve through graphs of different kind](./get-path-accross-formats.js)
 
+## [traverse through a slice of the ethereum blockchain](./eth.js)
+
+## [traverse through a git repo](./git.js)
+The example objects contained in "git-objects" have already been decompressed with zlib.  An example of how to do this:
+
+    $ cat .git/objects/7d/df25817f57c2090a9568cdb17106a76dad7d04 | zlib-flate -uncompress > 7ddf25817f57c2090a9568cdb17106a76dad7d04
+
 ## Video of the demos
 
 Find a video with a walkthrough of this examples on Youtube:

--- a/examples/traverse-ipld-graphs/eth.js
+++ b/examples/traverse-ipld-graphs/eth.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const createNode = require('./create-node')
+const path = require('path')
+const { CID } = require('multiformats/cid')
+const MultihashDigest = require('multiformats/hashes/digest')
+const fs = require('fs').promises
+const uint8ArrayToString = require('uint8arrays/to-string')
+const { convert } = require('ipld-format-to-blockcodec')
+const sha3 = require('js-sha3')
+
+async function main () {
+  const ipfs = await createNode({
+    ipld: {
+      codecs: [
+        ...Object.values(require('ipld-ethereum')).map(format => convert(format))
+      ],
+      hashers: [{
+        name: 'keccak-256',
+        code: 0x1b,
+        digest: async (buf) => {
+          return MultihashDigest.create(
+            0x1b,
+            new Uint8Array(sha3.keccak256.arrayBuffer(buf))
+          )
+        }
+      }]
+    }
+  })
+
+  console.log('\nStart of the example:')
+
+  const ethBlocks = [
+    path.join(__dirname, '/eth-blocks/block_302516'),
+    path.join(__dirname, '/eth-blocks/block_302517')
+  ]
+
+  for (const ethBlockPath of ethBlocks) {
+    const data = await fs.readFile(ethBlockPath)
+
+    const cid = await ipfs.block.put(data, {
+      format: 'eth-block',
+      mhtype: 'keccak-256',
+      version: 1
+    })
+
+    console.log(cid.toString())
+  }
+
+  const block302516 = CID.parse('z43AaGEywSDX5PUJcrn5GfZmb6FjisJyR7uahhWPk456f7k7LDA')
+  const block302517 = CID.parse('z43AaGF42R2DXsU65bNnHRCypLPr9sg6D7CUws5raiqATVaB1jj')
+  let res
+
+  res = await ipfs.dag.get(block302516, { path: 'number' })
+  console.log(uint8ArrayToString(res.value, 'base16'))
+
+  res = await ipfs.dag.get(block302517, { path: 'parent/number' })
+  console.log(uint8ArrayToString(res.value, 'base16'))
+
+  await ipfs.stop()
+}
+
+main()
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/examples/traverse-ipld-graphs/git.js
+++ b/examples/traverse-ipld-graphs/git.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const createNode = require('./create-node')
+const path = require('path')
+const { CID } = require('multiformats/cid')
+const MultihashDigest = require('multiformats/hashes/digest')
+const fs = require('fs').promises
+const uint8ArrayToString = require('uint8arrays/to-string')
+const { convert } = require('ipld-format-to-blockcodec')
+const crypto = require('crypto')
+
+async function main () {
+  const ipfs = await createNode({
+    ipld: {
+      codecs: [
+        convert(require('ipld-git'))
+      ],
+      hashers: [{
+        name: 'sha1',
+        code: 0x11,
+        digest: async (buf) => {
+          return MultihashDigest.create(0x11, crypto.createHash('sha1').update(buf).digest())
+        }
+      }]
+    }
+  })
+
+  console.log('\nStart of the example:')
+
+  const gitObjects = [
+    path.join(__dirname, '/git-objects/0f328c91df28c5c01b9e9f9f7e663191fa156593'),
+    path.join(__dirname, '/git-objects/177bf18bc707d82b21cdefd0b43b38fc8c5c13fe'),
+    path.join(__dirname, '/git-objects/23cc25f631cb076d5de5036c87678ea713cbaa6a'),
+    path.join(__dirname, '/git-objects/4e425dba7745a781f0712c9a01455899e8c0c249'),
+    path.join(__dirname, '/git-objects/6850c7be7136e6be00976ddbae80671b945c3e9d'),
+    path.join(__dirname, '/git-objects/a5095353cd62a178663dd26efc2d61f4f61bccbe'),
+    path.join(__dirname, '/git-objects/dc9bd15e8b81b6565d3736f9c308bd1bba60f33a'),
+    path.join(__dirname, '/git-objects/e68e6f6e31857877a79fd6b3956898436bb5a76f'),
+    path.join(__dirname, '/git-objects/ee62b3d206cb23f939208898f32d8708c0e3fa3c'),
+    path.join(__dirname, '/git-objects/ee71cef5001b84b0314438f76cf0acd338a2fd21')
+  ]
+
+  await Promise.all(gitObjects.map(async gitObjectsPath => {
+    const data = await fs.readFile(gitObjectsPath)
+
+    const cid = await ipfs.block.put(data, {
+      format: 'git-raw',
+      mhtype: 'sha1',
+      version: 1
+    })
+
+    console.log(cid.toString())
+  }))
+
+  const v1tag = CID.parse('z8mWaGfwSWLMPJ6Q2JdsAjGiXTf61Nbue')
+
+  async function logResult (fn, comment) {
+    const result = await fn()
+
+    if (result.value instanceof Uint8Array) { // Blobs (files) are returned as buffer instance
+      result.value = uint8ArrayToString(result.value)
+    }
+
+    console.log('-'.repeat(80))
+    console.log(comment)
+    console.log(result.value)
+  }
+
+  await logResult(() => ipfs.dag.get(v1tag), 'Tag object:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/message' }), 'Tagged commit message:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/parents/0/message' }), 'Parent of tagged commit:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/tree/src/hash/hello/hash' }), '/src/hello file:')
+  await logResult(() => ipfs.dag.get(v1tag, { path: '/object/parents/0/tree/src/hash/hello/hash' }), 'previous version of /src/hello file:')
+
+  await ipfs.stop()
+}
+
+main()
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/examples/traverse-ipld-graphs/package.json
+++ b/examples/traverse-ipld-graphs/package.json
@@ -13,10 +13,10 @@
     "test-ipfs-example": "^3.0.0"
   },
   "dependencies": {
-    "@ipld/dag-pb": "^2.1.3",
     "ipfs": "^0.56.0",
-    "ipld-git": "^0.6.1",
     "ipld-ethereum": "^6.0.0",
-    "multiformats": "^9.4.1"
+    "ipld-format-to-blockcodec": "0.0.1",
+    "ipld-git": "^0.6.1",
+    "js-sha3": "^0.8.0"
   }
 }

--- a/examples/traverse-ipld-graphs/test.js
+++ b/examples/traverse-ipld-graphs/test.js
@@ -18,6 +18,12 @@ async function runTest () {
   console.info('Testing get-path-accross-formats.js')
   await waitForOutput('capoeira', path.resolve(__dirname, 'get-path-accross-formats.js'))
 
+  console.info('Testing eth.js')
+  await waitForOutput('302516', path.resolve(__dirname, 'eth.js'))
+
+  console.info('Testing git.js')
+  await waitForOutput("CID(baf4bcfhoohhpkaa3qsydcrby65wpblgthcrp2ii)", path.resolve(__dirname, 'git.js'))
+
   console.info('Done!')
 }
 


### PR DESCRIPTION
These were removed during the multiformats upgrade but they are quite useful as a demo of how to configure extra multiformat blockcodecs/hashers