### PR TITLE
chore: update ipfs-utils

### DIFF
--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -92,7 +92,7 @@
     "ipfs-unixfs": "^6.0.3",
     "ipfs-unixfs-exporter": "^7.0.3",
     "ipfs-unixfs-importer": "^9.0.3",
-    "ipfs-utils": "^8.1.4",
+    "ipfs-utils": "^9.0.1",
     "ipns": "^0.15.0",
     "is-domain-name": "^1.0.1",
     "is-ipfs": "^6.0.1",


### PR DESCRIPTION
This should be `9.x.x` like everywhere else.