### PR TITLE
fix: isOnline returns the type 'Promise' (#3953)

### DIFF
--- a/packages/ipfs-core-types/src/root.ts
+++ b/packages/ipfs-core-types/src/root.ts
@@ -135,7 +135,7 @@ export interface API<OptionExtension = {}> {
    * Returns true if this IPFS node is online - that is, it's listening on network addresses
    * for incoming connections
    */
-  isOnline: () => boolean
+  isOnline: () => Promise<boolean>
 }
 
 export interface IPFSEntry {


### PR DESCRIPTION
The function `isOnline` defined in `packages/ipfs-core-types/src/root.ts` returns the type `Promise<boolean>` .