### PR TITLE
fix: pass hasher loader to bitswap

### DIFF
--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -83,7 +83,7 @@
     "hashlru": "^2.3.0",
     "interface-blockstore": "^2.0.2",
     "interface-datastore": "^6.0.2",
-    "ipfs-bitswap": "^7.0.0",
+    "ipfs-bitswap": "^7.0.1",
     "ipfs-core-config": "^0.1.2",
     "ipfs-core-types": "^0.8.2",
     "ipfs-core-utils": "^0.12.0",

--- a/packages/ipfs-core/src/components/index.js
+++ b/packages/ipfs-core/src/components/index.js
@@ -155,6 +155,7 @@ class IPFS {
       mfsPreload,
       print,
       keychain,
+      hashers: this.hashers,
       options
     })
 

--- a/packages/ipfs-core/src/components/network.js
+++ b/packages/ipfs-core/src/components/network.js
@@ -14,6 +14,7 @@ import { BlockStorage } from '../block-storage.js'
  * @property {Repo} options.repo
  * @property {Print} options.print
  * @property {IPFSOptions} options.options
+ * @property {import('ipfs-core-utils/multihashes').Multihashes} options.hashers
  *
  * @typedef {import('ipfs-core-types/src/config').Config} IPFSConfig
  * @typedef {import('../types').Options} IPFSOptions
@@ -44,7 +45,7 @@ export class Network {
   /**
    * @param {Options} options
    */
-  static async start ({ peerId, repo, print, options }) {
+  static async start ({ peerId, repo, print, hashers, options }) {
     // Need to ensure that repo is open as it could have been closed between
     // `init` and `start`.
     if (repo.closed) {
@@ -73,7 +74,10 @@ export class Network {
       print(`Swarm listening on ${ma}/p2p/${peerId.toB58String()}`)
     }
 
-    const bitswap = createBitswap(libp2p, repo.blocks, { statsEnabled: true })
+    const bitswap = createBitswap(libp2p, repo.blocks, {
+      statsEnabled: true,
+      hashLoader: hashers
+    })
     await bitswap.start()
 
     const blockstore = new BlockStorage(repo.blocks, bitswap)

--- a/packages/ipfs-core/src/components/start.js
+++ b/packages/ipfs-core/src/components/start.js
@@ -10,9 +10,10 @@ import { Service } from '../utils/service.js'
  * @param {import('../types').MfsPreload} config.mfsPreload
  * @param {import('./ipns').IPNSAPI} config.ipns
  * @param {import('libp2p/src/keychain')} config.keychain
+ * @param {import('ipfs-core-utils/multihashes').Multihashes} config.hashers
  * @param {import('../types').Options} config.options
  */
-export function createStart ({ network, preload, peerId, keychain, repo, ipns, mfsPreload, print, options }) {
+export function createStart ({ network, preload, peerId, keychain, repo, ipns, mfsPreload, print, hashers, options }) {
   /**
    * @type {import('ipfs-core-types/src/root').API["start"]}
    */
@@ -21,6 +22,7 @@ export function createStart ({ network, preload, peerId, keychain, repo, ipns, m
       peerId,
       repo,
       print,
+      hashers,
       options
     })
 


### PR DESCRIPTION
To allow loading esoteric hashing algorithms encountered in CID prefixes found in bitswap messages, pass the configurable hasher loader to bitswap.