### PR TITLE
chore: re-enable testing examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -320,7 +320,7 @@ jobs:
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser angular
             repo: https://github.com/ipfs-examples/js-ipfs-browser-angular.git
-            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-core-types@$PWD/packages/ipfs-core-types
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-core-types@$PWD/packages/ipfs-core-types/dist
           - name: ipfs browser browserify
             repo: https://github.com/ipfs-examples/js-ipfs-browser-browserify.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
@@ -404,7 +404,7 @@ jobs:
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: types with typed js
             repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-typed-js.git
-            deps: ipfs-core@$PWD/packages/ipfs-core/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-core-types@$PWD/packages/ipfs-core-types/dist
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -368,7 +368,7 @@ jobs:
             deps: ipfs@$PWD/packages/ipfs/dist
           - name: ipfs custom ipld formats
             repo: https://github.com/ipfs-examples/js-ipfs-custom-ipld-formats.git
-            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs custom libp2p
             repo: https://github.com/ipfs-examples/js-ipfs-custom-libp2p.git
             deps: ipfs@$PWD/packages/ipfs/dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,52 +317,52 @@ jobs:
         example:
           - name: ipfs browser add readable stream
             repo: https://github.com/ipfs-examples/js-ipfs-browser-add-readable-stream.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser angular
             repo: https://github.com/ipfs-examples/js-ipfs-browser-angular.git
-            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-core-types@$PWD/packages/ipfs-core-types
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-core-types@$PWD/packages/ipfs-core-types
           - name: ipfs browser browserify
             repo: https://github.com/ipfs-examples/js-ipfs-browser-browserify.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser react
             repo: https://github.com/ipfs-examples/js-ipfs-browser-create-react-app.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser exchange files
             repo: https://github.com/ipfs-examples/js-ipfs-browser-exchange-files.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs@$PWD/packages/ipfs/dist,ipfs-core-types@$PWD/packages/ipfs-core-types/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs browser ipns publish
-            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
             repo: https://github.com/ipfs-examples/js-ipfs-browser-ipns-publish.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs browser mfs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-mfs.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           # - name: ipfs browser nextjs
           #   repo: https://github.com/ipfs-examples/js-ipfs-browser-nextjs.git
-          #   deps: ipfs@$PWD/packages/ipfs/dist
+          #   deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser parceljs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-parceljs.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser readable stream
             repo: https://github.com/ipfs-examples/js-ipfs-browser-readablestream.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser service worker
             repo: https://github.com/ipfs-examples/js-ipfs-browser-service-worker.git
-            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-message-port-client/dist@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-protocol@$PWD/packages/ipfs-message-port-protocol/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-message-port-client/dist@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-protocol@$PWD/packages/ipfs-message-port-protocol/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
           - name: ipfs browser sharing across tabs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-sharing-node-across-tabs.git
-            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-message-port-client@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-message-port-client@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
           - name: ipfs browser video streaming
             repo: https://github.com/ipfs-examples/js-ipfs-browser-video-streaming.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser vue
             repo: https://github.com/ipfs-examples/js-ipfs-browser-vue.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser webpack
             repo: https://github.com/ipfs-examples/js-ipfs-browser-webpack.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs circuit relaying
             repo: https://github.com/ipfs-examples/js-ipfs-circuit-relaying.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs custom ipfs repo
             repo: https://github.com/ipfs-examples/js-ipfs-custom-ipfs-repo.git
             deps: ipfs@$PWD/packages/ipfs/dist
@@ -371,13 +371,13 @@ jobs:
             deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs custom libp2p
             repo: https://github.com/ipfs-examples/js-ipfs-custom-libp2p.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs-http-client browser pubsub
             repo: https://github.com/ipfs-examples/js-ipfs-http-client-browser-pubsub.git
-            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist,ipfs@$PWD/packages/ipfs/dist
           - name: ipfs-http-client bundle webpack
             repo: https://github.com/ipfs-examples/js-ipfs-http-client-bundle-webpack.git
