### PR TITLE
fix: use Key.asKey instead of instanceOf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -136,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -205,7 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -246,7 +246,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -275,7 +275,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/packages/ipfs-core-types/package.json
+++ b/packages/ipfs-core-types/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
-    "interface-datastore": "^5.0.0",
+    "interface-datastore": "^5.2.0",
     "multiaddr": "^10.0.0",
     "multiformats": "^9.4.1"
   },

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -74,7 +74,7 @@
     "hamt-sharding": "^2.0.0",
     "hashlru": "^2.3.0",
     "interface-blockstore": "^1.0.0",
-    "interface-datastore": "^5.0.0",
+    "interface-datastore": "^5.2.0",
     "ipfs-bitswap": "^6.0.0",
     "ipfs-core-types": "^0.7.2",
     "ipfs-core-utils": "^0.10.4",

--- a/packages/ipfs-core/src/ipns/publisher.js
+++ b/packages/ipfs-core/src/ipns/publisher.js
@@ -92,7 +92,9 @@ class IpnsPublisher {
    * @param {IPNSEntry} entry
    */
   async _publishEntry (key, entry) {
-    if (!(key instanceof Key)) {
+    const k = Key.asKey(key)
+
+    if (!k) {
       const errMsg = 'datastore key does not have a valid format'
 
       log.error(errMsg)
@@ -112,12 +114,12 @@ class IpnsPublisher {
 
     // Add record to routing (buffer key)
     try {
-      const res = await this._routing.put(key.uint8Array(), entryData)
-      log(`ipns record for ${uint8ArrayToString(key.uint8Array(), 'base64')} was stored in the routing`)
+      const res = await this._routing.put(k.uint8Array(), entryData)
+      log(`ipns record for ${uint8ArrayToString(k.uint8Array(), 'base64')} was stored in the routing`)
 
       return res
     } catch (err) {
-      const errMsg = `ipns record for ${uint8ArrayToString(key.uint8Array(), 'base64')} could not be stored in the routing`
+      const errMsg = `ipns record for ${uint8ArrayToString(k.uint8Array(), 'base64')} could not be stored in the routing`
       log.error(errMsg)
       log.error(err)
 
@@ -130,7 +132,9 @@ class IpnsPublisher {
    * @param {PublicKey} publicKey
    */
   async _publishPublicKey (key, publicKey) {
-    if (!(key instanceof Key)) {
+    const k = Key.asKey(key)
+
+    if (!k) {
       const errMsg = 'datastore key does not have a valid format'
       log.error(errMsg)
 
@@ -146,12 +150,12 @@ class IpnsPublisher {
 
     // Add public key to routing (buffer key)
     try {
-      const res = await this._routing.put(key.uint8Array(), publicKey.bytes)
+      const res = await this._routing.put(k.uint8Array(), publicKey.bytes)
       log(`public key for ${uint8ArrayToString(key.uint8Array(), 'base64')} was stored in the routing`)
 
       return res
     } catch (err) {
-      const errMsg = `public key for ${uint8ArrayToString(key.uint8Array(), 'base64')} could not be stored in the routing`
+      const errMsg = `public key for ${uint8ArrayToString(k.uint8Array(), 'base64')} could not be stored in the routing`
       log.error(errMsg)
       log.error(err)
 

--- a/packages/ipfs-core/src/ipns/publisher.js
+++ b/packages/ipfs-core/src/ipns/publisher.js
@@ -151,7 +151,7 @@ class IpnsPublisher {
     // Add public key to routing (buffer key)
     try {
       const res = await this._routing.put(k.uint8Array(), publicKey.bytes)
-      log(`public key for ${uint8ArrayToString(key.uint8Array(), 'base64')} was stored in the routing`)
+      log(`public key for ${uint8ArrayToString(k.uint8Array(), 'base64')} was stored in the routing`)
 
       return res
     } catch (err) {


### PR DESCRIPTION
Using `instanceOf` is not reliable since instances of classes can cross the CLS/ESM boundary and/or come from different browser bundles.

Instead see if we can treat what we've been handed as a `Key` by using the `Key.asKey` method.

Fixes #3852