### PR TITLE
fix: use correct datastores

### DIFF
--- a/packages/ipfs-core/src/components/files/utils/update-mfs-root.js
+++ b/packages/ipfs-core/src/components/files/utils/update-mfs-root.js
@@ -22,7 +22,7 @@ const updateMfsRoot = async (context, cid, options) => {
 
   log(`New MFS root will be ${cid}`)
 
-  await context.repo.datastore.put(MFS_ROOT_KEY, cid.bytes)
+  await context.repo.root.put(MFS_ROOT_KEY, cid.bytes)
 
   return cid
 }

--- a/packages/ipfs-core/src/components/files/utils/with-mfs-root.js
+++ b/packages/ipfs-core/src/components/files/utils/with-mfs-root.js
@@ -25,13 +25,13 @@ const loadMfsRoot = async (context, options) => {
   }
 
   // Open the repo if it's been closed
-  await context.repo.datastore.open()
+  await context.repo.root.open()
 
   // Load the MFS root CID
   let cid
 
   try {
-    const buf = await context.repo.datastore.get(MFS_ROOT_KEY)
+    const buf = await context.repo.root.get(MFS_ROOT_KEY)
 
     cid = CID.decode(buf)
   } catch (err) {
@@ -52,7 +52,7 @@ const loadMfsRoot = async (context, options) => {
       throw errCode(new Error('Request aborted'), 'ERR_ABORTED', { name: 'Aborted' })
     }
 
-    await context.repo.datastore.put(MFS_ROOT_KEY, cid.bytes)
+    await context.repo.root.put(MFS_ROOT_KEY, cid.bytes)
   }
 
   log(`Loaded MFS root /ipfs/${cid}`)

--- a/packages/ipfs-core/src/runtime/repo-nodejs.js
+++ b/packages/ipfs-core/src/runtime/repo-nodejs.js
@@ -53,7 +53,7 @@ module.exports = (print, codecs, options = {}) => {
       )
     ),
     datastore: new DatastoreLevel(`${repoPath}/datastore`),
-    keys: new DatastoreLevel(`${repoPath}/keys`),
+    keys: new DatastoreFS(`${repoPath}/keys`),
     pins: new DatastoreLevel(`${repoPath}/pins`)
   }, {
     autoMigrate: options.autoMigrate != null ? options.autoMigrate : true,


### PR DESCRIPTION
- keys is a fs datastore
- mfs uses the root datastore though it should really use the datastore datastore
  - will need a repo migration to fix this