### PR TITLE
fix: restore default level-js options

### DIFF
--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -64,7 +64,7 @@
     "blockstore-datastore-adapter": "1.0.0",
     "datastore-core": "^5.0.1",
     "datastore-fs": "^5.0.2",
-    "datastore-level": "^6.0.1",
+    "datastore-level": "^6.0.2",
     "datastore-pubsub": "^0.7.0",
     "debug": "^4.1.1",
     "dlv": "^1.1.3",

--- a/packages/ipfs-core/src/runtime/repo-browser.js
+++ b/packages/ipfs-core/src/runtime/repo-browser.js
@@ -21,29 +21,24 @@ module.exports = (print, codecs, options) => {
 
   return createRepo(repoPath, (codeOrName) => codecs.getCodec(codeOrName), {
     root: new DatastoreLevel(repoPath, {
-      extension: '',
       prefix: '',
       version: 2
     }),
     blocks: new BlockstoreDatastoreAdapter(
       new DatastoreLevel(`${repoPath}/blocks`, {
-        extension: '',
         prefix: '',
         version: 2
       })
     ),
     datastore: new DatastoreLevel(`${repoPath}/datastore`, {
-      extension: '',
       prefix: '',
       version: 2
     }),
     keys: new DatastoreLevel(`${repoPath}/keys`, {
-      extension: '',
       prefix: '',
       version: 2
     }),
     pins: new DatastoreLevel(`${repoPath}/pins`, {
-      extension: '',
       prefix: '',
       version: 2
     })

--- a/packages/ipfs-core/src/runtime/repo-browser.js
+++ b/packages/ipfs-core/src/runtime/repo-browser.js
@@ -20,13 +20,33 @@ module.exports = (print, codecs, options) => {
   const repoPath = options.path || 'ipfs'
 
   return createRepo(repoPath, (codeOrName) => codecs.getCodec(codeOrName), {
-    root: new DatastoreLevel(repoPath),
+    root: new DatastoreLevel(repoPath, {
+      extension: '',
+      prefix: '',
+      version: 2
+    }),
     blocks: new BlockstoreDatastoreAdapter(
-      new DatastoreLevel(`${repoPath}/blocks`)
+      new DatastoreLevel(`${repoPath}/blocks`, {
+        extension: '',
+        prefix: '',
+        version: 2
+      })
     ),
-    datastore: new DatastoreLevel(`${repoPath}/datastore`),
-    keys: new DatastoreLevel(`${repoPath}/keys`),
-    pins: new DatastoreLevel(`${repoPath}/pins`)
+    datastore: new DatastoreLevel(`${repoPath}/datastore`, {
+      extension: '',
+      prefix: '',
+      version: 2
+    }),
+    keys: new DatastoreLevel(`${repoPath}/keys`, {
+      extension: '',
+      prefix: '',
+      version: 2
+    }),
+    pins: new DatastoreLevel(`${repoPath}/pins`, {
+      extension: '',
+      prefix: '',
+      version: 2
+    })
   }, {
     autoMigrate: options.autoMigrate,
     onMigrationProgress: options.onMigrationProgress || print


### PR DESCRIPTION
Restores level-js options from https://github.com/ipfs/js-ipfs-repo/blob/b82938fcef0f949517fbd6f63700c2c0178ef117/src/default-options-browser.js

The ones that are valid anyway.