### PR TITLE
fix: typo in 'multiformats' type defs

### DIFF
--- a/packages/ipfs-core-types/src/bitswap/index.d.ts
+++ b/packages/ipfs-core-types/src/bitswap/index.d.ts
@@ -1,4 +1,4 @@
-import type { CID } from 'multiformts/cid'
+import type { CID } from 'multiformats/cid'
 import type { AbortOptions } from '../utils'
 
 export interface API<OptionExtension = {}> {

--- a/packages/ipfs-core-types/src/block/index.d.ts
+++ b/packages/ipfs-core-types/src/block/index.d.ts
@@ -1,4 +1,4 @@
-import { AbortOptions, PreloadOptions, IPFSPath } from '../utils'
+import { AbortOptions, PreloadOptions } from '../utils'
 import { CID, CIDVersion } from 'multiformats/cid'
 
 export interface API<OptionExtension = {}> {

--- a/packages/ipfs-core-types/src/block/index.d.ts
+++ b/packages/ipfs-core-types/src/block/index.d.ts
@@ -78,7 +78,7 @@ export interface API<OptionExtension = {}> {
    * // Logs: 3739
    * ```
    */
-  stat: (ipfsPath: IPFSPath, options?: AbortOptions & PreloadOptions & OptionExtension) => Promise<StatResult>
+  stat: (cid: CID, options?: AbortOptions & PreloadOptions & OptionExtension) => Promise<StatResult>
 }
 
 export interface PutOptions extends AbortOptions, PreloadOptions {

--- a/packages/ipfs-core-types/src/dht/index.d.ts
+++ b/packages/ipfs-core-types/src/dht/index.d.ts
@@ -1,6 +1,6 @@
 import type { AbortOptions } from '../utils'
 import type { Multiaddr } from 'multiaddr'
-import type { CID } from 'multiformts/cid'
+import type { CID } from 'multiformats/cid'
 
 export interface API<OptionExtension = {}> {
   /**

--- a/packages/ipfs-core-types/src/name/index.d.ts
+++ b/packages/ipfs-core-types/src/name/index.d.ts
@@ -1,4 +1,4 @@
-import { CID } from 'multiformts/cid'
+import { CID } from 'multiformats/cid'
 import type { AbortOptions } from '../utils'
 import type { API as PubsubAPI } from './pubsub'
 

--- a/packages/ipfs-core-types/src/object/index.d.ts
+++ b/packages/ipfs-core-types/src/object/index.d.ts
@@ -1,4 +1,4 @@
-import type { CID } from 'multiformts/cid'
+import type { CID } from 'multiformats/cid'
 import type { AbortOptions, PreloadOptions } from '../utils'
 import type { API as PatchAPI } from './patch'
 import type { PBNode, PBLink } from '@ipld/dag-pb'

--- a/packages/ipfs-core-types/src/object/patch/index.d.ts
+++ b/packages/ipfs-core-types/src/object/patch/index.d.ts
@@ -1,4 +1,4 @@
-import type { CID } from 'multiformts/cid'
+import type { CID } from 'multiformats/cid'
 import type { AbortOptions } from '../../utils'
 import type { PBLink as DAGLink } from '@ipld/dag-pb'
 

--- a/packages/ipfs-core-types/src/pin/index.d.ts
+++ b/packages/ipfs-core-types/src/pin/index.d.ts
@@ -1,5 +1,5 @@
 import type { AbortOptions, AwaitIterable } from '../utils'
-import type { CID } from 'multiformts/cid'
+import type { CID } from 'multiformats/cid'
 import type { API as Remote } from './remote'
 
 export interface API<OptionExtension = {}> {

--- a/packages/ipfs-core-types/src/pin/remote/index.d.ts
+++ b/packages/ipfs-core-types/src/pin/remote/index.d.ts
@@ -1,4 +1,4 @@
-import { CID } from 'multiformts/cid'
+import { CID } from 'multiformats/cid'
 import { Multiaddr } from 'multiaddr'
 import { API as Service } from './service'
 import { AbortOptions } from '../../utils'

--- a/packages/ipfs-core-types/src/repo/index.d.ts
+++ b/packages/ipfs-core-types/src/repo/index.d.ts
@@ -1,5 +1,5 @@
 import type { AbortOptions } from '../utils'
-import { CID } from 'multiformts/cid'
+import { CID } from 'multiformats/cid'
 
 export interface API<OptionExtension = {}> {
   /**

--- a/packages/ipfs-core-types/src/utils.d.ts
+++ b/packages/ipfs-core-types/src/utils.d.ts
@@ -1,4 +1,4 @@
-import { CID } from 'multiformts/cid'
+import { CID } from 'multiformats/cid'
 import { Mtime, MtimeLike } from 'ipfs-unixfs'
 
 export type Entry<Content extends AsyncIterable<Uint8Array>|Blob> =

--- a/packages/ipfs-core/src/components/dht.js
+++ b/packages/ipfs-core/src/components/dht.js
@@ -65,18 +65,7 @@ module.exports = ({ network, repo }) => {
      */
     async * provide (cids, options = { recursive: false }) {
       const { libp2p } = await use(network, options)
-      /** @type {CID[]} */
       const cidArr = Array.isArray(cids) ? cids : [cids]
-
-      for (const i in cids) {
-        if (typeof cids[i] === 'string') {
-          try {
-            cids[i] = CID.parse(cids[i])
-          } catch (err) {
-            throw errCode(err, 'ERR_INVALID_CID')
-          }
-        }
-      }
 
       // ensure blocks are actually local
       const hasCids = await Promise.all(cidArr.map(cid => repo.blocks.has(cid)))
@@ -91,7 +80,7 @@ module.exports = ({ network, repo }) => {
         throw errCode(new Error('not implemented yet'), 'ERR_NOT_IMPLEMENTED_YET')
       }
 
-      for (const cid of cids) {
+      for (const cid of cidArr) {
         yield libp2p._dht.provide(cid)
       }
     },

--- a/packages/ipfs-http-server/src/api/resources/object.js
+++ b/packages/ipfs-http-server/src/api/resources/object.js
@@ -399,9 +399,10 @@ exports.stat = {
 
     const base = await ipfs.bases.getBase(cidBase)
 
-    stats.Hash = stats.Hash.toString(base.encoder)
-
-    return h.response(stats)
+    return h.response({
+      ...stats,
+      Hash: stats.Hash.toString(base.encoder)
+    })
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/ipfs/js-ipfs/issues/3776

It'd be nice to have some kind of tests that caught this, but that might mean adding typescript examples that use this which is probably a fair bit of work. @achingbrain thoughts?