### PR TITLE
fix: error types

### DIFF
--- a/packages/interface-ipfs-core/src/dht/query.js
+++ b/packages/interface-ipfs-core/src/dht/query.js
@@ -53,7 +53,7 @@ module.exports = (factory, options) => {
         const peers = await all(nodeA.dht.query(nodeBId.id, { timeout: timeout - 1000 }))
         expect(peers.map(p => p.id.toString())).to.include(nodeBId.id)
       } catch (err) {
-        if (err.name === 'TimeoutError') {
+        if (err instanceof Error && err.name === 'TimeoutError') {
           // This test is meh. DHT works best with >= 20 nodes. Therefore a
           // failure might happen, but we don't want to report it as such.
           // Hence skip the test before the timeout is reached

--- a/packages/interface-ipfs-core/src/files/cp.js
+++ b/packages/interface-ipfs-core/src/files/cp.js
@@ -109,7 +109,7 @@ module.exports = (factory, options) => {
         await ipfs.files.cp(source, destination)
         throw new Error('No error was thrown when trying to overwrite a file')
       } catch (err) {
-        expect(err.message).to.contain('directory already has entry by that name')
+        expect(err).to.have.property('message').that.contains('directory already has entry by that name')
       }
     })
 
@@ -124,7 +124,7 @@ module.exports = (factory, options) => {
         await ipfs.files.cp(source, source)
         throw new Error('No error was thrown for a non-existent file')
       } catch (err) {
-        expect(err.message).to.contain('directory already has entry by that name')
+        expect(err).to.have.property('message').that.contains('directory already has entry by that name')
       }
     })
 

--- a/packages/interface-ipfs-core/src/files/mv.js
+++ b/packages/interface-ipfs-core/src/files/mv.js
@@ -77,7 +77,7 @@ module.exports = (factory, options) => {
         await ipfs.files.stat(source)
         throw new Error('Directory was copied but not removed')
       } catch (err) {
-        expect(err.message).to.contain('does not exist')
+        expect(err).to.have.property('message').that.contains('does not exist')
       }
     })
 
@@ -104,7 +104,7 @@ module.exports = (factory, options) => {
         await ipfs.files.stat(source)
         throw new Error('Directory was copied but not removed')
       } catch (err) {
-        expect(err.message).to.contain('does not exist')
+        expect(err).to.have.property('message').that.contains('does not exist')
       }
     })
 
@@ -145,8 +145,8 @@ module.exports = (factory, options) => {
         try {
           await ipfs.files.stat(shardedDirPath)
           throw new Error('Dir was not removed')
-        } catch (error) {
-          expect(error.message).to.contain('does not exist')
+        } catch (err) {
+          expect(err).to.have.property('message').that.contains('does not exist')
         }
       })
 
@@ -165,8 +165,8 @@ module.exports = (factory, options) => {
         try {
           await ipfs.files.stat(dirPath)
           throw new Error('Dir was not removed')
-        } catch (error) {
-          expect(error.message).to.contain('does not exist')
+        } catch (err) {
+          expect(err).to.have.property('message').that.contains('does not exist')
         }
       })
 
@@ -185,8 +185,8 @@ module.exports = (factory, options) => {
         try {
           await ipfs.files.stat(otherShardedDirPath)
           throw new Error('Sharded dir was not removed')
-        } catch (error) {
-          expect(error.message).to.contain('does not exist')
+        } catch (err) {
+          expect(err).to.have.property('message').that.contains('does not exist')
         }
       })
 
@@ -211,8 +211,8 @@ module.exports = (factory, options) => {
         try {
           await ipfs.files.stat(filePath)
           throw new Error('File was not removed')
-        } catch (error) {
-          expect(error.message).to.contain('does not exist')
+        } catch (err) {
+          expect(err).to.have.property('message').that.contains('does not exist')
         }
       })
 
@@ -238,8 +238,8 @@ module.exports = (factory, options) => {
         try {
           await ipfs.files.stat(filePath)
           throw new Error('File was not removed')
-        } catch (error) {
-          expect(error.message).to.contain('does not exist')
+        } catch (err) {
+          expect(err).to.have.property('message').that.contains('does not exist')
         }
       })
 
@@ -265,8 +265,8 @@ module.exports = (factory, options) => {
         try {
           await ipfs.files.stat(filePath)
           throw new Error('File was not removed')
-        } catch (error) {
-          expect(error.message).to.contain('does not exist')
+        } catch (err) {
+          expect(err).to.have.property('message').that.contains('does not exist')
         }
       })
 
@@ -292,8 +292,8 @@ module.exports = (factory, options) => {
         try {
           await ipfs.files.stat(filePath)
           throw new Error('File was not removed')
-        } catch (error) {
-          expect(error.message).to.contain('does not exist')
+        } catch (err) {
+          expect(err).to.have.property('message').that.contains('does not exist')
         }
       })
     })

