### PR TITLE
fix: remove use of instanceof for CID class

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -45,7 +45,7 @@
     "@types/pako": "^1.0.2",
     "@types/readable-stream": "^2.3.11",
     "abort-controller": "^3.0.0",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "delay": "^5.0.0",
     "err-code": "^3.0.1",
     "interface-blockstore": "^1.0.0",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@types/progress": "^2.0.3",
     "@types/yargs": "^16.0.0",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "it-to-buffer": "^2.0.0",
     "nanoid": "^3.1.12",
     "ncp": "^2.0.0",

--- a/packages/ipfs-cli/src/utils.js
+++ b/packages/ipfs-cli/src/utils.js
@@ -338,8 +338,10 @@ const escapeControlCharacters = (str) => {
  * @returns {any}
  */
 const makeEntriesPrintable = (obj, cidBase) => {
-  if (obj instanceof CID) {
-    return { '/': obj.toString(cidBase.encoder) }
+  const cid = CID.asCID(obj)
+
+  if (cid) {
+    return { '/': cid.toString(cidBase.encoder) }
   }
 
   if (typeof obj === 'string') {

--- a/packages/ipfs-client/package.json
+++ b/packages/ipfs-client/package.json
@@ -37,7 +37,7 @@
     "merge-options": "^3.0.4"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/ipfs-core-types/package.json
+++ b/packages/ipfs-core-types/package.json
@@ -47,7 +47,7 @@
     "multiformats": "^9.4.1"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "rimraf": "^3.0.2"
   },
   "contributors": [

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@web-std/file": "^1.1.2",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/ipfs-core-utils/src/pins/normalise-input.js
+++ b/packages/ipfs-core-utils/src/pins/normalise-input.js
@@ -53,8 +53,10 @@ async function * normaliseInput (input) {
   }
 
   // CID
-  if (input instanceof CID) {
-    yield toPin({ cid: input })
+  const cid = CID.asCID(input)
+
+  if (cid) {
+    yield toPin({ cid })
     return
   }
 
@@ -78,7 +80,7 @@ async function * normaliseInput (input) {
     if (first.done) return iterator
 
     // Iterable<CID|String>
-    if (first.value instanceof CID || first.value instanceof String || typeof first.value === 'string') {
+    if (CID.asCID(first.value) || first.value instanceof String || typeof first.value === 'string') {
       yield toPin({ cid: first.value })
       for (const cid of iterator) {
         yield toPin({ cid })
@@ -106,7 +108,7 @@ async function * normaliseInput (input) {
     if (first.done) return iterator
 
     // AsyncIterable<CID|String>
-    if (first.value instanceof CID || first.value instanceof String || typeof first.value === 'string') {
+    if (CID.asCID(first.value) || first.value instanceof String || typeof first.value === 'string') {
       yield toPin({ cid: first.value })
       for await (const cid of iterator) {
         yield toPin({ cid })

--- a/packages/ipfs-core-utils/src/to-cid-and-path.js
+++ b/packages/ipfs-core-utils/src/to-cid-and-path.js
@@ -18,9 +18,11 @@ const toCidAndPath = (string) => {
     }
   }
 
-  if (string instanceof CID) {
+  let cid = CID.asCID(string)
+
+  if (cid) {
     return {
-      cid: string,
+      cid,
       path: undefined
     }
   }
@@ -30,7 +32,6 @@ const toCidAndPath = (string) => {
   }
 
   const parts = string.split('/')
-  let cid
   let path
 
   try {

--- a/packages/ipfs-core-utils/src/to-cid-and-path.js
+++ b/packages/ipfs-core-utils/src/to-cid-and-path.js
@@ -27,6 +27,8 @@ const toCidAndPath = (string) => {
     }
   }
 
+  string = string.toString()
+
   if (string.startsWith(IPFS_PREFIX)) {
     string = string.substring(IPFS_PREFIX.length)
   }

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -134,7 +134,7 @@
     "@types/dlv": "^1.1.2",
     "@types/pako": "^1.0.2",
     "@types/rimraf": "^3.0.1",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "delay": "^5.0.0",
     "go-ipfs": "0.9.1",
     "interface-blockstore-tests": "^1.0.0",

--- a/packages/ipfs-core/src/components/block/utils.js
+++ b/packages/ipfs-core/src/components/block/utils.js
@@ -1,23 +1,14 @@
 'use strict'
 
 const { CID } = require('multiformats/cid')
-const errCode = require('err-code')
 
 /**
  * @param {string|Uint8Array|CID} cid
  */
 exports.cleanCid = cid => {
-  if (cid instanceof CID) {
-    return cid
-  }
-
-  if (typeof cid === 'string') {
-    return CID.parse(cid)
-  }
-
   if (cid instanceof Uint8Array) {
     return CID.decode(cid)
   }
 
-  throw errCode(new Error('Invalid CID'), 'ERR_INVALID_CID')
+  return CID.parse(cid.toString())
 }

--- a/packages/ipfs-core/src/components/files/utils/to-mfs-path.js
+++ b/packages/ipfs-core/src/components/files/utils/to-mfs-path.js
@@ -99,10 +99,10 @@ const toMfsPath = async (context, path, options) => {
 
   let ipfsPath = ''
 
-  if (path instanceof CID) {
+  if (CID.asCID(CID)) {
     ipfsPath = `/ipfs/${path}`
   } else {
-    ipfsPath = path
+    ipfsPath = path.toString()
   }
 
   ipfsPath = ipfsPath.trim()

--- a/packages/ipfs-core/src/components/files/utils/to-mfs-path.js
+++ b/packages/ipfs-core/src/components/files/utils/to-mfs-path.js
@@ -99,7 +99,7 @@ const toMfsPath = async (context, path, options) => {
 
   let ipfsPath = ''
 
-  if (CID.asCID(CID)) {
+  if (CID.asCID(path)) {
     ipfsPath = `/ipfs/${path}`
   } else {
     ipfsPath = path.toString()

--- a/packages/ipfs-core/src/components/object/links.js
+++ b/packages/ipfs-core/src/components/object/links.js
@@ -32,11 +32,13 @@ function findLinks (node, links = []) {
       }
     }
 
-    if (val instanceof CID) {
+    const cid = CID.asCID(val)
+
+    if (cid) {
       links.push({
         Name: '',
         Tsize: 0,
-        Hash: val
+        Hash: cid
       })
       continue
     }

--- a/packages/ipfs-core/src/components/pin/add.js
+++ b/packages/ipfs-core/src/components/pin/add.js
@@ -14,9 +14,11 @@ module.exports = ({ addAll }) =>
   (path, options = {}) => {
     let iter
 
-    if (path instanceof CID) {
+    const cid = CID.asCID(path)
+
+    if (cid) {
       iter = addAll([{
-        cid: path,
+        cid,
         ...options
       }], options)
     } else {

--- a/packages/ipfs-core/src/components/resolve.js
+++ b/packages/ipfs-core/src/components/resolve.js
@@ -48,7 +48,7 @@ module.exports = ({ repo, codecs, bases, name }) => {
     let remainderPath = path
 
     for await (const result of results) {
-      if (result.value instanceof CID) {
+      if (CID.asCID(result.value)) {
         value = result.value
         remainderPath = result.remainderPath
       }

--- a/packages/ipfs-core/src/utils.js
+++ b/packages/ipfs-core/src/utils.js
@@ -25,17 +25,21 @@ const ERR_BAD_PATH = 'ERR_BAD_PATH'
  * @throws on an invalid @param pathStr
  */
 const normalizePath = (pathStr) => {
-  if (pathStr instanceof CID) {
+  const cid = CID.asCID(pathStr)
+
+  if (cid) {
     return `/ipfs/${pathStr}`
   }
 
+  const str = pathStr.toString()
+
   try {
-    CID.parse(pathStr)
-    pathStr = `/ipfs/${pathStr}`
+    CID.parse(str)
+    pathStr = `/ipfs/${str}`
   } catch {}
 
-  if (isIpfs.path(pathStr)) {
-    return pathStr
+  if (isIpfs.path(str)) {
+    return str
   } else {
     throw errCode(new Error(`invalid path: ${pathStr}`), ERR_BAD_PATH)
   }
@@ -45,21 +49,22 @@ const normalizePath = (pathStr) => {
 // TODO: don't forget ipfs-core-utils/src/to-cid-and-path
 /**
  * @param {Uint8Array|CID|string} path
- * @returns {string}
- */
+  */
 const normalizeCidPath = (path) => {
   if (path instanceof Uint8Array) {
     return CID.decode(path).toString()
   }
-  if (path instanceof CID) {
-    return path.toString()
-  }
+
+  path = path.toString()
+
   if (path.indexOf('/ipfs/') === 0) {
     path = path.substring('/ipfs/'.length)
   }
+
   if (path.charAt(path.length - 1) === '/') {
     path = path.substring(0, path.length - 1)
   }
+
   return path
 }
 
@@ -95,7 +100,7 @@ const resolvePath = async function (repo, codecs, ipfsPath, options = {}) {
       for await (const { value, remainderPath } of resolve(cid, options.path, codecs, repo, {
         signal: options.signal
       })) {
-        if (!(value instanceof CID)) {
+        if (!CID.asCID(value)) {
           break
         }
 
@@ -235,7 +240,7 @@ const resolve = async function * (cid, path, codecs, repo, options) {
       throw errCode(new Error(`no link named "${key}" under ${lastCid}`), 'ERR_NO_LINK')
     }
 
-    if (value instanceof CID) {
+    if (CID.asCID(value)) {
       lastCid = value
       value = await load(value)
     }

--- a/packages/ipfs-core/src/utils.js
+++ b/packages/ipfs-core/src/utils.js
@@ -49,7 +49,7 @@ const normalizePath = (pathStr) => {
 // TODO: don't forget ipfs-core-utils/src/to-cid-and-path
 /**
  * @param {Uint8Array|CID|string} path
-  */
+ */
 const normalizeCidPath = (path) => {
   if (path instanceof Uint8Array) {
     return CID.decode(path).toString()

--- a/packages/ipfs-core/src/utils.js
+++ b/packages/ipfs-core/src/utils.js
@@ -34,8 +34,7 @@ const normalizePath = (pathStr) => {
   const str = pathStr.toString()
 
   try {
-    CID.parse(str)
-    pathStr = `/ipfs/${str}`
+    return `/ipfs/${CID.parse(str)}`
   } catch {}
 
   if (isIpfs.path(str)) {

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -43,7 +43,7 @@
     "libp2p-webrtc-star": "^0.23.0"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
     "ws": "^7.3.1"
   },

--- a/packages/ipfs-grpc-client/package.json
+++ b/packages/ipfs-grpc-client/package.json
@@ -50,7 +50,7 @@
     "ws": "^7.3.1"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "it-all": "^1.0.4",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1"

--- a/packages/ipfs-grpc-server/package.json
+++ b/packages/ipfs-grpc-server/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/ws": "^7.4.0",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "ipfs-core": "^0.10.4",
     "it-all": "^1.0.4",
     "it-drain": "^1.0.3",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -67,7 +67,7 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "delay": "^5.0.0",
     "go-ipfs": "0.9.1",
     "ipfsd-ctl": "^10.0.3",

--- a/packages/ipfs-http-client/src/files/cp.js
+++ b/packages/ipfs-http-client/src/files/cp.js
@@ -20,7 +20,7 @@ module.exports = configure(api => {
     const res = await api.post('files/cp', {
       signal: options.signal,
       searchParams: toUrlSearchParams({
-        arg: sourceArr.concat(destination).map(src => src instanceof CID ? `/ipfs/${src}` : src),
+        arg: sourceArr.concat(destination).map(src => CID.asCID(src) ? `/ipfs/${src}` : src),
         ...options
       }),
       headers: options.headers

--- a/packages/ipfs-http-client/src/files/ls.js
+++ b/packages/ipfs-http-client/src/files/ls.js
@@ -21,7 +21,7 @@ module.exports = configure(api => {
     const res = await api.post('files/ls', {
       signal: options.signal,
       searchParams: toUrlSearchParams({
-        arg: path instanceof CID ? `/ipfs/${path}` : path,
+        arg: CID.asCID(path) ? `/ipfs/${path}` : path,
         // default long to true, diverges from go-ipfs where its false by default
         long: true,
         ...options,

--- a/packages/ipfs-http-client/src/files/stat.js
+++ b/packages/ipfs-http-client/src/files/stat.js
@@ -15,13 +15,6 @@ module.exports = configure(api => {
    * @type {FilesAPI["stat"]}
    */
   async function stat (path, options = {}) {
-    if (path && !(path instanceof CID) && typeof path !== 'string') {
-      options = path || {}
-      path = '/'
-    }
-
-    options = options || {}
-
     const res = await api.post('files/stat', {
       signal: options.signal,
       searchParams: toUrlSearchParams({

--- a/packages/ipfs-http-client/src/lib/resolve.js
+++ b/packages/ipfs-http-client/src/lib/resolve.js
@@ -57,8 +57,10 @@ const resolve = async function * (cid, path, codecs, getBlock, options) {
       throw errCode(new Error(`no link named "${key}" under ${lastCid}`), 'ERR_NO_LINK')
     }
 
-    if (value instanceof CID) {
-      lastCid = value
+    const cid = CID.asCID(value)
+
+    if (cid) {
+      lastCid = cid
       value = await load(value)
     }
   }

--- a/packages/ipfs-http-client/src/pin/remote/index.js
+++ b/packages/ipfs-http-client/src/pin/remote/index.js
@@ -119,7 +119,7 @@ const encodeService = (service) => {
  * @returns {string}
  */
 const encodeCID = (cid) => {
-  if (cid instanceof CID) {
+  if (CID.asCID(CID)) {
     return cid.toString()
   } else {
     throw new TypeError(`CID instance expected instead of ${typeof cid}`)

--- a/packages/ipfs-http-client/src/pin/remote/index.js
+++ b/packages/ipfs-http-client/src/pin/remote/index.js
@@ -119,7 +119,7 @@ const encodeService = (service) => {
  * @returns {string}
  */
 const encodeCID = (cid) => {
-  if (CID.asCID(CID)) {
+  if (CID.asCID(cid)) {
     return cid.toString()
   } else {
     throw new TypeError(`CID instance expected instead of ${typeof cid}`)

--- a/packages/ipfs-http-gateway/package.json
+++ b/packages/ipfs-http-gateway/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@types/hapi-pino": "^8.0.1",
     "@types/hapi__hapi": "^20.0.5",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "file-type": "^16.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^11.1.1"

--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@types/hapi-pino": "^8.0.1",
     "@types/hapi__hapi": "^20.0.5",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "form-data": "^4.0.0",
     "ipfs-http-client": "^52.0.2",
     "iso-random-stream": "^2.0.0",

--- a/packages/ipfs-message-port-client/package.json
+++ b/packages/ipfs-message-port-client/package.json
@@ -40,7 +40,7 @@
     "multiformats": "^9.4.1"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "interface-ipfs-core": "^0.150.1",
     "ipfs-core": "^0.10.4",
     "ipfs-message-port-server": "^0.9.1",

--- a/packages/ipfs-message-port-client/src/core.js
+++ b/packages/ipfs-message-port-client/src/core.js
@@ -122,7 +122,8 @@ CoreClient.prototype.add = async function add (input, options = {}) {
  * @type {RootAPI["cat"]}
  */
 CoreClient.prototype.cat = async function * cat (inputPath, options = {}) {
-  const input = inputPath instanceof CID ? encodeCID(inputPath) : inputPath
+  const cid = CID.asCID(inputPath)
+  const input = cid ? encodeCID(cid) : inputPath
   const result = await this.remote.cat({ ...options, path: input })
   yield * decodeIterable(result.data, identity)
 }
@@ -133,7 +134,8 @@ CoreClient.prototype.cat = async function * cat (inputPath, options = {}) {
  * @type {RootAPI["ls"]}
  */
 CoreClient.prototype.ls = async function * ls (inputPath, options = {}) {
-  const input = inputPath instanceof CID ? encodeCID(inputPath) : inputPath
+  const cid = CID.asCID(inputPath)
+  const input = cid ? encodeCID(cid) : inputPath
   const result = await this.remote.ls({ ...options, path: input })
 
   yield * decodeIterable(result.data, decodeLsEntry)

--- a/packages/ipfs-message-port-client/src/files.js
+++ b/packages/ipfs-message-port-client/src/files.js
@@ -49,8 +49,11 @@ module.exports = FilesClient
  *
  * @param {string|CID} pathOrCID
  */
-const encodeLocation = pathOrCID =>
-  pathOrCID instanceof CID ? `/ipfs/${pathOrCID.toString()}` : pathOrCID
+const encodeLocation = pathOrCID => {
+  const cid = CID.asCID(pathOrCID)
+
+  return cid ? `/ipfs/${pathOrCID.toString()}` : pathOrCID.toString()
+}
 
 /**
  * @param {EncodedStat} data

--- a/packages/ipfs-message-port-protocol/package.json
+++ b/packages/ipfs-message-port-protocol/package.json
@@ -50,7 +50,7 @@
     "multiformats": "^9.4.1"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "rimraf": "^3.0.2",
     "uint8arrays": "^3.0.0"
   },

--- a/packages/ipfs-message-port-protocol/src/dag.js
+++ b/packages/ipfs-message-port-protocol/src/dag.js
@@ -68,9 +68,11 @@ exports.encodeNode = encodeNode
  */
 const collectNode = (value, cids, transfer) => {
   if (value != null && typeof value === 'object') {
-    if (value instanceof CID) {
-      cids.push(value)
-      encodeCID(value, transfer)
+    const cid = CID.asCID(value)
+
+    if (cid) {
+      cids.push(cid)
+      encodeCID(cid, transfer)
     } else if (value instanceof ArrayBuffer) {
       if (transfer) {
         transfer.push(value)

--- a/packages/ipfs-message-port-server/package.json
+++ b/packages/ipfs-message-port-server/package.json
@@ -44,7 +44,7 @@
     "multiformats": "^9.4.1"
   },
   "devDependencies": {
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "rimraf": "^3.0.2"
   },
   "engines": {

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/semver": "^7.3.4",
     "@types/update-notifier": "^5.0.0",
-    "aegir": "^35.0.2",
+    "aegir": "^35.0.3",
     "assert": "^2.0.0",
     "cross-env": "^7.0.0",
     "electron-webrtc": "^0.3.0",


### PR DESCRIPTION
When we use ipjs to publish esm modules as esm and cjs, consuming code
can end up loading classes from different locations based on whether
the consuming code is esm or cjs so `instanceof` becomes unreliable.

Remove its use with the CID class since we dual publish that one.