### PR TITLE
fix: throw error on missing input to add/addAll

### DIFF
--- a/packages/interface-ipfs-core/src/add.js
+++ b/packages/interface-ipfs-core/src/add.js
@@ -233,6 +233,16 @@ module.exports = (factory, options) => {
       await expect(ipfs.add(nonValid)).to.eventually.be.rejected()
     })
 
+    it('should fail when passed undefined input', async () => {
+      // @ts-expect-error undefined is non valid
+      await expect(ipfs.add(undefined)).to.eventually.be.rejected()
+    })
+
+    it('should fail when passed null input', async () => {
+      // @ts-expect-error null is non valid
+      await expect(ipfs.add(null)).to.eventually.be.rejected()
+    })
+
     it('should wrap content in a directory', async () => {
       const data = { path: 'testfile.txt', content: fixtures.smallFile.data }
 

--- a/packages/interface-ipfs-core/src/pubsub/publish.js
+++ b/packages/interface-ipfs-core/src/pubsub/publish.js
@@ -32,8 +32,8 @@ module.exports = (factory, options) => {
 
     it('should fail with undefined msg', async () => {
       const topic = getTopic()
-      // @ts-ignore invalid parameter
-      await expect(ipfs.pubsub.publish(topic)).to.eventually.rejectedWith('argument "data" is required')
+      // @ts-expect-error invalid parameter
+      await expect(ipfs.pubsub.publish(topic)).to.eventually.be.rejected()
     })
 
     it('should publish message from buffer', () => {

--- a/packages/ipfs-core-utils/src/files/normalise-input/normalise-input.js
+++ b/packages/ipfs-core-utils/src/files/normalise-input/normalise-input.js
@@ -28,7 +28,7 @@ const {
 // eslint-disable-next-line complexity
 module.exports = async function * normaliseInput (input, normaliseContent) {
   if (input === null || input === undefined) {
-    return
+    throw errCode(new Error(`Unexpected input: ${input}`), 'ERR_UNEXPECTED_INPUT')
   }
 
   // String


### PR DESCRIPTION
Throws an error with a more descriptive error message.

The error messages over http are not descriptive due to https://github.com/node-fetch/node-fetch/issues/753

Fixes #3788