--- a/packages/interface-ipfs-core/src/files/write.js
+++ b/packages/interface-ipfs-core/src/files/write.js
@@ -257,7 +257,7 @@ module.exports = (factory, options) => {
         })
         throw new Error('Writing a file to a non-existent folder without the --parents flag should have failed')
       } catch (err) {
-        expect(err.message).to.contain('does not exist')
+        expect(err).to.have.property('message').that.contains('does not exist')
       }
     })
 
@@ -268,7 +268,7 @@ module.exports = (factory, options) => {
         await ipfs.files.write(filePath, smallFile)
         throw new Error('Writing a file to a non-existent file without the --create flag should have failed')
       } catch (err) {
-        expect(err.message).to.contain('file does not exist')
+        expect(err).to.have.property('message').that.contains('file does not exist')
       }
     })
 
@@ -286,7 +286,7 @@ module.exports = (factory, options) => {
 
         throw new Error('Writing a path with a file in it should have failed')
       } catch (err) {
-        expect(err.message).to.contain('Not a directory')
+        expect(err).to.have.property('message').that.contains('Not a directory')
       }
     })
 

--- a/packages/interface-ipfs-core/src/key/gen.js
+++ b/packages/interface-ipfs-core/src/key/gen.js
@@ -59,7 +59,8 @@ module.exports = (factory, options) => {
 
           expect(imported).to.be.an.instanceOf(kt.expectedType)
         } catch (err) {
-          if (err.code === 'ERR_NOT_IMPLEMENTED') {
+          // @ts-expect-error code is not a property of error
+          if (err instanceof Error && err.code === 'ERR_NOT_IMPLEMENTED') {
             // key export is not exposed over the HTTP API
             // @ts-ignore this is mocha
             this.skip('Cannot verify key type')

--- a/packages/interface-ipfs-core/src/miscellaneous/dns.js
+++ b/packages/interface-ipfs-core/src/miscellaneous/dns.js
@@ -35,7 +35,7 @@ module.exports = (factory, options) => {
         // matches pattern /ipns/<ipnsaddress>
         expect(res).to.match(/\/ipns\/.+$/)
       } catch (err) {
-        if (err.message.includes('could not resolve name')) {
+        if (err instanceof Error && err.message.includes('could not resolve name')) {
           // @ts-ignore this is mocha
           return this.skip()
         }
@@ -51,7 +51,7 @@ module.exports = (factory, options) => {
         // matches pattern /ipfs/<hash>
         expect(res).to.match(/\/ipfs\/.+$/)
       } catch (err) {
-        if (err.message.includes('could not resolve name')) {
+        if (err instanceof Error && err.message.includes('could not resolve name')) {
           // @ts-ignore this is mocha
           return this.skip()
         }
@@ -67,7 +67,7 @@ module.exports = (factory, options) => {
         // matches pattern /ipfs/<hash>
         expect(res).to.match(/\/ipfs\/.+$/)
       } catch (err) {
-        if (err.message.includes('could not resolve name')) {
+        if (err instanceof Error && err.message.includes('could not resolve name')) {
           // @ts-ignore this is mocha
           return this.skip()
         }

--- a/packages/ipfs-message-port-protocol/src/core.js
+++ b/packages/ipfs-message-port-protocol/src/core.js
@@ -124,7 +124,7 @@ const encodeIterable = (iterable, encode, transfer) => {
               itemTransfer
             )
           }
-        } catch (error) {
+        } catch (/** @type {Error} */ error) {
           port.postMessage({
             type: 'throw',
             error: encodeError(error)

--- a/packages/ipfs-message-port-protocol/src/core.js
+++ b/packages/ipfs-message-port-protocol/src/core.js
@@ -127,8 +127,7 @@ const encodeIterable = (iterable, encode, transfer) => {
         } catch (error) {
           port.postMessage({
             type: 'throw',
-            // @ts-ignore ts thinks error is type 'unknown'?
-            error: encodeError(error)
+            error: encodeError(error instanceof Error ? error : new Error(`${error}`))
           })
           port.close()
         }

--- a/packages/ipfs-message-port-protocol/src/core.js
+++ b/packages/ipfs-message-port-protocol/src/core.js
@@ -124,9 +124,10 @@ const encodeIterable = (iterable, encode, transfer) => {
               itemTransfer
             )
           }
-        } catch (/** @type {Error} */ error) {
+        } catch (error) {
           port.postMessage({
             type: 'throw',
+            // @ts-ignore ts thinks error is type 'unknown'?
             error: encodeError(error)
           })
           port.close()


### PR DESCRIPTION
`typescript@4.4.x` changed the default type of `catch` variables from `any` to `unknown` so now we have to ensure that we are dealing with `Error` instances otherwise `tsc` flags it as an error.