### PR TITLE
fix: handle node readable streams properly

### DIFF
--- a/packages/ipfs-core-utils/src/files/normalise-content.js
+++ b/packages/ipfs-core-utils/src/files/normalise-content.js
@@ -14,7 +14,14 @@ import {
 /**
  * @param {import('./normalise').ToContent} input
  */
-export async function * normaliseContent (input) {
+export async function normaliseContent (input) {
+  return toAsyncGenerator(input)
+}
+
+/**
+ * @param {import('./normalise').ToContent} input
+ */
+async function * toAsyncGenerator (input) {
   // Bytes | String
   if (isBytes(input)) {
     yield toBytes(input)

--- a/packages/ipfs-core-utils/src/files/normalise.js
+++ b/packages/ipfs-core-utils/src/files/normalise.js
@@ -72,7 +72,7 @@ export async function * normalise (input, normaliseContent) {
       return
     }
 
-    // Node ReadableStream<Node ReadableStream>
+    // fs.ReadStream<Bytes>
     if (value._readableState) {
       // @ts-ignore Node readable streams have a `.path` property so we need to pass it as the content
       yield * map(peekable, (/** @type {ImportCandidate} */ value) => toFileObject({ content: value }, normaliseContent))

--- a/packages/ipfs-core-utils/test/files/normalise-input.spec.js
+++ b/packages/ipfs-core-utils/test/files/normalise-input.spec.js
@@ -86,12 +86,6 @@ function browserReadableStreamOf (thing) {
   })
 }
 
-function nodeReadStreamOf (thing) {
-  return (async function * () { // eslint-disable-line require-await
-    yield thing
-  }())
-}
-
 describe('normalise-input', function () {
   /**
    * @param {() => any} content
@@ -234,14 +228,13 @@ describe('normalise-input', function () {
 
       testInputType(NODEFSREADSTREAM, 'Node fs.ReadStream', false)
 
-      it(`Iterable<Node fs.ReadStream>`, async function () {
+      it('Iterable<Node fs.ReadStream>', async function () {
         await testContent(iterableOf(NODEFSREADSTREAM()))
       })
 
-      it(`AsyncIterable<Node fs.ReadStream>`, async function () {
+      it('AsyncIterable<Node fs.ReadStream>', async function () {
         await testContent(asyncIterableOf(NODEFSREADSTREAM()))
       })
-
     })
   }
 })

--- a/packages/ipfs-core-utils/test/fixtures/file.txt
+++ b/packages/ipfs-core-utils/test/fixtures/file.txt
@@ -1,0 +1,1 @@
+hello world

--- a/packages/ipfs-grpc-client/src/core-api/files/write.js
+++ b/packages/ipfs-grpc-client/src/core-api/files/write.js
@@ -12,7 +12,7 @@ import {
  * @param {*} content
  */
 async function * stream (path, content) {
-  for await (const buf of normaliseContent(content)) {
+  for await (const buf of await normaliseContent(content)) {
     yield { path, content: buf }
   }
 }


### PR DESCRIPTION
Readable streams returned from `fs.createReadStream` have a `.path` property which was throwing off the content normalisation.

Fixes #3882