### PR TITLE
Fixed a typo in FILES.md file

### DIFF
--- a/docs/core-api/FILES.md
+++ b/docs/core-api/FILES.md
@@ -204,7 +204,7 @@ const file = {
   content: 'ABC'
 }
 
-const result = await ipfs.add(content)
+const result = await ipfs.add(file)
 
 console.info(result)
 


### PR DESCRIPTION
There seems to be a typo in [FILES.md](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md) file
On line 207,
`const result = await ipfs.add(content)`

This should be `const result = await ipfs.add(file)`

This PR fixes #3740 