### PR TITLE
fix: do not lose files when writing files into subshards that contain other subshards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -365,7 +365,7 @@ jobs:
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs custom ipfs repo
             repo: https://github.com/ipfs-examples/js-ipfs-custom-ipfs-repo.git
-            deps: ipfs@$PWD/packages/ipfs/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs custom ipld formats
             repo: https://github.com/ipfs-examples/js-ipfs-custom-ipld-formats.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -347,7 +347,7 @@ jobs:
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser service worker
             repo: https://github.com/ipfs-examples/js-ipfs-browser-service-worker.git
-            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-message-port-client/dist@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-protocol@$PWD/packages/ipfs-message-port-protocol/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-message-port-client@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-protocol@$PWD/packages/ipfs-message-port-protocol/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist
           - name: ipfs browser sharing across tabs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-sharing-node-across-tabs.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-message-port-client@$PWD/packages/ipfs-message-port-client/dist,ipfs-message-port-server@$PWD/packages/ipfs-message-port-server/dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,7 +380,7 @@ jobs:
             deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist,ipfs@$PWD/packages/ipfs/dist
           - name: ipfs-http-client name api
             repo: https://github.com/ipfs-examples/js-ipfs-http-client-name-api.git
-            deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs-http-client upload file
             repo: https://github.com/ipfs-examples/js-ipfs-http-client-upload-file.git
             deps: ipfs@$PWD/packages/ipfs/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist

--- a/packages/interface-ipfs-core/src/utils/dump-shard.js
+++ b/packages/interface-ipfs-core/src/utils/dump-shard.js
@@ -1,0 +1,41 @@
+import { UnixFS } from 'ipfs-unixfs'
+
+/**
+ * @param {string} path
+ * @param {import('ipfs-core-types').IPFS} ipfs
+ */
+export default async function dumpShard (path, ipfs) {
+  const stats = await ipfs.files.stat(path)
+  const { value: node } = await ipfs.dag.get(stats.cid)
+  const entry = UnixFS.unmarshal(node.Data)
+
+  if (entry.type !== 'hamt-sharded-directory') {
+    throw new Error('Not a shard')
+  }
+
+  await dumpSubShard(stats.cid, ipfs)
+}
+
+/**
+ * @param {import('multiformats/cid').CID} cid
+ * @param {import('ipfs-core-types').IPFS} ipfs
+ * @param {string} prefix
+ */
+async function dumpSubShard (cid, ipfs, prefix = '') {
+  const { value: node } = await ipfs.dag.get(cid)
+  const entry = UnixFS.unmarshal(node.Data)
+
+  if (entry.type !== 'hamt-sharded-directory') {
+    throw new Error('Not a shard')
+  }
+
+  for (const link of node.Links) {
+    const { value: subNode } = await ipfs.dag.get(link.Hash)
+    const subEntry = UnixFS.unmarshal(subNode.Data)
+    console.info(`${prefix}${link.Name}`, ' ', subEntry.type) // eslint-disable-line no-console
+
+    if (link.Name.length === 2) {
+      await dumpSubShard(link.Hash, ipfs, `${prefix}  `)
+    }
+  }
+}

--- a/packages/ipfs-core/src/components/files/utils/add-link.js
+++ b/packages/ipfs-core/src/components/files/utils/add-link.js
@@ -339,7 +339,7 @@ const addFileToShardedDirectory = async (context, options) => {
     // subshard hasn't been loaded, descend to the next level of the HAMT
     if (!path[index]) {
       log(`Loaded new subshard ${segment.prefix}`)
-      await recreateHamtLevel(subShard.Links, rootBucket, segment.bucket, parseInt(segment.prefix, 16))
+      await recreateHamtLevel(context, subShard.Links, rootBucket, segment.bucket, parseInt(segment.prefix, 16))
 
       const position = await rootBucket._findNewBucketAndPos(file.name)
 
@@ -355,7 +355,7 @@ const addFileToShardedDirectory = async (context, options) => {
     const nextSegment = path[index]
 
     // add next levels worth of links to bucket
-    await addLinksToHamtBucket(subShard.Links, nextSegment.bucket, rootBucket)
+    await addLinksToHamtBucket(context, subShard.Links, nextSegment.bucket, rootBucket)
 
     nextSegment.node = subShard
   }

--- a/packages/ipfs-core/src/components/files/write.js
+++ b/packages/ipfs-core/src/components/files/write.js
@@ -3,7 +3,6 @@ import { importer } from 'ipfs-unixfs-importer'
 import {
   decode
 } from '@ipld/dag-pb'
-import { sha256, sha512 } from 'multiformats/hashes/sha2'
 import { createStat } from './stat.js'
 import { createMkdir } from './mkdir.js'
 import { addLink } from './utils/add-link.js'
@@ -293,17 +292,7 @@ const write = async (context, source, destination, options) => {
     mtime = destination.unixfs.mtime
   }
 
-  let hasher
-  switch (options.hashAlg) {
-    case 'sha2-256':
-      hasher = sha256
-      break
-    case 'sha2-512':
-      hasher = sha512
-      break
-    default:
-      throw new Error(`TODO vmx 2021-03-31: Proper error message for unsupported hash algorithms like ${options.hashAlg}`)
-  }
+  const hasher = await context.hashers.getHasher(options.hashAlg)
 
   const result = await last(importer([{
     content: content,


### PR DESCRIPTION
When writing a file into a hamt shard we hash the filename to figure out where in the
shard to place the file.

If the hash means that we end up adding the file into an existing subshard that also
contains another subshard, we should populate the other subshard's children otherwise
they will not be there when we calculate the new CID for the subshard and they will
be lost.

Fixes #3921