### PR TITLE
fix: return rate in/out as number

### DIFF
--- a/docs/core-api/STATS.md
+++ b/docs/core-api/STATS.md
@@ -62,8 +62,8 @@ for await (const stats of ipfs.stats.bw()) {
 }
 // { totalIn: BigInt {...},
 //   totalOut: BigInt {...},
-//   rateIn: float {...},
-//   rateOut: float {...} }
+//   rateIn: number {...},
+//   rateOut: number {...} }
 ```
 
 A great source of [examples][] can be found in the tests for this API.

--- a/docs/core-api/STATS.md
+++ b/docs/core-api/STATS.md
@@ -51,8 +51,8 @@ Each yielded object contains the following keys:
 
 - `totalIn` - is a [BigInt][bigNumber], in bytes.
 - `totalOut` - is a [BigInt][bigNumber], in bytes.
-- `rateIn` - is a [BigInt][bigNumber], in bytes.
-- `rateOut` - is a [BigInt][bigNumber], in bytes.
+- `rateIn` - is a `float`, in bytes.
+- `rateOut` - is a `float`, in bytes.
 
 ### Example
 
@@ -62,8 +62,8 @@ for await (const stats of ipfs.stats.bw()) {
 }
 // { totalIn: BigInt {...},
 //   totalOut: BigInt {...},
-//   rateIn: BigInt {...},
-//   rateOut: BigInt {...} }
+//   rateIn: float {...},
+//   rateOut: float {...} }
 ```
 
 A great source of [examples][] can be found in the tests for this API.

--- a/packages/interface-ipfs-core/src/stats/utils.js
+++ b/packages/interface-ipfs-core/src/stats/utils.js
@@ -50,8 +50,8 @@ exports.expectIsBandwidth = (err, stats) => {
   expect(stats).to.have.a.property('rateOut')
   expect(isBigInt(stats.totalIn)).to.eql(true)
   expect(isBigInt(stats.totalOut)).to.eql(true)
-  expect(isBigInt(stats.rateIn)).to.eql(true)
-  expect(isBigInt(stats.rateOut)).to.eql(true)
+  expect(stats.rateIn).to.be.a('number')
+  expect(stats.rateOut).to.be.a('number')
 }
 
 /**

--- a/packages/ipfs-core-types/src/stats/index.d.ts
+++ b/packages/ipfs-core-types/src/stats/index.d.ts
@@ -22,6 +22,6 @@ export interface BWOptions extends AbortOptions {
 export interface BWResult {
   totalIn: bigint
   totalOut: bigint
-  rateIn: float
-  rateOut: float
+  rateIn: number
+  rateOut: number
 }

--- a/packages/ipfs-core-types/src/stats/index.d.ts
+++ b/packages/ipfs-core-types/src/stats/index.d.ts
@@ -22,6 +22,6 @@ export interface BWOptions extends AbortOptions {
 export interface BWResult {
   totalIn: bigint
   totalOut: bigint
-  rateIn: bigint
-  rateOut: bigint
+  rateIn: float
+  rateOut: float
 }

--- a/packages/ipfs-core/src/components/stats/bw.js
+++ b/packages/ipfs-core/src/components/stats/bw.js
@@ -45,8 +45,8 @@ function getBandwidthStats (libp2p, opts) {
     return {
       totalIn: BigInt(0),
       totalOut: BigInt(0),
-      rateIn: BigInt(0),
-      rateOut: BigInt(0)
+      rateIn: 0.0,
+      rateOut: 0.0
     }
   }
 
@@ -55,8 +55,8 @@ function getBandwidthStats (libp2p, opts) {
   return {
     totalIn: BigInt(snapshot.dataReceived.integerValue().toString()),
     totalOut: BigInt(snapshot.dataSent.integerValue().toString()),
-    rateIn: BigInt(Math.round(movingAverages.dataReceived[60000].movingAverage() / 60)),
-    rateOut: BigInt(Math.round(movingAverages.dataSent[60000].movingAverage() / 60))
+    rateIn: movingAverages.dataReceived[60000].movingAverage() / 60,
+    rateOut: movingAverages.dataSent[60000].movingAverage() / 60
   }
 }
 

--- a/packages/ipfs-core/src/components/stats/bw.js
+++ b/packages/ipfs-core/src/components/stats/bw.js
@@ -14,8 +14,8 @@ const withTimeoutOption = require('ipfs-core-utils/src/with-timeout-option')
  * @typedef {Object} BandwidthInfo
  * @property {bigint} totalIn
  * @property {bigint} totalOut
- * @property {bigint} rateIn
- * @property {bigint} rateOut
+ * @property {number} rateIn
+ * @property {number} rateOut
  *
  * @typedef {import('libp2p')} libp2p
  * @typedef {import('peer-id')} PeerId

--- a/packages/ipfs-http-client/src/stats/bw.js
+++ b/packages/ipfs-http-client/src/stats/bw.js
@@ -21,8 +21,8 @@ module.exports = configure(api => {
       transform: (stats) => ({
         totalIn: BigInt(stats.TotalIn),
         totalOut: BigInt(stats.TotalOut),
-        rateIn: BigInt(stats.RateIn),
-        rateOut: BigInt(stats.RateOut)
+        rateIn: parseFloat(stats.RateIn),
+        rateOut: parseFloat(stats.RateOut)
       })
     })
 

--- a/packages/ipfs-http-server/src/api/resources/stats.js
+++ b/packages/ipfs-http-server/src/api/resources/stats.js
@@ -61,8 +61,8 @@ exports.bw = {
         yield * map(source, stat => ({
           TotalIn: stat.totalIn.toString(),
           TotalOut: stat.totalOut.toString(),
-          RateIn: stat.rateIn.toString(),
-          RateOut: stat.rateOut.toString()
+          RateIn: stat.rateIn,
+          RateOut: stat.rateOut
         }))
       }
     ))


### PR DESCRIPTION
The return type for `rateIn`/`rateOut` should be a number and not an integer.

go-IPFS returns a `float64` which isn't representable in js, but we are not interested in that level of accuracy for this value so just return it as a regular `number` which can be a `float`.

Fixes #3782

BREAKING CHANGE: rateIn/rateOut are returned as numbers