### PR TITLE
chore: revert "chore(deps-dev): bump go-ipfs from 0.8.0 to 0.9.1"

### DIFF
--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -132,7 +132,7 @@
     "@types/rimraf": "^3.0.1",
     "aegir": "^34.0.2",
     "delay": "^5.0.0",
-    "go-ipfs": "0.9.1",
+    "go-ipfs": "0.8.0",
     "interface-blockstore-tests": "^1.0.0",
     "interface-ipfs-core": "^0.148.0",
     "ipfsd-ctl": "^10.0.3",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "aegir": "^34.0.2",
     "delay": "^5.0.0",
-    "go-ipfs": "0.9.1",
+    "go-ipfs": "0.8.0",
     "ipfsd-ctl": "^10.0.3",
     "it-all": "^1.0.4",
     "it-first": "^1.0.4",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -51,7 +51,7 @@
     "assert": "^2.0.0",
     "cross-env": "^7.0.0",
     "electron-webrtc": "^0.3.0",
-    "go-ipfs": "0.9.1",
+    "go-ipfs": "0.8.0",
     "interface-ipfs-core": "^0.148.0",
     "ipfs-client": "^0.5.1",
     "ipfs-core-types": "^0.6.1",


### PR DESCRIPTION
Reverts ipfs/js-ipfs#3765 - for some reason Travis CI didn't run on that PR and the build is failing.