### PR TITLE
docs: fixed a typo in CONFIG.md file

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -200,7 +200,7 @@ Options for Multicast DNS peer discovery:
 
 ### `webRTCStar`
 
-WebRTCStar is a discovery mechanism prvided by a signalling-star that allows peer-to-peer communications in the browser.
+WebRTCStar is a discovery mechanism provided by a signalling-star that allows peer-to-peer communications in the browser.
 
 Options for webRTCstar peer discovery:
 


### PR DESCRIPTION
A typo exists in the [CONFIG.md](https://github.com/ipfs/js-ipfs/blob/master/docs/CONFIG.md#webrtcstar) file.

line 207:  `WebRTCStar is a discovery mechanism prvided by a signalling-star`

should be: `WebRTCStar is a discovery mechanism provided by a signalling-star`