### PR TITLE
feat: Add support for dag-jose

### DIFF
--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -58,6 +58,7 @@
     "@ipld/dag-pb": "^2.1.3",
     "abort-controller": "^3.0.0",
     "any-signal": "^2.1.2",
+    "dag-jose": "^1.0.0",
     "debug": "^4.1.1",
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.8.4",

--- a/packages/ipfs-http-client/src/index.js
+++ b/packages/ipfs-http-client/src/index.js
@@ -5,6 +5,7 @@ import { Multicodecs } from 'ipfs-core-utils/multicodecs'
 import { Multihashes } from 'ipfs-core-utils/multihashes'
 import * as dagPB from '@ipld/dag-pb'
 import * as dagCBOR from '@ipld/dag-cbor'
+import * as dagJOSE from 'dag-jose'
 import { identity } from 'multiformats/hashes/identity'
 import { bases, hashes, codecs } from 'multiformats/basics'
 import { createBitswap } from './bitswap/index.js'
@@ -79,7 +80,7 @@ export function create (options = {}) {
   /** @type {BlockCodec[]} */
   const blockCodecs = Object.values(codecs);
 
-  [dagPB, dagCBOR, id].concat((options.ipld && options.ipld.codecs) || []).forEach(codec => blockCodecs.push(codec))
+  [dagPB, dagCBOR, dagJOSE, id].concat((options.ipld && options.ipld.codecs) || []).forEach(codec => blockCodecs.push(codec))
 
   const multicodecs = new Multicodecs({
     codecs: blockCodecs,


### PR DESCRIPTION
Support for dag-jose was recently merged into go-ipfs https://github.com/ipfs/go-ipfs/pull/8569. This PR adds support for dag-jose in the `js-ipfs-http-client` so that the new codec in go-ipfs can be used from javascript environments.

A few notes:
- This is not super urgent as it's easy to plug in additional ipld codecs in javascript. More of a nice to have to be symmetric with go-ipfs
- Maybe the `ipfs-core` package should also support dag-jose?

