### PR TITLE
fix: detect ed25519 keys in ws test

### DIFF
--- a/examples/browser-exchange-files/test.js
+++ b/examples/browser-exchange-files/test.js
@@ -68,7 +68,7 @@ async function runTest () {
     const id = await relay.api.id()
     const address = id.addresses
       .map(ma => ma.toString())
-      .find(addr => addr.includes('/ws/p2p'))
+      .find(addr => addr.includes('/ws/p2p/'))
 
     if (!address) {
       throw new Error(`Could not find web socket address in ${id.addresses}`)

--- a/examples/circuit-relaying/test.js
+++ b/examples/circuit-relaying/test.js
@@ -63,7 +63,7 @@ async function runTest () {
     const id = await relay.api.id()
     const address = id.addresses
       .map(ma => ma.toString())
-      .find(addr => addr.includes('/ws/p2p/Qm'))
+      .find(addr => addr.includes('/ws/p2p/'))
 
     if (!address) {
       throw new Error(`Could not find web socket address in ${id.addresses}`)


### PR DESCRIPTION
Relax test to just look for `/ws/p2p/` string