### PR TITLE
fix: override node-fetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "lerna": "^3.22.0",
+    "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2"
   },


### PR DESCRIPTION
We need the fix from https://github.com/node-fetch/node-fetch/pull/1172
in node-fetch otherwise we can't detect when the other end of a streaming
response closes the connection.

At the moment we're using a fork of node-fetch with this patch applied
but the npm7 depdending hoisting algorithm hoists the wrong version so
here we add a dep to the root package.json to ensure we get the right
one.

This should only affect development and not published versions.  We can
revert this and switch to undici when node 16 becomes lts at the end
of October.