### PR TITLE
docs: add CORS to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We've come a long way, but this project is still in Alpha, lots of development i
 ## Getting started
 
 * Read the [docs](https://github.com/ipfs/js-ipfs/tree/master/docs)
+* Ensure CORS is [correctly configured](https://github.com/ipfs/js-ipfs/blob/master/docs/CORS.md) for use with the HTTP client
 * Look into the [examples](https://github.com/ipfs-examples/js-ipfs-examples/tree/master) to learn how to spawn an IPFS node in Node.js and in the Browser
 * Consult the [Core API docs](https://github.com/ipfs/js-ipfs/tree/master/docs/core-api) to see what you can do with an IPFS node
 * Visit https://dweb-primer.ipfs.io to learn about IPFS and the concepts that underpin it


### PR DESCRIPTION
Fixes #3597.

I assumed that the request is to have a link near the top for the CORS configuration. If the idea is to rework where those docs are placed and also make it easier to find through the docs directory, let me know.