-            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist,ipfs@$PWD/packages/ipfs/dist
           - name: ipfs-http-client name api
             repo: https://github.com/ipfs-examples/js-ipfs-http-client-name-api.git
             deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
@@ -386,25 +386,25 @@ jobs:
             deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs 101
             repo: https://github.com/ipfs-examples/js-ipfs-101.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs-client add files
             repo: https://github.com/ipfs-examples/js-ipfs-ipfs-client-add-files.git
             deps: ipfs@$PWD/packages/ipfs/dist,ipfs-client@$PWD/packages/ipfs-client
           - name: ipfs electron js
             repo: https://github.com/ipfs-examples/js-ipfs-run-in-electron.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs running multiple nodes
             repo: https://github.com/ipfs-examples/js-ipfs-running-multiple-nodes.git
             deps: ipfs@$PWD/packages/ipfs/dist
           - name: ipfs traverse ipld graphs
             repo: https://github.com/ipfs-examples/js-ipfs-traverse-ipld-graphs.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: types with typescript
             repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-ts.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: types with typed js
             repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-typed-js.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -308,129 +308,129 @@ jobs:
           npm run link
       - run: npm run test:interface:message-port-client -- --since ${{ github.event.pull_request.base.sha }} --concurrency 1
 
-  # test-examples:
-  #   name: Test example ${{ matrix.example.name }}
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       example:
-  #         - name: ipfs browser add readable stream
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-add-readable-stream.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser angular
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-angular.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist,ipfs-core-types@$PWD/packages/ipfs-core-types
-  #         - name: ipfs browser browserify
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-browserify.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser react
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-create-react-app.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser exchange files
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-exchange-files.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser ipns publish
-  #           deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-ipns-publish.git
-  #         - name: ipfs browser mfs
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-mfs.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser nextjs
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-nextjs.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser parceljs
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-parceljs.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser readable stream
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-readablestream.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser service worker
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-service-worker.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist,ipfs-message-port-client/dist@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-protocol@$PWD/packages/ipfs-message-port-protocol/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
-  #         - name: ipfs browser sharing across tabs
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-sharing-node-across-tabs.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist,ipfs-message-port-client@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
-  #         - name: ipfs browser video streaming
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-video-streaming.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser vue
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-vue.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs browser webpack
-  #           repo: https://github.com/ipfs-examples/js-ipfs-browser-webpack.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs circuit relaying
-  #           repo: https://github.com/ipfs-examples/js-ipfs-circuit-relaying.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs custom ipfs repo
-  #           repo: https://github.com/ipfs-examples/js-ipfs-custom-ipfs-repo.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs custom ipld formats
-  #           repo: https://github.com/ipfs-examples/js-ipfs-custom-ipld-formats.git
-  #           deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
-  #         - name: ipfs custom libp2p
-  #           repo: https://github.com/ipfs-examples/js-ipfs-custom-libp2p.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs-http-client browser pubsub
-  #           repo: https://github.com/ipfs-examples/js-ipfs-http-client-browser-pubsub.git
-  #           deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist
-  #         - name: ipfs-http-client bundle webpack
-  #           repo: https://github.com/ipfs-examples/js-ipfs-http-client-bundle-webpack.git
-  #           deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist
-  #         - name: ipfs-http-client name api
-  #           repo: https://github.com/ipfs-examples/js-ipfs-http-client-name-api.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
-  #         - name: ipfs-http-client upload file
-  #           repo: https://github.com/ipfs-examples/js-ipfs-http-client-upload-file.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
-  #         - name: ipfs 101
-  #           repo: https://github.com/ipfs-examples/js-ipfs-101.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs-client add files
-  #           repo: https://github.com/ipfs-examples/js-ipfs-ipfs-client-add-files.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist,ipfs-client@$PWD/packages/ipfs-client
-  #         - name: ipfs electron js
-  #           repo: https://github.com/ipfs-examples/js-ipfs-run-in-electron.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs running multiple nodes
-  #           repo: https://github.com/ipfs-examples/js-ipfs-running-multiple-nodes.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: ipfs traverse ipld graphs
-  #           repo: https://github.com/ipfs-examples/js-ipfs-traverse-ipld-graphs.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: types with typescript
-  #           repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-ts.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #         - name: types with typed js
-  #           repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-typed-js.git
-  #           deps: ipfs@$PWD/packages/ipfs/dist
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 16
-  #     - uses: actions/cache@v2
-  #       id: cache
-  #       env:
-  #         CACHE_NAME: cache-node-modules
-  #       with:
-  #         path: |
-  #           ~/.npm
-  #           ./node_modules
-  #           ./packages/*/node_modules
-  #           ./packages/*/dist
-  #         key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
-  #     - name: Install Dependencies
-  #       if: steps.cache.outputs.cache-hit != 'true'
-  #       run: |
-  #         npm install
-  #         npm run build
-  #         npm run link
-  #     - uses: GabrielBB/xvfb-action@v1
-  #       name: Run npm run test:external -- -- -- ${{ matrix.example.repo }} --deps ${{ matrix.example.deps }}
-  #       with:
-  #         run: npm run test:external -- -- -- ${{ matrix.example.repo }} --deps ${{ matrix.example.deps }}
+  test-examples:
+    name: Test example ${{ matrix.example.name }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example:
+          - name: ipfs browser add readable stream
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-add-readable-stream.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser angular
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-angular.git
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-core-types@$PWD/packages/ipfs-core-types
+          - name: ipfs browser browserify
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-browserify.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser react
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-create-react-app.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser exchange files
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-exchange-files.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser ipns publish
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-ipns-publish.git
+          - name: ipfs browser mfs
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-mfs.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          # - name: ipfs browser nextjs
+          #   repo: https://github.com/ipfs-examples/js-ipfs-browser-nextjs.git
+          #   deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser parceljs
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-parceljs.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser readable stream
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-readablestream.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser service worker
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-service-worker.git
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-message-port-client/dist@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-protocol@$PWD/packages/ipfs-message-port-protocol/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
+          - name: ipfs browser sharing across tabs
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-sharing-node-across-tabs.git
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-message-port-client@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
+          - name: ipfs browser video streaming
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-video-streaming.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser vue
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-vue.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs browser webpack
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-webpack.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs circuit relaying
+            repo: https://github.com/ipfs-examples/js-ipfs-circuit-relaying.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs custom ipfs repo
+            repo: https://github.com/ipfs-examples/js-ipfs-custom-ipfs-repo.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs custom ipld formats
+            repo: https://github.com/ipfs-examples/js-ipfs-custom-ipld-formats.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs custom libp2p
+            repo: https://github.com/ipfs-examples/js-ipfs-custom-libp2p.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs-http-client browser pubsub
+            repo: https://github.com/ipfs-examples/js-ipfs-http-client-browser-pubsub.git
+            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs-http-client bundle webpack
+            repo: https://github.com/ipfs-examples/js-ipfs-http-client-bundle-webpack.git
+            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs-http-client name api
+            repo: https://github.com/ipfs-examples/js-ipfs-http-client-name-api.git
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs-http-client upload file
+            repo: https://github.com/ipfs-examples/js-ipfs-http-client-upload-file.git
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs 101
+            repo: https://github.com/ipfs-examples/js-ipfs-101.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs-client add files
+            repo: https://github.com/ipfs-examples/js-ipfs-ipfs-client-add-files.git
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-client@$PWD/packages/ipfs-client
+          - name: ipfs electron js
+            repo: https://github.com/ipfs-examples/js-ipfs-run-in-electron.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs running multiple nodes
+            repo: https://github.com/ipfs-examples/js-ipfs-running-multiple-nodes.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs traverse ipld graphs
+            repo: https://github.com/ipfs-examples/js-ipfs-traverse-ipld-graphs.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: types with typescript
+            repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-ts.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+          - name: types with typed js
+            repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-typed-js.git
+            deps: ipfs@$PWD/packages/ipfs/dist
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache
+        env:
+          CACHE_NAME: cache-node-modules
+        with:
+          path: |
+            ~/.npm
+            ./node_modules
+            ./packages/*/node_modules
+            ./packages/*/dist
+          key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          npm install
+          npm run build
+          npm run link
+      - uses: GabrielBB/xvfb-action@v1
+        name: Run npm run test:external -- -- -- ${{ matrix.example.repo }} --deps ${{ matrix.example.deps }}
+        with:
+          run: npm run test:external -- -- -- ${{ matrix.example.repo }} --deps ${{ matrix.example.deps }}
 
   test-externals:
     name: Test external ${{ matrix.external.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -389,7 +389,7 @@ jobs:
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs-client add files
             repo: https://github.com/ipfs-examples/js-ipfs-ipfs-client-add-files.git
-            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-client@$PWD/packages/ipfs-client
+            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-client@$PWD/packages/ipfs-client/dist
           - name: ipfs electron js
             repo: https://github.com/ipfs-examples/js-ipfs-run-in-electron.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist

--- a/packages/ipfs-http-response/package.json
+++ b/packages/ipfs-http-response/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "lint": "aegir ts -p check && aegir lint",
     "clean": "rimraf ./dist",
-    "build": "aegir build",
+    "build": "aegir build --no-bundle",
     "pretest": "aegir build --esm-tests",
     "test": "aegir test -t node",
     "test:node": "aegir test -t node",
@@ -70,7 +70,6 @@
     "it-reader": "^3.0.0",
     "it-to-stream": "^1.0.0",
     "mime-types": "^2.1.30",
-    "multiformats": "^9.4.1",
     "p-try-each": "^1.0.1"
   },
   "devDependencies": {
@@ -80,10 +79,8 @@
     "ipfs-core": "^0.11.1",
     "ipfsd-ctl": "^10.0.4",
     "it-all": "^1.0.4",
-    "path": "^0.12.7",
     "rimraf": "^3.0.2",
-    "uint8arrays": "^3.0.0",
-    "util": "^0.12.3"
+    "uint8arrays": "^3.0.0"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>",

--- a/packages/ipfs-http-response/package.json
+++ b/packages/ipfs-http-response/package.json
@@ -39,7 +39,7 @@
     "pretest": "aegir build --esm-tests",
     "test": "aegir test -t node",
     "test:node": "aegir test -t node",
-    "dep-check": "aegir dep-check -i rimraf"
+    "dep-check": "aegir dep-check -i rimraf -i global"
   },
   "browser": {
     "file-type": "file-type/browser",
@@ -76,6 +76,7 @@
     "@types/ejs": "^3.1.0",
     "aegir": "^35.1.1",
     "get-stream": "^6.0.0",
+    "global": "^4.4.0",
     "ipfs-core": "^0.11.1",
     "ipfsd-ctl": "^10.0.4",
     "it-all": "^1.0.4",

--- a/packages/ipfs-http-response/package.json
+++ b/packages/ipfs-http-response/package.json
@@ -34,13 +34,12 @@
   },
   "scripts": {
     "lint": "aegir ts -p check && aegir lint",
+    "clean": "rimraf ./dist",
     "build": "aegir build",
-    "release": "aegir release --target node",
-    "release-minor": "aegir release --type minor --target node",
-    "release-major": "aegir release --type major --target node",
     "pretest": "aegir build --esm-tests",
     "test": "aegir test -t node",
-    "test:node": "aegir test -t node"
+    "test:node": "aegir test -t node",
+    "dep-check": "aegir dep-check -i rimraf"
   },
   "browser": {
     "file-type": "file-type/browser",
@@ -82,6 +81,7 @@
     "ipfsd-ctl": "^10.0.4",
     "it-all": "^1.0.4",
     "path": "^0.12.7",
+    "rimraf": "^3.0.2",
     "uint8arrays": "^3.0.0",
     "util": "^0.12.3"
   },


### PR DESCRIPTION
Re-enables testing all examples except nextjs which needs a new release before the fix to enhanced-resolve will be pulled in.