### PR TITLE
fix: do not accept single items for ipfs.add

### DIFF
--- a/packages/interface-ipfs-core/src/add-all.js
+++ b/packages/interface-ipfs-core/src/add-all.js
@@ -301,6 +301,26 @@ export function testAddAll (factory, options) {
       await expect(all(ipfs.addAll(nonValid))).to.eventually.be.rejected()
     })
 
+    it('should fail when passed single file objects', async () => {
+      const nonValid = { content: 'hello world' }
+
+      // @ts-expect-error nonValid is non valid
+      await expect(all(ipfs.addAll(nonValid))).to.eventually.be.rejectedWith(/single item passed/)
+    })
+
+    it('should fail when passed single strings', async () => {
+      const nonValid = 'hello world'
+
+      await expect(all(ipfs.addAll(nonValid))).to.eventually.be.rejectedWith(/single item passed/)
+    })
+
+    it('should fail when passed single buffers', async () => {
+      const nonValid = uint8ArrayFromString('hello world')
+
+      // @ts-expect-error nonValid is non valid
+      await expect(all(ipfs.addAll(nonValid))).to.eventually.be.rejectedWith(/single item passed/)
+    })
+
     it('should wrap content in a directory', async () => {
       const data = { path: 'testfile.txt', content: fixtures.smallFile.data }
 

--- a/packages/interface-ipfs-core/src/add.js
+++ b/packages/interface-ipfs-core/src/add.js
@@ -244,6 +244,20 @@ export function testAdd (factory, options) {
       await expect(ipfs.add(null)).to.eventually.be.rejected()
     })
 
+    it('should fail when passed multiple file objects', async () => {
+      const nonValid = [{ content: 'hello' }, { content: 'world' }]
+
+      // @ts-expect-error nonValid is non valid
+      await expect(ipfs.add(nonValid)).to.eventually.be.rejectedWith(/multiple items passed/)
+    })
+
+    it('should fail when passed multiple strings', async () => {
+      const nonValid = ['hello', 'world']
+
+      // @ts-expect-error nonValid is non valid
+      await expect(ipfs.add(nonValid)).to.eventually.be.rejectedWith(/multiple items passed/)
+    })
+
     it('should wrap content in a directory', async () => {
       const data = { path: 'testfile.txt', content: fixtures.smallFile.data }
 

--- a/packages/interface-ipfs-core/src/add.js
+++ b/packages/interface-ipfs-core/src/add.js
@@ -251,13 +251,6 @@ export function testAdd (factory, options) {
       await expect(ipfs.add(nonValid)).to.eventually.be.rejectedWith(/multiple items passed/)
     })
 
-    it('should fail when passed multiple strings', async () => {
-      const nonValid = ['hello', 'world']
-
-      // @ts-expect-error nonValid is non valid
-      await expect(ipfs.add(nonValid)).to.eventually.be.rejectedWith(/multiple items passed/)
-    })
-
     it('should wrap content in a directory', async () => {
       const data = { path: 'testfile.txt', content: fixtures.smallFile.data }
 

--- a/packages/ipfs-cli/src/parser.js
+++ b/packages/ipfs-cli/src/parser.js
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs'
 import { ipfsPathHelp, disablePrinting } from './utils.js'
 import { commandList } from './commands/index.js'

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -38,11 +38,17 @@
     ".": {
       "import": "./src/index.js"
     },
-    "./files/normalise-input": {
-      "import": "./src/files/normalise-input.js"
+    "./files/normalise-input-single": {
+      "import": "./src/files/normalise-input-single.js"
     },
-    "./files/normalise-input.browser": {
-      "import": "./src/files/normalise-input.browser.js"
+    "./files/normalise-input-single.browser": {
+      "import": "./src/files/normalise-input-single.browser.js"
+    },
+    "./files/normalise-input-multiple": {
+      "import": "./src/files/normalise-input-multiple.js"
+    },
+    "./files/normalise-input-multiple.browser": {
+      "import": "./src/files/normalise-input-multiple.browser.js"
     },
     "./files/normalise-content": {
       "import": "./src/files/normalise-content.js"

--- a/packages/ipfs-core-utils/src/files/normalise-candidate-multiple.js
+++ b/packages/ipfs-core-utils/src/files/normalise-candidate-multiple.js
@@ -14,33 +14,23 @@ import {
 } from 'ipfs-unixfs'
 
 /**
+ * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
  * @typedef {import('ipfs-core-types/src/utils').ToContent} ToContent
  * @typedef {import('ipfs-unixfs-importer').ImportCandidate} ImporterImportCandidate
- * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
  * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
  */
 
 /**
- * @param {ImportCandidate | ImportCandidateStream} input
+ * @param {ImportCandidateStream} input
  * @param {(content:ToContent) => Promise<AsyncIterable<Uint8Array>>} normaliseContent
  */
 // eslint-disable-next-line complexity
-export async function * normalise (input, normaliseContent) {
-  if (input === null || input === undefined) {
-    throw errCode(new Error(`Unexpected input: ${input}`), 'ERR_UNEXPECTED_INPUT')
-  }
-
+export async function * normaliseCandidateMultiple (input, normaliseContent) {
   // String
-  if (typeof input === 'string' || input instanceof String) {
-    yield toFileObject(input.toString(), normaliseContent)
-    return
-  }
-
   // Uint8Array|ArrayBuffer|TypedArray
   // Blob|File
-  if (isBytes(input) || isBlob(input)) {
-    yield toFileObject(input, normaliseContent)
-    return
+  if (typeof input === 'string' || input instanceof String || isBytes(input) || isBlob(input)) {
+    throw errCode(new Error('Unexpected input: single item passed'), 'ERR_UNEXPECTED_INPUT')
   }
 
   // Browser ReadableStream
@@ -68,22 +58,13 @@ export async function * normalise (input, normaliseContent) {
     // (Async)Iterable<Number>
     // (Async)Iterable<Bytes>
     if (Number.isInteger(value) || isBytes(value)) {
-      yield toFileObject(peekable, normaliseContent)
-      return
+      throw errCode(new Error('Unexpected input: single item passed'), 'ERR_UNEXPECTED_INPUT')
     }
 
-    // fs.ReadStream<Bytes>
+    // (Async)Iterable<fs.ReadStream>
     if (value._readableState) {
-      // @ts-ignore Node readable streams have a `.path` property so we need to pass it as the content
+      // @ts-ignore Node fs.ReadStreams have a `.path` property so we need to pass it as the content
       yield * map(peekable, (/** @type {ImportCandidate} */ value) => toFileObject({ content: value }, normaliseContent))
-      return
-    }
-
-    // (Async)Iterable<Blob>
-    // (Async)Iterable<String>
-    // (Async)Iterable<{ path, content }>
-    if (isFileObject(value) || isBlob(value) || typeof value === 'string' || value instanceof String) {
-      yield * map(peekable, (/** @type {ImportCandidate} */ value) => toFileObject(value, normaliseContent))
       return
     }
 
@@ -91,18 +72,17 @@ export async function * normalise (input, normaliseContent) {
     // (Async)Iterable<ReadableStream<?>>
     // ReadableStream<(Async)Iterable<?>>
     // ReadableStream<ReadableStream<?>>
-    if (value[Symbol.iterator] || value[Symbol.asyncIterator] || isReadableStream(value)) {
+    if (isFileObject(value) || value[Symbol.iterator] || value[Symbol.asyncIterator] || isReadableStream(value)) {
       yield * map(peekable, (/** @type {ImportCandidate} */ value) => toFileObject(value, normaliseContent))
       return
     }
   }
 
   // { path, content: ? }
-  // Note: Detected _after_ (Async)Iterable<?> because Node.js streams have a
+  // Note: Detected _after_ (Async)Iterable<?> because Node.js fs.ReadStreams have a
   // `path` property that passes this check.
   if (isFileObject(input)) {
-    yield toFileObject(input, normaliseContent)
-    return
+    throw errCode(new Error('Unexpected input: single item passed'), 'ERR_UNEXPECTED_INPUT')
   }
 
   throw errCode(new Error('Unexpected input: ' + typeof input), 'ERR_UNEXPECTED_INPUT')

--- a/packages/ipfs-core-utils/src/files/normalise-candidate-single.js
+++ b/packages/ipfs-core-utils/src/files/normalise-candidate-single.js
@@ -1,0 +1,118 @@
+import errCode from 'err-code'
+import browserStreamToIt from 'browser-readablestream-to-it'
+import itPeekable from 'it-peekable'
+import map from 'it-map'
+import {
+  isBytes,
+  isBlob,
+  isReadableStream,
+  isFileObject
+} from './utils.js'
+import {
+  parseMtime,
+  parseMode
+} from 'ipfs-unixfs'
+
+/**
+ * @typedef {import('ipfs-core-types/src/utils').ToContent} ToContent
+ * @typedef {import('ipfs-unixfs-importer').ImportCandidate} ImporterImportCandidate
+ * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
+ * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
+ */
+
+/**
+ * @param {ImportCandidate} input
+ * @param {(content:ToContent) => Promise<AsyncIterable<Uint8Array>>} normaliseContent
+ */
+// eslint-disable-next-line complexity
+export async function * normaliseCandidateSingle (input, normaliseContent) {
+  if (input === null || input === undefined) {
+    throw errCode(new Error(`Unexpected input: ${input}`), 'ERR_UNEXPECTED_INPUT')
+  }
+
+  // String
+  if (typeof input === 'string' || input instanceof String) {
+    yield toFileObject(input.toString(), normaliseContent)
+    return
+  }
+
+  // Uint8Array|ArrayBuffer|TypedArray
+  // Blob|File
+  if (isBytes(input) || isBlob(input)) {
+    yield toFileObject(input, normaliseContent)
+    return
+  }
+
+  // Browser ReadableStream
+  if (isReadableStream(input)) {
+    input = browserStreamToIt(input)
+  }
+
+  // Iterable<?>
+  if (Symbol.iterator in input || Symbol.asyncIterator in input) {
+    // @ts-ignore it's (async)iterable
+    const peekable = itPeekable(input)
+
+    /** @type {any} value **/
+    const { value, done } = await peekable.peek()
+
+    if (done) {
+      // make sure empty iterators result in empty files
+      yield { content: [] }
+      return
+    }
+
+    peekable.push(value)
+
+    // (Async)Iterable<Number>
+    // (Async)Iterable<Bytes>
+    if (Number.isInteger(value) || isBytes(value)) {
+      yield toFileObject(peekable, normaliseContent)
+      return
+    }
+
+    // (Async)Iterable<fs.ReadStream>
+    if (value._readableState) {
+      // @ts-ignore Node fs.ReadStreams have a `.path` property so we need to pass it as the content
+      yield * map(peekable, (/** @type {ImportCandidate} */ value) => toFileObject({ content: value }, normaliseContent))
+      return
+    }
+
+    throw errCode(new Error('Unexpected input: multiple items passed'), 'ERR_UNEXPECTED_INPUT')
+  }
+
+  // { path, content: ? }
+  // Note: Detected _after_ (Async)Iterable<?> because Node.js fs.ReadStreams have a
+  // `path` property that passes this check.
+  if (isFileObject(input)) {
+    yield toFileObject(input, normaliseContent)
+    return
+  }
+
+  throw errCode(new Error('Unexpected input: cannot convert "' + typeof input + '" into ImportCandidate'), 'ERR_UNEXPECTED_INPUT')
+}
+
+/**
+ * @param {ImportCandidate} input
+ * @param {(content:ToContent) => Promise<AsyncIterable<Uint8Array>>} normaliseContent
+ */
+async function toFileObject (input, normaliseContent) {
+  // @ts-ignore - Those properties don't exist on most input types
+  const { path, mode, mtime, content } = input
+
+  /** @type {ImporterImportCandidate} */
+  const file = {
+    path: path || '',
+    mode: parseMode(mode),
+    mtime: parseMtime(mtime)
+  }
+
+  if (content) {
+    file.content = await normaliseContent(content)
+  } else if (!path) { // Not already a file object with path or content prop
+    // @ts-ignore - input still can be different ToContent
+    file.content = await normaliseContent(input)
+  }
+
+  return file
+}

--- a/packages/ipfs-core-utils/src/files/normalise-candidate-single.js
+++ b/packages/ipfs-core-utils/src/files/normalise-candidate-single.js
@@ -1,7 +1,6 @@
 import errCode from 'err-code'
 import browserStreamToIt from 'browser-readablestream-to-it'
 import itPeekable from 'it-peekable'
-import map from 'it-map'
 import {
   isBytes,
   isBlob,
@@ -66,19 +65,13 @@ export async function * normaliseCandidateSingle (input, normaliseContent) {
 
     // (Async)Iterable<Number>
     // (Async)Iterable<Bytes>
-    if (Number.isInteger(value) || isBytes(value)) {
+    // (Async)Iterable<String>
+    if (Number.isInteger(value) || isBytes(value) || typeof value === 'string' || value instanceof String) {
       yield toFileObject(peekable, normaliseContent)
       return
     }
 
-    // (Async)Iterable<fs.ReadStream>
-    if (value._readableState) {
-      // @ts-ignore Node fs.ReadStreams have a `.path` property so we need to pass it as the content
-      yield * map(peekable, (/** @type {ImportCandidate} */ value) => toFileObject({ content: value }, normaliseContent))
-      return
-    }
-
-    throw errCode(new Error('Unexpected input: multiple items passed'), 'ERR_UNEXPECTED_INPUT')
+    throw errCode(new Error('Unexpected input: multiple items passed - if you are using ipfs.add, please use ipfs.addAll instead'), 'ERR_UNEXPECTED_INPUT')
   }
 
   // { path, content: ? }

--- a/packages/ipfs-core-utils/src/files/normalise-content.browser.js
+++ b/packages/ipfs-core-utils/src/files/normalise-content.browser.js
@@ -9,7 +9,7 @@ import {
 } from './utils.js'
 
 /**
- * @param {import('./normalise').ToContent} input
+ * @param {import('ipfs-core-types/src/utils').ToContent} input
  */
 export async function normaliseContent (input) {
   // Bytes

--- a/packages/ipfs-core-utils/src/files/normalise-input-multiple.browser.js
+++ b/packages/ipfs-core-utils/src/files/normalise-input-multiple.browser.js
@@ -1,0 +1,24 @@
+import { normaliseContent } from './normalise-content.browser.js'
+import { normaliseCandidateMultiple } from './normalise-candidate-multiple.js'
+
+/**
+ * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
+ * @typedef {import('ipfs-core-types/src/utils').BrowserImportCandidate} BrowserImportCandidate
+ */
+
+/**
+ * Transforms any of the `ipfs.addAll` input types into
+ *
+ * ```
+ * AsyncIterable<{ path, mode, mtime, content: Blob }>
+ * ```
+ *
+ * See https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#ipfsadddata-options
+ *
+ * @param {ImportCandidateStream} input
+ * @returns {AsyncGenerator<BrowserImportCandidate, void, undefined>}
+ */
+export function normaliseInput (input) {
+  // @ts-expect-error browser normaliseContent returns a Blob not an AsyncIterable<Uint8Array>
+  return normaliseCandidateMultiple(input, normaliseContent, true)
+}

--- a/packages/ipfs-core-utils/src/files/normalise-input-multiple.js
+++ b/packages/ipfs-core-utils/src/files/normalise-input-multiple.js
@@ -1,0 +1,21 @@
+import { normaliseContent } from './normalise-content.js'
+import { normaliseCandidateMultiple } from './normalise-candidate-multiple.js'
+
+/**
+ * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
+ */
+
+/**
+ * Transforms any of the `ipfs.addAll` input types into
+ *
+ * ```
+ * AsyncIterable<{ path, mode, mtime, content: AsyncIterable<Uint8Array> }>
+ * ```
+ *
+ * See https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#ipfsadddata-options
+ *
+ * @param {ImportCandidateStream} input
+ */
+export function normaliseInput (input) {
+  return normaliseCandidateMultiple(input, normaliseContent)
+}

--- a/packages/ipfs-core-utils/src/files/normalise-input-single.browser.js
+++ b/packages/ipfs-core-utils/src/files/normalise-input-single.browser.js
@@ -1,8 +1,7 @@
 import { normaliseContent } from './normalise-content.browser.js'
-import { normalise } from './normalise.js'
+import { normaliseCandidateSingle } from './normalise-candidate-single.js'
 
 /**
- * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
  * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
  * @typedef {import('ipfs-core-types/src/utils').BrowserImportCandidate} BrowserImportCandidate
  */
@@ -16,10 +15,10 @@ import { normalise } from './normalise.js'
  *
  * See https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#ipfsadddata-options
  *
- * @param {ImportCandidate | ImportCandidateStream} input
- * @returns {AsyncGenerator<BrowserImportCandidate, void, undefined>}
+ * @param {ImportCandidate} input
+ * @returns {BrowserImportCandidate}
  */
 export function normaliseInput (input) {
-  // @ts-ignore normaliseContent returns Blob and not AsyncIterator
-  return normalise(input, normaliseContent)
+  // @ts-expect-error browser normaliseContent returns a Blob not an AsyncIterable<Uint8Array>
+  return normaliseCandidateSingle(input, normaliseContent)
 }

--- a/packages/ipfs-core-utils/src/files/normalise-input-single.js
+++ b/packages/ipfs-core-utils/src/files/normalise-input-single.js
@@ -1,8 +1,7 @@
 import { normaliseContent } from './normalise-content.js'
-import { normalise } from './normalise.js'
+import { normaliseCandidateSingle } from './normalise-candidate-single.js'
 
 /**
- * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
  * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
  */
 
@@ -15,8 +14,8 @@ import { normalise } from './normalise.js'
  *
  * See https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#ipfsadddata-options
  *
- * @param {ImportCandidate | ImportCandidateStream} input
+ * @param {ImportCandidate} input
  */
 export function normaliseInput (input) {
-  return normalise(input, normaliseContent)
+  return normaliseCandidateSingle(input, normaliseContent)
 }

--- a/packages/ipfs-core-utils/src/multipart-request.browser.js
+++ b/packages/ipfs-core-utils/src/multipart-request.browser.js
@@ -1,16 +1,15 @@
 
 // Import browser version otherwise electron-renderer will end up with node
 // version and fail.
-import { normaliseInput } from './files/normalise-input.browser.js'
+import { normaliseInput } from './files/normalise-input-multiple.browser.js'
 import { modeToString } from './mode-to-string.js'
 
 /**
  * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
- * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
  */
 
 /**
- * @param {ImportCandidateStream|ImportCandidate} source
+ * @param {ImportCandidateStream} source
  * @param {AbortController} abortController
  * @param {Headers|Record<string, string>} [headers]
  */

--- a/packages/ipfs-core-utils/src/multipart-request.js
+++ b/packages/ipfs-core-utils/src/multipart-request.js
@@ -4,12 +4,11 @@ import { multipartRequest as multipartRequestBrowser } from './multipart-request
 import { nanoid } from 'nanoid'
 
 /**
- * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
  * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
  */
 
 /**
- * @param {ImportCandidateStream|ImportCandidate} source
+ * @param {ImportCandidateStream} source
  * @param {AbortController} abortController
  * @param {Headers|Record<string, string>} [headers]
  * @param {string} [boundary]

--- a/packages/ipfs-core-utils/src/multipart-request.node.js
+++ b/packages/ipfs-core-utils/src/multipart-request.node.js
@@ -5,6 +5,7 @@ import mergeOpts from 'merge-options'
 // @ts-expect-error no types
 import toStream from 'it-to-stream'
 import debug from 'debug'
+import itPeekable from 'it-peekable'
 
 const merge = mergeOpts.bind({ ignoreUndefined: true })
 const log = debug('ipfs:core-utils:multipart-request')
@@ -27,8 +28,8 @@ export async function multipartRequest (source, abortController, headers = {}, b
     try {
       let index = 0
 
-      // @ts-ignore wrong input type for normaliseInput
-      for await (const { content, path, mode, mtime } of normaliseInput(source)) {
+      // @ts-ignore
+      for await (const { content, path, mode, mtime } of source) {
         let fileSuffix = ''
         const type = content ? 'file' : 'dir'
 
@@ -79,12 +80,26 @@ export async function multipartRequest (source, abortController, headers = {}, b
     }
   }
 
+  // peek at the first value in order to get the input stream moving
+  // and to validate its contents.
+  // We cannot do this in the `for await..of` in streamFiles due to
+  // https://github.com/node-fetch/node-fetch/issues/753
+  const peekable = itPeekable(normaliseInput(source))
+
+  /** @type {any} value **/
+  const { value, done } = await peekable.peek()
+
+  if (!done) {
+    peekable.push(value)
+  }
+
   return {
     parts: null,
     total: -1,
     headers: merge(headers, {
       'Content-Type': `multipart/form-data; boundary=${boundary}`
     }),
-    body: await toStream(streamFiles(source))
+    // @ts-expect-error normaliseInput returns unixfs importer import candidates
+    body: toStream(streamFiles(peekable))
   }
 }

--- a/packages/ipfs-core-utils/src/multipart-request.node.js
+++ b/packages/ipfs-core-utils/src/multipart-request.node.js
@@ -1,4 +1,4 @@
-import { normaliseInput } from './files/normalise-input.js'
+import { normaliseInput } from './files/normalise-input-multiple.js'
 import { nanoid } from 'nanoid'
 import { modeToString } from './mode-to-string.js'
 import mergeOpts from 'merge-options'
@@ -11,18 +11,17 @@ const log = debug('ipfs:core-utils:multipart-request')
 
 /**
  * @typedef {import('ipfs-core-types/src/utils').ImportCandidateStream} ImportCandidateStream
- * @typedef {import('ipfs-core-types/src/utils').ImportCandidate} ImportCandidate
  */
 
 /**
- * @param {ImportCandidateStream|ImportCandidate} source
+ * @param {ImportCandidateStream} source
  * @param {AbortController} abortController
  * @param {Headers|Record<string, string>} [headers]
  * @param {string} [boundary]
  */
 export async function multipartRequest (source, abortController, headers = {}, boundary = `-----------------------------${nanoid()}`) {
   /**
-   * @param {ImportCandidateStream|ImportCandidate} source
+   * @param {ImportCandidateStream} source
    */
   async function * streamFiles (source) {
     try {

--- a/packages/ipfs-core-utils/test/files/normalise-input-multiple.spec.js
+++ b/packages/ipfs-core-utils/test/files/normalise-input-multiple.spec.js
@@ -5,7 +5,7 @@ import blobToIt from 'blob-to-it'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import all from 'it-all'
 import { File } from '@web-std/file'
-import { normaliseInput } from '../../src/files/normalise-input.js'
+import { normaliseInput } from '../../src/files/normalise-input-multiple.js'
 import { isNode } from 'ipfs-utils/src/env.js'
 import resolve from 'aegir/utils/resolve.js'
 
@@ -86,7 +86,7 @@ function browserReadableStreamOf (thing) {
   })
 }
 
-describe('normalise-input', function () {
+describe('normalise-input-multiple', function () {
   /**
    * @param {() => any} content
    * @param {string} name

--- a/packages/ipfs-core-utils/test/files/normalise-input-multiple.spec.js
+++ b/packages/ipfs-core-utils/test/files/normalise-input-multiple.spec.js
@@ -16,6 +16,7 @@ const NEWSTRING = () => new String('hello world') // eslint-disable-line no-new-
 const BUFFER = () => uint8ArrayFromString(STRING())
 const ARRAY = () => Array.from(BUFFER())
 const TYPEDARRAY = () => Uint8Array.from(ARRAY())
+const FILE = () => new File([BUFFER()], 'test-file.txt')
 /** @type {() => Blob} */
 let BLOB
 
@@ -55,6 +56,14 @@ async function testContent (input) {
 }
 
 /**
+ * @param {*} input
+ * @param {RegExp} message
+ */
+async function testFailure (input, message) {
+  await expect(all(normaliseInput(input))).to.eventually.be.rejectedWith(message)
+}
+
+/**
  * @template T
  * @param {T} thing
  * @returns {T[]}
@@ -90,14 +99,14 @@ describe('normalise-input-multiple', function () {
   /**
    * @param {() => any} content
    * @param {string} name
-   * @param {boolean} isBytes
+   * @param {{ acceptStream: boolean, acceptContentStream: boolean }} options
    */
-  function testInputType (content, name, isBytes) {
-    it(name, async function () {
-      await testContent(content())
+  function testInputType (content, name, { acceptStream, acceptContentStream }) {
+    it(`Failure ${name}`, async function () {
+      await testFailure(content(), /single item passed/)
     })
 
-    if (isBytes) {
+    if (acceptStream) {
       if (ReadableStream) {
         it(`ReadableStream<${name}>`, async function () {
           await testContent(browserReadableStreamOf(content()))
@@ -111,43 +120,35 @@ describe('normalise-input-multiple', function () {
       it(`AsyncIterable<${name}>`, async function () {
         await testContent(asyncIterableOf(content()))
       })
-    }
-
-    it(`{ path: '', content: ${name} }`, async function () {
-      await testContent({ path: '', content: content() })
-    })
-
-    if (isBytes) {
+    } else {
       if (ReadableStream) {
-        it(`{ path: '', content: ReadableStream<${name}> }`, async function () {
-          await testContent({ path: '', content: browserReadableStreamOf(content()) })
+        it(`Failure ReadableStream<${name}>`, async function () {
+          await testFailure(browserReadableStreamOf(content()), /single item passed/)
         })
       }
 
-      it(`{ path: '', content: Iterable<${name}> }`, async function () {
-        await testContent({ path: '', content: iterableOf(content()) })
+      it(`Failure Iterable<${name}>`, async function () {
+        await testFailure(iterableOf(content()), /single item passed/)
       })
 
-      it(`{ path: '', content: AsyncIterable<${name}> }`, async function () {
-        await testContent({ path: '', content: asyncIterableOf(content()) })
-      })
-    }
-
-    if (ReadableStream) {
-      it(`ReadableStream<${name}>`, async function () {
-        await testContent(browserReadableStreamOf(content()))
+      it(`Failure AsyncIterable<${name}>`, async function () {
+        await testFailure(asyncIterableOf(content()), /single item passed/)
       })
     }
 
-    it(`Iterable<{ path: '', content: ${name} }`, async function () {
+    it(`Failure { path: '', content: ${name} }`, async function () {
+      await testFailure({ path: '', content: content() }, /single item passed/)
+    })
+
+    it(`Iterable<{ path: '', content: ${name} }>`, async function () {
       await testContent(iterableOf({ path: '', content: content() }))
     })
 
-    it(`AsyncIterable<{ path: '', content: ${name} }`, async function () {
+    it(`AsyncIterable<{ path: '', content: ${name} }>`, async function () {
       await testContent(asyncIterableOf({ path: '', content: content() }))
     })
 
-    if (isBytes) {
+    if (acceptContentStream) {
       if (ReadableStream) {
         it(`Iterable<{ path: '', content: ReadableStream<${name}> }>`, async function () {
           await testContent(iterableOf({ path: '', content: browserReadableStreamOf(content()) }))
@@ -175,16 +176,53 @@ describe('normalise-input-multiple', function () {
       it(`AsyncIterable<{ path: '', content: AsyncIterable<${name}> }>`, async function () {
         await testContent(asyncIterableOf({ path: '', content: asyncIterableOf(content()) }))
       })
+    } else {
+      if (ReadableStream) {
+        it(`Failure Iterable<{ path: '', content: ReadableStream<${name}> }>`, async function () {
+          await testFailure(iterableOf({ path: '', content: browserReadableStreamOf(content()) }), /Unexpected input/)
+        })
+      }
+
+      it(`Failure Iterable<{ path: '', content: Iterable<${name}> }>`, async function () {
+        await testFailure(iterableOf({ path: '', content: iterableOf(content()) }), /Unexpected input/)
+      })
+
+      it(`Failure Iterable<{ path: '', content: AsyncIterable<${name}> }>`, async function () {
+        await testFailure(iterableOf({ path: '', content: asyncIterableOf(content()) }), /Unexpected input/)
+      })
+
+      if (ReadableStream) {
+        it(`Failure AsyncIterable<{ path: '', content: ReadableStream<${name}> }>`, async function () {
+          await testFailure(asyncIterableOf({ path: '', content: browserReadableStreamOf(content()) }), /Unexpected input/)
+        })
+      }
+
+      it(`Failure AsyncIterable<{ path: '', content: Iterable<${name}> }>`, async function () {
+        await testFailure(asyncIterableOf({ path: '', content: iterableOf(content()) }), /Unexpected input/)
+      })
+
+      it(`Failure AsyncIterable<{ path: '', content: AsyncIterable<${name}> }>`, async function () {
+        await testFailure(asyncIterableOf({ path: '', content: asyncIterableOf(content()) }), /Unexpected input/)
+      })
     }
   }
 
   describe('String', () => {
-    testInputType(STRING, 'String', true)
-    testInputType(NEWSTRING, 'new String()', true)
+    testInputType(STRING, 'String', {
+      acceptStream: true,
+      acceptContentStream: true
+    })
+    testInputType(NEWSTRING, 'new String()', {
+      acceptStream: true,
+      acceptContentStream: true
+    })
   })
 
   describe('Buffer', () => {
-    testInputType(BUFFER, 'Buffer', true)
+    testInputType(BUFFER, 'Buffer', {
+      acceptStream: true,
+      acceptContentStream: true
+    })
   })
 
   describe('Blob', () => {
@@ -192,23 +230,31 @@ describe('normalise-input-multiple', function () {
       return
     }
 
-    testInputType(BLOB, 'Blob', false)
+    testInputType(BLOB, 'Blob', {
+      acceptStream: true,
+      acceptContentStream: false
+    })
   })
 
   describe('@web-std/file', () => {
-    it('normalizes File input', async () => {
-      const FILE = new File([BUFFER()], 'test-file.txt')
-
-      await testContent(FILE)
+    testInputType(FILE, 'File', {
+      acceptStream: true,
+      acceptContentStream: false
     })
   })
 
   describe('Iterable<Number>', () => {
-    testInputType(ARRAY, 'Iterable<Number>', false)
+    testInputType(ARRAY, 'Iterable<Number>', {
+      acceptStream: true,
+      acceptContentStream: false
+    })
   })
 
   describe('TypedArray', () => {
-    testInputType(TYPEDARRAY, 'TypedArray', true)
+    testInputType(TYPEDARRAY, 'TypedArray', {
+      acceptStream: true,
+      acceptContentStream: true
+    })
   })
 
   if (isNode) {
@@ -226,14 +272,9 @@ describe('normalise-input-multiple', function () {
         return fs.createReadStream(path)
       }
 
-      testInputType(NODEFSREADSTREAM, 'Node fs.ReadStream', false)
-
-      it('Iterable<Node fs.ReadStream>', async function () {
-        await testContent(iterableOf(NODEFSREADSTREAM()))
-      })
-
-      it('AsyncIterable<Node fs.ReadStream>', async function () {
-        await testContent(asyncIterableOf(NODEFSREADSTREAM()))
+      testInputType(NODEFSREADSTREAM, 'Node fs.ReadStream', {
+        acceptStream: true,
+        acceptContentStream: false
       })
     })
   }

--- a/packages/ipfs-core-utils/test/files/normalise-input-single.spec.js
+++ b/packages/ipfs-core-utils/test/files/normalise-input-single.spec.js
@@ -1,0 +1,240 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/utils/chai.js'
+import blobToIt from 'blob-to-it'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import all from 'it-all'
+import { File } from '@web-std/file'
+import { normaliseInput } from '../../src/files/normalise-input-single.js'
+import { isNode } from 'ipfs-utils/src/env.js'
+import resolve from 'aegir/utils/resolve.js'
+
+const { Blob, ReadableStream } = globalThis
+
+const STRING = () => 'hello world'
+const NEWSTRING = () => new String('hello world') // eslint-disable-line no-new-wrappers
+const BUFFER = () => uint8ArrayFromString(STRING())
+const ARRAY = () => Array.from(BUFFER())
+const TYPEDARRAY = () => Uint8Array.from(ARRAY())
+/** @type {() => Blob} */
+let BLOB
+
+if (Blob) {
+  BLOB = () => new Blob([
+    STRING()
+  ])
+}
+
+/**
+ * @param {import('ipfs-unixfs-importer').ImportCandidate[]} input
+ */
+async function verifyNormalisation (input) {
+  expect(input.length).to.equal(1)
+  expect(input[0].path).to.equal('')
+
+  let content = input[0].content
+
+  if (Blob && content instanceof Blob) {
+    content = blobToIt(content)
+  }
+
+  if (!content || content instanceof Uint8Array) {
+    throw new Error('Content expected')
+  }
+
+  await expect(all(content)).to.eventually.deep.equal([BUFFER()])
+}
+
+/**
+ * @param {*} input
+ */
+async function testContent (input) {
+  const result = await all(normaliseInput(input))
+
+  await verifyNormalisation(result)
+}
+
+/**
+ * @template T
+ * @param {T} thing
+ * @returns {T[]}
+ */
+function iterableOf (thing) {
+  return [thing]
+}
+
+/**
+ * @template T
+ * @param {T} thing
+ * @returns {AsyncIterable<T>}
+ */
+function asyncIterableOf (thing) {
+  return (async function * () { // eslint-disable-line require-await
+    yield thing
+  }())
+}
+
+/**
+ * @param {*} thing
+ */
+function browserReadableStreamOf (thing) {
+  return new ReadableStream({
+    start (controller) {
+      controller.enqueue(thing)
+      controller.close()
+    }
+  })
+}
+
+describe('normalise-input-single', function () {
+  /**
+   * @param {() => any} content
+   * @param {string} name
+   * @param {boolean} isBytes
+   */
+  function testInputType (content, name, isBytes) {
+    it(name, async function () {
+      await testContent(content())
+    })
+
+    if (isBytes) {
+      if (ReadableStream) {
+        it(`ReadableStream<${name}>`, async function () {
+          await testContent(browserReadableStreamOf(content()))
+        })
+      }
+
+      it(`Iterable<${name}>`, async function () {
+        await testContent(iterableOf(content()))
+      })
+
+      it(`AsyncIterable<${name}>`, async function () {
+        await testContent(asyncIterableOf(content()))
+      })
+    }
+
+    it(`{ path: '', content: ${name} }`, async function () {
+      await testContent({ path: '', content: content() })
+    })
+
+    if (isBytes) {
+      if (ReadableStream) {
+        it(`{ path: '', content: ReadableStream<${name}> }`, async function () {
+          await testContent({ path: '', content: browserReadableStreamOf(content()) })
+        })
+      }
+
+      it(`{ path: '', content: Iterable<${name}> }`, async function () {
+        await testContent({ path: '', content: iterableOf(content()) })
+      })
+
+      it(`{ path: '', content: AsyncIterable<${name}> }`, async function () {
+        await testContent({ path: '', content: asyncIterableOf(content()) })
+      })
+    }
+
+    if (ReadableStream) {
+      it(`ReadableStream<${name}>`, async function () {
+        await testContent(browserReadableStreamOf(content()))
+      })
+    }
+
+    it(`Iterable<{ path: '', content: ${name} }`, async function () {
+      await testContent(iterableOf({ path: '', content: content() }))
+    })
+
+    it(`AsyncIterable<{ path: '', content: ${name} }`, async function () {
+      await testContent(asyncIterableOf({ path: '', content: content() }))
+    })
+
+    if (isBytes) {
+      if (ReadableStream) {
+        it(`Iterable<{ path: '', content: ReadableStream<${name}> }>`, async function () {
+          await testContent(iterableOf({ path: '', content: browserReadableStreamOf(content()) }))
+        })
+      }
+
+      it(`Iterable<{ path: '', content: Iterable<${name}> }>`, async function () {
+        await testContent(iterableOf({ path: '', content: iterableOf(content()) }))
+      })
+
+      it(`Iterable<{ path: '', content: AsyncIterable<${name}> }>`, async function () {
+        await testContent(iterableOf({ path: '', content: asyncIterableOf(content()) }))
+      })
+
+      if (ReadableStream) {
+        it(`AsyncIterable<{ path: '', content: ReadableStream<${name}> }>`, async function () {
+          await testContent(asyncIterableOf({ path: '', content: browserReadableStreamOf(content()) }))
+        })
+      }
+
+      it(`AsyncIterable<{ path: '', content: Iterable<${name}> }>`, async function () {
+        await testContent(asyncIterableOf({ path: '', content: iterableOf(content()) }))
+      })
+
+      it(`AsyncIterable<{ path: '', content: AsyncIterable<${name}> }>`, async function () {
+        await testContent(asyncIterableOf({ path: '', content: asyncIterableOf(content()) }))
+      })
+    }
+  }
+
+  describe('String', () => {
+    testInputType(STRING, 'String', true)
+    testInputType(NEWSTRING, 'new String()', true)
+  })
+
+  describe('Buffer', () => {
+    testInputType(BUFFER, 'Buffer', true)
+  })
+
+  describe('Blob', () => {
+    if (!Blob) {
+      return
+    }
+
+    testInputType(BLOB, 'Blob', false)
+  })
+
+  describe('@web-std/file', () => {
+    it('normalizes File input', async () => {
+      const FILE = new File([BUFFER()], 'test-file.txt')
+
+      await testContent(FILE)
+    })
+  })
+
+  describe('Iterable<Number>', () => {
+    testInputType(ARRAY, 'Iterable<Number>', false)
+  })
+
+  describe('TypedArray', () => {
+    testInputType(TYPEDARRAY, 'TypedArray', true)
+  })
+
+  if (isNode) {
+    /** @type {import('fs')} */
+    let fs
+
+    before(async () => {
+      fs = await import('fs')
+    })
+
+    describe('Node fs.ReadStream', () => {
+      const NODEFSREADSTREAM = () => {
+        const path = resolve('test/fixtures/file.txt', 'ipfs-core-utils')
+
+        return fs.createReadStream(path)
+      }
+
+      testInputType(NODEFSREADSTREAM, 'Node fs.ReadStream', false)
+
+      it('Iterable<Node fs.ReadStream>', async function () {
+        await testContent(iterableOf(NODEFSREADSTREAM()))
+      })
+
+      it('AsyncIterable<Node fs.ReadStream>', async function () {
+        await testContent(asyncIterableOf(NODEFSREADSTREAM()))
+      })
+    })
+  }
+})

--- a/packages/ipfs-core-utils/test/tests.spec.js
+++ b/packages/ipfs-core-utils/test/tests.spec.js
@@ -1,5 +1,6 @@
 
 import './files/format-mode.spec.js'
 import './files/format-mtime.spec.js'
-import './files/normalise-input.spec.js'
+import './files/normalise-input-multiple.spec.js'
+import './files/normalise-input-single.spec.js'
 import './pins/normalise-input.spec.js'

--- a/packages/ipfs-core/src/components/add-all/index.js
+++ b/packages/ipfs-core/src/components/add-all/index.js
@@ -1,5 +1,5 @@
 import { importer } from 'ipfs-unixfs-importer'
-import { normaliseInput } from 'ipfs-core-utils/files/normalise-input'
+import { normaliseInput } from 'ipfs-core-utils/files/normalise-input-multiple'
 import { parseChunkerString } from './utils.js'
 import { pipe } from 'it-pipe'
 import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'

--- a/packages/ipfs-core/src/components/add.js
+++ b/packages/ipfs-core/src/components/add.js
@@ -1,4 +1,5 @@
 import last from 'it-last'
+import { normaliseInput } from 'ipfs-core-utils/files/normalise-input-single'
 
 /**
  * @param {Object} context
@@ -10,7 +11,7 @@ export function createAdd ({ addAll }) {
    */
   async function add (entry, options = {}) {
     // @ts-ignore TODO: https://github.com/ipfs/js-ipfs/issues/3290
-    const result = await last(addAll(entry, options))
+    const result = await last(addAll(normaliseInput(entry), options))
     // Note this should never happen as `addAll` should yield at least one item
     // but to satisfy type checker we perfom this check and for good measure
     // throw an error in case it does happen.

--- a/packages/ipfs-core/src/version.js
+++ b/packages/ipfs-core/src/version.js
@@ -1,4 +1,4 @@
 
-export const ipfsCore = '0.11.0'
+export const ipfsCore = '0.11.1'
 export const commit = ''
-export const interfaceIpfsCore = '^0.151.0'
+export const interfaceIpfsCore = '^0.151.1'

--- a/packages/ipfs-grpc-client/src/core-api/add-all.js
+++ b/packages/ipfs-grpc-client/src/core-api/add-all.js
@@ -1,4 +1,4 @@
-import { normaliseInput } from 'ipfs-core-utils/files/normalise-input'
+import { normaliseInput } from 'ipfs-core-utils/files/normalise-input-multiple'
 import { CID } from 'multiformats/cid'
 import { bidiToDuplex } from '../utils/bidi-to-duplex.js'
 import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'

--- a/packages/ipfs-http-client/src/add.js
+++ b/packages/ipfs-http-client/src/add.js
@@ -1,6 +1,7 @@
 import { createAddAll } from './add-all.js'
 import last from 'it-last'
 import { configure } from './lib/configure.js'
+import { normaliseInput } from 'ipfs-core-utils/files/normalise-input-single'
 
 /**
  * @typedef {import('./types').HTTPClientExtraOptions} HTTPClientExtraOptions
@@ -18,7 +19,7 @@ export function createAdd (options) {
      */
     async function add (input, options = {}) {
       // @ts-ignore - last may return undefined if source is empty
-      return await last(all(input, options))
+      return await last(all(normaliseInput(input), options))
     }
     return add
   })(options)

--- a/packages/ipfs-http-client/src/block/put.js
+++ b/packages/ipfs-http-client/src/block/put.js
@@ -25,7 +25,7 @@ export const createPut = configure(api => {
         signal: signal,
         searchParams: toUrlSearchParams(options),
         ...(
-          await multipartRequest(data, controller, options.headers)
+          await multipartRequest([data], controller, options.headers)
         )
       })
       res = await response.json()

--- a/packages/ipfs-http-client/src/config/replace.js
+++ b/packages/ipfs-http-client/src/config/replace.js
@@ -23,7 +23,7 @@ export const createReplace = configure(api => {
       signal,
       searchParams: toUrlSearchParams(options),
       ...(
-        await multipartRequest(uint8ArrayFromString(JSON.stringify(config)), controller, options.headers)
+        await multipartRequest([uint8ArrayFromString(JSON.stringify(config))], controller, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/dag/put.js
+++ b/packages/ipfs-http-client/src/dag/put.js
@@ -39,7 +39,7 @@ export const createPut = (codecs, options) => {
         signal,
         searchParams: toUrlSearchParams(settings),
         ...(
-          await multipartRequest(serialized, controller, settings.headers)
+          await multipartRequest([serialized], controller, settings.headers)
         )
       })
       const data = await res.json()

--- a/packages/ipfs-http-client/src/dht/put.js
+++ b/packages/ipfs-http-client/src/dht/put.js
@@ -28,7 +28,7 @@ export const createPut = configure(api => {
         ...options
       }),
       ...(
-        await multipartRequest(value, controller, options.headers)
+        await multipartRequest([value], controller, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/files/write.js
+++ b/packages/ipfs-http-client/src/files/write.js
@@ -29,12 +29,12 @@ export const createWrite = configure(api => {
         ...options
       }),
       ...(
-        await multipartRequest({
+        await multipartRequest([{
           content: input,
           path: 'arg',
           mode: modeToString(options.mode),
           mtime: parseMtime(options.mtime)
-        }, controller, options.headers)
+        }], controller, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/object/patch/append-data.js
+++ b/packages/ipfs-http-client/src/object/patch/append-data.js
@@ -26,7 +26,7 @@ export const createAppendData = configure(api => {
         ...options
       }),
       ...(
-        await multipartRequest(data, controller, options.headers)
+        await multipartRequest([data], controller, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/object/patch/set-data.js
+++ b/packages/ipfs-http-client/src/object/patch/set-data.js
@@ -28,7 +28,7 @@ export const createSetData = configure(api => {
         ...options
       }),
       ...(
-        await multipartRequest(data, controller, options.headers)
+        await multipartRequest([data], controller, options.headers)
       )
     })
 

--- a/packages/ipfs-http-client/src/pubsub/publish.js
+++ b/packages/ipfs-http-client/src/pubsub/publish.js
@@ -27,7 +27,7 @@ export const createPublish = configure(api => {
       signal,
       searchParams,
       ...(
-        await multipartRequest(data, controller, options.headers)
+        await multipartRequest([data], controller, options.headers)
       )
     })
 

--- a/packages/ipfs-http-server/src/version.js
+++ b/packages/ipfs-http-server/src/version.js
@@ -1,2 +1,2 @@
 
-export const ipfsHttpClient = '^53.0.0'
+export const ipfsHttpClient = '^53.0.1'

--- a/packages/ipfs-message-port-client/package.json
+++ b/packages/ipfs-message-port-client/package.json
@@ -46,9 +46,11 @@
   },
   "dependencies": {
     "browser-readablestream-to-it": "^1.0.1",
+    "err-code": "^3.0.1",
     "ipfs-core-types": "^0.8.1",
     "ipfs-message-port-protocol": "^0.10.1",
     "ipfs-unixfs": "^6.0.3",
+    "it-peekable": "^1.0.2",
     "multiformats": "^9.4.1"
   },
   "devDependencies": {

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -89,7 +89,7 @@
     "ipfs-client": "^0.7.1",
     "ipfs-core-types": "^0.8.1",
     "ipfs-http-client": "^53.0.1",
-    "ipfs-interop": "^7.0.1",
+    "ipfs-interop": "^7.0.2",
     "ipfs-utils": "^9.0.2",
     "ipfsd-ctl": "^10.0.4",
     "iso-url": "^1.0.0",

--- a/packages/ipfs/src/package.js
+++ b/packages/ipfs/src/package.js
@@ -1,4 +1,4 @@
 
 export const name = 'ipfs'
-export const version = '0.59.0'
+export const version = '0.59.1'
 export const node = '>=14.0.0'


### PR DESCRIPTION
The types allow passing single items to `ipfs.addAll` and multiple items
to `ipfs.add`.

Instead, only accept single items to `ipfs.add` and streams of item to
`ipfs.addAll` and fail with a more helpful error message if you do not
do this.

BREAKING CHANGE: errors will now be thrown if multiple items are passed to `ipfs.add` or single items to `ipfs.addAll` (n.b. you can still pass a list of a single item to `ipfs.addAll`)