### PR TITLE
chore: add default option extentions

### DIFF
--- a/packages/ipfs-cli/src/commands/get.js
+++ b/packages/ipfs-cli/src/commands/get.js
@@ -43,7 +43,7 @@ export default {
     compressionLevel: {
       alias: ['l', 'compression-level'],
       type: 'number',
-      desc: 'The level of compression (1-9)',
+      desc: 'The level of compression (-1-9)',
       default: 6
     }
   },
@@ -57,7 +57,7 @@ export default {
    * @param {number} argv.timeout
    * @param {boolean} argv.archive
    * @param {boolean} argv.compress
-   * @param {number} argv.compressionLevel
+   * @param {-1 | 0 | 1 | 2 | 3 | 4 | 5 | 6| 7 | 8| 9} argv.compressionLevel
    */
   async handler ({ ctx: { ipfs, print }, ipfsPath, output, force, timeout, archive, compress, compressionLevel }) {
     print(`Saving file(s) ${stripControlCharacters(ipfsPath)}`)

--- a/packages/ipfs-core-config/src/init-assets.js
+++ b/packages/ipfs-core-config/src/init-assets.js
@@ -5,7 +5,7 @@ import assets from './init-files/init-docs/index.js'
  * Add the default assets to the repo.
  *
  * @param {object} arg
- * @param {import('ipfs-core-types/src/root').API["addAll"]} arg.addAll
+ * @param {import('ipfs-core-types/src/root').API<{}>["addAll"]} arg.addAll
  * @param {(msg: string) => void} arg.print
  */
 export async function initAssets ({ addAll, print }) {

--- a/packages/ipfs-core-types/src/root.ts
+++ b/packages/ipfs-core-types/src/root.ts
@@ -259,7 +259,7 @@ export interface CatOptions extends AbortOptions, PreloadOptions {
 export interface GetOptions extends AbortOptions, PreloadOptions {
   archive?: boolean
   compress?: boolean
-  compressionLevel?: number
+  compressionLevel?: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6| 7 | 8| 9
 }
 
 export interface ListOptions extends AbortOptions, PreloadOptions {

--- a/packages/ipfs-core/src/components/add-all/index.js
+++ b/packages/ipfs-core/src/components/add-all/index.js
@@ -22,7 +22,7 @@ export function createAddAll ({ repo, preload, options }) {
   const isShardingEnabled = options && options.sharding
 
   /**
-   * @type {import('ipfs-core-types/src/root').API["addAll"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["addAll"]}
    */
   async function * addAll (source, options = {}) {
     const opts = mergeOptions({

--- a/packages/ipfs-core/src/components/add.js
+++ b/packages/ipfs-core/src/components/add.js
@@ -3,11 +3,11 @@ import { normaliseInput } from 'ipfs-core-utils/files/normalise-input-single'
 
 /**
  * @param {Object} context
- * @param {import('ipfs-core-types/src/root').API["addAll"]} context.addAll
+ * @param {import('ipfs-core-types/src/root').API<{}>["addAll"]} context.addAll
  */
 export function createAdd ({ addAll }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["add"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["add"]}
    */
   async function add (entry, options = {}) {
     // @ts-ignore TODO: https://github.com/ipfs/js-ipfs/issues/3290

--- a/packages/ipfs-core/src/components/bitswap/stat.js
+++ b/packages/ipfs-core/src/components/bitswap/stat.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createStat ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/bitswap').API["stat"]}
+   * @type {import('ipfs-core-types/src/bitswap').API<{}>["stat"]}
    */
   async function stat (options = {}) {
     /** @type {import('ipfs-bitswap').IPFSBitswap} */

--- a/packages/ipfs-core/src/components/bitswap/unwant.js
+++ b/packages/ipfs-core/src/components/bitswap/unwant.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createUnwant ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/bitswap').API["unwant"]}
+   * @type {import('ipfs-core-types/src/bitswap').API<{}>["unwant"]}
    */
   async function unwant (cids, options = {}) {
     const { bitswap } = await network.use(options)

--- a/packages/ipfs-core/src/components/bitswap/wantlist-for-peer.js
+++ b/packages/ipfs-core/src/components/bitswap/wantlist-for-peer.js
@@ -7,7 +7,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createWantlistForPeer ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/bitswap').API["wantlistForPeer"]}
+   * @type {import('ipfs-core-types/src/bitswap').API<{}>["wantlistForPeer"]}
    */
   async function wantlistForPeer (peerId, options = {}) {
     const { bitswap } = await network.use(options)

--- a/packages/ipfs-core/src/components/bitswap/wantlist.js
+++ b/packages/ipfs-core/src/components/bitswap/wantlist.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createWantlist ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/bitswap').API["wantlist"]}
+   * @type {import('ipfs-core-types/src/bitswap').API<{}>["wantlist"]}
    */
   async function wantlist (options = {}) {
     const { bitswap } = await network.use(options)

--- a/packages/ipfs-core/src/components/block/get.js
+++ b/packages/ipfs-core/src/components/block/get.js
@@ -7,7 +7,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createGet ({ preload, repo }) {
   /**
-   * @type {import('ipfs-core-types/src/block').API["get"]}
+   * @type {import('ipfs-core-types/src/block').API<{}>["get"]}
    */
   async function get (cid, options = {}) { // eslint-disable-line require-await
     if (options.preload !== false) {

--- a/packages/ipfs-core/src/components/block/put.js
+++ b/packages/ipfs-core/src/components/block/put.js
@@ -15,7 +15,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createPut ({ codecs, hashers, repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/block').API["put"]}
+   * @type {import('ipfs-core-types/src/block').API<{}>["put"]}
    */
   async function put (block, options = {}) {
     const release = options.pin ? await repo.gcLock.readLock() : null

--- a/packages/ipfs-core/src/components/block/rm.js
+++ b/packages/ipfs-core/src/components/block/rm.js
@@ -14,7 +14,7 @@ const BLOCK_RM_CONCURRENCY = 8
  */
 export function createRm ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/block').API["rm"]}
+   * @type {import('ipfs-core-types/src/block').API<{}>["rm"]}
    */
   async function * rm (cids, options = {}) {
     if (!Array.isArray(cids)) {

--- a/packages/ipfs-core/src/components/block/stat.js
+++ b/packages/ipfs-core/src/components/block/stat.js
@@ -9,7 +9,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
 
 export function createStat ({ repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/block').API["stat"]}
+   * @type {import('ipfs-core-types/src/block').API<{}>["stat"]}
    */
   async function stat (cid, options = {}) {
     cid = cleanCid(cid)

--- a/packages/ipfs-core/src/components/bootstrap/add.js
+++ b/packages/ipfs-core/src/components/bootstrap/add.js
@@ -7,7 +7,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createAdd ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/bootstrap').API["add"]}
+   * @type {import('ipfs-core-types/src/bootstrap').API<{}>["add"]}
    */
   async function add (multiaddr, options = {}) {
     if (!isValidMultiaddr(multiaddr)) {

--- a/packages/ipfs-core/src/components/bootstrap/clear.js
+++ b/packages/ipfs-core/src/components/bootstrap/clear.js
@@ -7,7 +7,7 @@ import { Multiaddr } from 'multiaddr'
  */
 export function createClear ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/bootstrap').API["clear"]}
+   * @type {import('ipfs-core-types/src/bootstrap').API<{}>["clear"]}
    */
   async function clear (options = {}) {
     /** @type {import('ipfs-core-types/src/config').Config} */

--- a/packages/ipfs-core/src/components/bootstrap/list.js
+++ b/packages/ipfs-core/src/components/bootstrap/list.js
@@ -7,7 +7,7 @@ import { Multiaddr } from 'multiaddr'
  */
 export function createList ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/bootstrap').API["list"]}
+   * @type {import('ipfs-core-types/src/bootstrap').API<{}>["list"]}
    */
   async function list (options = {}) {
     /** @type {string[]|null} */

--- a/packages/ipfs-core/src/components/bootstrap/reset.js
+++ b/packages/ipfs-core/src/components/bootstrap/reset.js
@@ -8,7 +8,7 @@ import { Multiaddr } from 'multiaddr'
  */
 export function createReset ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/bootstrap').API["reset"]}
+   * @type {import('ipfs-core-types/src/bootstrap').API<{}>["reset"]}
    */
   async function reset (options = {}) {
     /** @type {import('ipfs-core-types/src/config').Config} */

--- a/packages/ipfs-core/src/components/bootstrap/rm.js
+++ b/packages/ipfs-core/src/components/bootstrap/rm.js
@@ -7,7 +7,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createRm ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/bootstrap').API["rm"]}
+   * @type {import('ipfs-core-types/src/bootstrap').API<{}>["rm"]}
    */
   async function rm (multiaddr, options = {}) {
     if (!isValidMultiaddr(multiaddr)) {

--- a/packages/ipfs-core/src/components/cat.js
+++ b/packages/ipfs-core/src/components/cat.js
@@ -12,7 +12,7 @@ import { CID } from 'multiformats/cid'
  */
 export function createCat ({ repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["cat"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["cat"]}
    */
   async function * cat (ipfsPath, options = {}) {
     ipfsPath = normalizeCidPath(ipfsPath)

--- a/packages/ipfs-core/src/components/config/index.js
+++ b/packages/ipfs-core/src/components/config/index.js
@@ -21,7 +21,7 @@ export function createConfig ({ repo }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/config').API["getAll"]}
+   * @type {import('ipfs-core-types/src/config').API<{}>["getAll"]}
    */
   async function getAll (options = {}) { // eslint-disable-line require-await
     // @ts-ignore TODO: move config typedefs into ipfs-repo
@@ -29,7 +29,7 @@ export function createConfig ({ repo }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/config').API["get"]}
+   * @type {import('ipfs-core-types/src/config').API<{}>["get"]}
    */
   async function get (key, options) { // eslint-disable-line require-await
     if (!key) {
@@ -41,21 +41,21 @@ export function createConfig ({ repo }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/config').API["set"]}
+   * @type {import('ipfs-core-types/src/config').API<{}>["set"]}
    */
   async function set (key, value, options) { // eslint-disable-line require-await
     return repo.config.set(key, value, options)
   }
 
   /**
-   * @type {import('ipfs-core-types/src/config').API["replace"]}
+   * @type {import('ipfs-core-types/src/config').API<{}>["replace"]}
    */
   async function replace (value, options) { // eslint-disable-line require-await
     return repo.config.replace(value, options)
   }
 
   /**
-   * @type {import('ipfs-core-types/src/config/profiles').API["apply"]}
+   * @type {import('ipfs-core-types/src/config/profiles').API<{}>["apply"]}
    */
   async function applyProfile (profileName, options = { dryRun: false }) {
     const { dryRun } = options
@@ -91,7 +91,7 @@ export function createConfig ({ repo }) {
 }
 
 /**
- * @type {import('ipfs-core-types/src/config/profiles').API["list"]}
+ * @type {import('ipfs-core-types/src/config/profiles').API<{}>["list"]}
  */
 async function listProfiles (_options) { // eslint-disable-line require-await
   return Object.keys(profiles).map(name => ({

--- a/packages/ipfs-core/src/components/dag/export.js
+++ b/packages/ipfs-core/src/components/dag/export.js
@@ -31,7 +31,7 @@ const NO_LINKS_CODECS = [
  */
 export function createExport ({ repo, preload, codecs }) {
   /**
-   * @type {import('ipfs-core-types/src/dag').API["export"]}
+   * @type {import('ipfs-core-types/src/dag').API<{}>["export"]}
    */
   async function * dagExport (root, options = {}) {
     if (options.preload !== false) {

--- a/packages/ipfs-core/src/components/dag/get.js
+++ b/packages/ipfs-core/src/components/dag/get.js
@@ -12,7 +12,7 @@ import errCode from 'err-code'
  */
 export function createGet ({ codecs, repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/dag').API["get"]}
+   * @type {import('ipfs-core-types/src/dag').API<{}>["get"]}
    */
   const get = async function get (cid, options = {}) {
     if (options.preload !== false) {

--- a/packages/ipfs-core/src/components/dag/import.js
+++ b/packages/ipfs-core/src/components/dag/import.js
@@ -19,7 +19,7 @@ const log = debug('ipfs:components:dag:import')
  */
 export function createImport ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/dag').API["import"]}
+   * @type {import('ipfs-core-types/src/dag').API<{}>["import"]}
    */
   async function * dagImport (sources, options = {}) {
     const release = await repo.gcLock.readLock()

--- a/packages/ipfs-core/src/components/dag/put.js
+++ b/packages/ipfs-core/src/components/dag/put.js
@@ -10,7 +10,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createPut ({ repo, codecs, hashers, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/dag').API["put"]}
+   * @type {import('ipfs-core-types/src/dag').API<{}>["put"]}
    */
   async function put (dagNode, options = {}) {
     const release = options.pin ? await repo.gcLock.readLock() : null

--- a/packages/ipfs-core/src/components/dag/resolve.js
+++ b/packages/ipfs-core/src/components/dag/resolve.js
@@ -10,7 +10,7 @@ import { resolvePath } from '../../utils.js'
  */
 export function createResolve ({ repo, codecs, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/dag').API["resolve"]}
+   * @type {import('ipfs-core-types/src/dag').API<{}>["resolve"]}
    */
   async function dagResolve (ipfsPath, options = {}) {
     const {

--- a/packages/ipfs-core/src/components/dht.js
+++ b/packages/ipfs-core/src/components/dht.js
@@ -157,7 +157,7 @@ function mapEvent (event) {
 export function createDht ({ network, repo, peerId }) {
   const { get, put, findProvs, findPeer, provide, query } = {
     /**
-     * @type {import('ipfs-core-types/src/dht').API["get"]}
+     * @type {import('ipfs-core-types/src/dht').API<{}>["get"]}
      */
     async * get (key, options = {}) {
       const { libp2p } = await use(network, peerId, options)
@@ -168,7 +168,7 @@ export function createDht ({ network, repo, peerId }) {
     },
 
     /**
-     * @type {import('ipfs-core-types/src/dht').API["put"]}
+     * @type {import('ipfs-core-types/src/dht').API<{}>["put"]}
      */
     async * put (key, value, options) {
       const { libp2p } = await use(network, peerId, options)
@@ -179,9 +179,9 @@ export function createDht ({ network, repo, peerId }) {
     },
 
     /**
-     * @type {import('ipfs-core-types/src/dht').API["findProvs"]}
+     * @type {import('ipfs-core-types/src/dht').API<{}>["findProvs"]}
      */
-    async * findProvs (cid, options = { numProviders: 20 }) {
+    async * findProvs (cid, options = {}) {
       const { libp2p } = await use(network, peerId, options)
 
       yield * map(libp2p._dht.findProviders(cid, {
@@ -190,7 +190,7 @@ export function createDht ({ network, repo, peerId }) {
     },
 
     /**
-     * @type {import('ipfs-core-types/src/dht').API["findPeer"]}
+     * @type {import('ipfs-core-types/src/dht').API<{}>["findPeer"]}
      */
     async * findPeer (peerIdToFind, options = {}) {
       const { libp2p } = await use(network, peerId, options)
@@ -201,7 +201,7 @@ export function createDht ({ network, repo, peerId }) {
     },
 
     /**
-     * @type {import('ipfs-core-types/src/dht').API["provide"]}
+     * @type {import('ipfs-core-types/src/dht').API<{}>["provide"]}
      */
     async * provide (cid, options = { recursive: false }) {
       const { libp2p } = await use(network, peerId, options)
@@ -222,7 +222,7 @@ export function createDht ({ network, repo, peerId }) {
     },
 
     /**
-     * @type {import('ipfs-core-types/src/dht').API["query"]}
+     * @type {import('ipfs-core-types/src/dht').API<{}>["query"]}
      */
     async * query (peerIdToQuery, options = {}) {
       const { libp2p } = await use(network, peerId, options)

--- a/packages/ipfs-core/src/components/dns.js
+++ b/packages/ipfs-core/src/components/dns.js
@@ -17,7 +17,7 @@ function fqdnFixups (domain) {
 
 export function createDns () {
   /**
-   * @type {import('ipfs-core-types/src/root').API["dns"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["dns"]}
    */
   const resolveDNS = async (domain, options = { recursive: true }) => { // eslint-disable-line require-await
     if (typeof domain !== 'string') {

--- a/packages/ipfs-core/src/components/files/chmod.js
+++ b/packages/ipfs-core/src/components/files/chmod.js
@@ -214,7 +214,7 @@ function calculateMode (mode, metadata) {
  */
 export function createChmod (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["chmod"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["chmod"]}
    */
   async function mfsChmod (path, mode, options = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/cp.js
+++ b/packages/ipfs-core/src/components/files/cp.js
@@ -47,7 +47,7 @@ const defaultOptions = {
  */
 export function createCp (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["cp"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["cp"]}
    */
   async function mfsCp (from, to, opts = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/flush.js
+++ b/packages/ipfs-core/src/components/files/flush.js
@@ -21,7 +21,7 @@ const defaultOptions = {}
  */
 export function createFlush (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["flush"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["flush"]}
    */
   async function mfsFlush (path, options = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/ls.js
+++ b/packages/ipfs-core/src/components/files/ls.js
@@ -33,7 +33,7 @@ const toOutput = (fsEntry) => {
  */
 export function createLs (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["ls"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["ls"]}
    */
   async function * mfsLs (path, options = {}) {
     const mfsPath = await toMfsPath(context, path, options)

--- a/packages/ipfs-core/src/components/files/mkdir.js
+++ b/packages/ipfs-core/src/components/files/mkdir.js
@@ -47,7 +47,7 @@ const defaultOptions = {
  */
 export function createMkdir (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["mkdir"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["mkdir"]}
    */
   async function mfsMkdir (path, options = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/mv.js
+++ b/packages/ipfs-core/src/components/files/mv.js
@@ -34,7 +34,7 @@ const defaultOptions = {
  */
 export function createMv (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["mv"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["mv"]}
    */
   async function mfsMv (from, to, options = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/read.js
+++ b/packages/ipfs-core/src/components/files/read.js
@@ -28,7 +28,7 @@ const defaultOptions = {
  */
 export function createRead (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["read"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["read"]}
    */
   function mfsRead (path, options = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/rm.js
+++ b/packages/ipfs-core/src/components/files/rm.js
@@ -38,7 +38,7 @@ const defaultOptions = {
  */
 export function createRm (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["rm"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["rm"]}
    */
   async function mfsRm (paths, opts = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/stat.js
+++ b/packages/ipfs-core/src/components/files/stat.js
@@ -33,7 +33,7 @@ const defaultOptions = {
  */
 export function createStat (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["stat"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["stat"]}
    */
   async function mfsStat (path, options = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/touch.js
+++ b/packages/ipfs-core/src/components/files/touch.js
@@ -43,7 +43,7 @@ const defaultOptions = {
  */
 export function createTouch (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["touch"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["touch"]}
    */
   async function mfsTouch (path, options = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/files/write.js
+++ b/packages/ipfs-core/src/components/files/write.js
@@ -82,7 +82,7 @@ const defaultOptions = {
  */
 export function createWrite (context) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["write"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["write"]}
    */
   async function mfsWrite (path, content, opts = {}) {
     /** @type {DefaultOptions} */

--- a/packages/ipfs-core/src/components/get.js
+++ b/packages/ipfs-core/src/components/get.js
@@ -21,11 +21,11 @@ const DEFAULT_COMPRESSION_LEVEL = 6
  */
 export function createGet ({ repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["get"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["get"]}
    */
   async function * get (ipfsPath, options = {}) {
-    if (options.compressionLevel < 0 || options.compressionLevel > 9) {
-      throw errCode(new Error('Compression level must be between 1 and 9'), 'ERR_INVALID_PARAMS')
+    if (options.compressionLevel != null && (options.compressionLevel < -1 || options.compressionLevel > 9)) {
+      throw errCode(new Error('Compression level must be between -1 and 9'), 'ERR_INVALID_PARAMS')
     }
 
     if (options.preload !== false) {

--- a/packages/ipfs-core/src/components/id.js
+++ b/packages/ipfs-core/src/components/id.js
@@ -12,7 +12,7 @@ import { NotStartedError } from '../errors.js'
  */
 export function createId ({ peerId, network }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["id"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["id"]}
    */
   async function id (options = {}) { // eslint-disable-line require-await
     if (options.peerId === peerId.toB58String()) {

--- a/packages/ipfs-core/src/components/key/export.js
+++ b/packages/ipfs-core/src/components/key/export.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createExport ({ keychain }) {
   /**
-   * @type {import('ipfs-core-types/src/key').API["export"]}
+   * @type {import('ipfs-core-types/src/key').API<{}>["export"]}
    */
   const exportKey = (name, password) =>
     keychain.exportKey(name, password)

--- a/packages/ipfs-core/src/components/key/gen.js
+++ b/packages/ipfs-core/src/components/key/gen.js
@@ -9,7 +9,7 @@ const DEFAULT_KEY_SIZE = 2048
  */
 export function createGen ({ keychain }) {
   /**
-   * @type {import('ipfs-core-types/src/key').API["gen"]}
+   * @type {import('ipfs-core-types/src/key').API<{}>["gen"]}
    */
   const gen = (name, options = { type: DEFAULT_KEY_TYPE, size: DEFAULT_KEY_SIZE }) => {
     return keychain.createKey(name, options.type || DEFAULT_KEY_TYPE, options.size || DEFAULT_KEY_SIZE)

--- a/packages/ipfs-core/src/components/key/import.js
+++ b/packages/ipfs-core/src/components/key/import.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createImport ({ keychain }) {
   /**
-   * @type {import('ipfs-core-types/src/key').API["import"]}
+   * @type {import('ipfs-core-types/src/key').API<{}>["import"]}
    */
   const importKey = (name, pem, password) => {
     return keychain.importKey(name, pem, password)

--- a/packages/ipfs-core/src/components/key/info.js
+++ b/packages/ipfs-core/src/components/key/info.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createInfo ({ keychain }) {
   /**
-   * @type {import('ipfs-core-types/src/key').API["info"]}
+   * @type {import('ipfs-core-types/src/key').API<{}>["info"]}
    */
   const info = (name) => keychain.findKeyByName(name)
 

--- a/packages/ipfs-core/src/components/key/list.js
+++ b/packages/ipfs-core/src/components/key/list.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createList ({ keychain }) {
   /**
-   * @type {import('ipfs-core-types/src/key').API["list"]}
+   * @type {import('ipfs-core-types/src/key').API<{}>["list"]}
    */
   const list = () => keychain.listKeys()
 

--- a/packages/ipfs-core/src/components/key/rename.js
+++ b/packages/ipfs-core/src/components/key/rename.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createRename ({ keychain }) {
   /**
-   * @type {import('ipfs-core-types/src/key').API["rename"]}
+   * @type {import('ipfs-core-types/src/key').API<{}>["rename"]}
    */
   const rename = async (oldName, newName) => {
     const key = await keychain.renameKey(oldName, newName)

--- a/packages/ipfs-core/src/components/key/rm.js
+++ b/packages/ipfs-core/src/components/key/rm.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createRm ({ keychain }) {
   /**
-   * @type {import('ipfs-core-types/src/key').API["rm"]}
+   * @type {import('ipfs-core-types/src/key').API<{}>["rm"]}
    */
   const rm = (name) => keychain.removeKey(name)
 

--- a/packages/ipfs-core/src/components/ls.js
+++ b/packages/ipfs-core/src/components/ls.js
@@ -13,7 +13,7 @@ import { CID } from 'multiformats/cid'
  */
 export function createLs ({ repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["ls"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["ls"]}
    */
   async function * ls (ipfsPath, options = {}) {
     const legacyPath = normalizeCidPath(ipfsPath)

--- a/packages/ipfs-core/src/components/name/index.js
+++ b/packages/ipfs-core/src/components/name/index.js
@@ -10,9 +10,9 @@ export class NameAPI {
    * @param {import('../../types').Options} config.options
    * @param {import('ipfs-repo').IPFSRepo} config.repo
    * @param {import('ipfs-core-utils/multicodecs').Multicodecs} config.codecs
-   * @param {import('ipfs-core-types/src/root').API["isOnline"]} config.isOnline
+   * @param {import('ipfs-core-types/src/root').API<{}>["isOnline"]} config.isOnline
    * @param {import('libp2p/src/keychain')} config.keychain
-   * @param {import('ipfs-core-types/src/root').API["dns"]} config.dns
+   * @param {import('ipfs-core-types/src/root').API<{}>["dns"]} config.dns
    */
   constructor ({ dns, ipns, repo, codecs, peerId, isOnline, keychain, options }) {
     this.publish = createPublish({ ipns, repo, codecs, peerId, isOnline, keychain })

--- a/packages/ipfs-core/src/components/name/publish.js
+++ b/packages/ipfs-core/src/components/name/publish.js
@@ -20,7 +20,7 @@ const log = Object.assign(debug('ipfs:name:publish'), {
  * @param {import('ipfs-repo').IPFSRepo} config.repo
  * @param {import('ipfs-core-utils/multicodecs').Multicodecs} config.codecs
  * @param {import('peer-id')} config.peerId
- * @param {import('ipfs-core-types/src/root').API["isOnline"]} config.isOnline
+ * @param {import('ipfs-core-types/src/root').API<{}>["isOnline"]} config.isOnline
  * @param {import('libp2p/src/keychain')} config.keychain
  */
 export function createPublish ({ ipns, repo, codecs, peerId, isOnline, keychain }) {
@@ -44,7 +44,7 @@ export function createPublish ({ ipns, repo, codecs, peerId, isOnline, keychain 
   }
 
   /**
-   * @type {import('ipfs-core-types/src/name').API["publish"]}
+   * @type {import('ipfs-core-types/src/name').API<{}>["publish"]}
    */
   async function publish (value, options = {}) {
     const resolve = !(options.resolve === false)

--- a/packages/ipfs-core/src/components/name/pubsub/cancel.js
+++ b/packages/ipfs-core/src/components/name/pubsub/cancel.js
@@ -10,7 +10,7 @@ export function createCancel ({ ipns, options }) {
   const experimental = options.EXPERIMENTAL
 
   /**
-   * @type {import('ipfs-core-types/src/name/pubsub').API["cancel"]}
+   * @type {import('ipfs-core-types/src/name/pubsub').API<{}>["cancel"]}
    */
   async function cancel (name, options = {}) { // eslint-disable-line require-await
     const pubsub = getPubsubRouting(ipns, experimental)

--- a/packages/ipfs-core/src/components/name/pubsub/state.js
+++ b/packages/ipfs-core/src/components/name/pubsub/state.js
@@ -10,7 +10,7 @@ export function createState ({ ipns, options }) {
   const experimental = options.EXPERIMENTAL
 
   /**
-   * @type {import('ipfs-core-types/src/name/pubsub').API["state"]}
+   * @type {import('ipfs-core-types/src/name/pubsub').API<{}>["state"]}
    */
   async function state (_options = {}) { // eslint-disable-line require-await
     try {

--- a/packages/ipfs-core/src/components/name/pubsub/subs.js
+++ b/packages/ipfs-core/src/components/name/pubsub/subs.js
@@ -10,7 +10,7 @@ export function createSubs ({ ipns, options }) {
   const experimental = options.EXPERIMENTAL
 
   /**
-   * @type {import('ipfs-core-types/src/name/pubsub').API["subs"]}
+   * @type {import('ipfs-core-types/src/name/pubsub').API<{}>["subs"]}
    */
   async function subs (options = {}) { // eslint-disable-line require-await
     const pubsub = getPubsubRouting(ipns, experimental)

--- a/packages/ipfs-core/src/components/name/resolve.js
+++ b/packages/ipfs-core/src/components/name/resolve.js
@@ -31,15 +31,15 @@ const appendRemainder = (result, remainder) =>
  * IPNS - Inter-Planetary Naming System
  *
  * @param {Object} config
- * @param {import('ipfs-core-types/src/root').API["dns"]} config.dns
+ * @param {import('ipfs-core-types/src/root').API<{}>["dns"]} config.dns
  * @param {import('../ipns').IPNSAPI} config.ipns
  * @param {import('peer-id')} config.peerId
- * @param {import('ipfs-core-types/src/root').API["isOnline"]} config.isOnline
+ * @param {import('ipfs-core-types/src/root').API<{}>["isOnline"]} config.isOnline
  * @param {import('../../types').Options} config.options
  */
 export function createResolve ({ dns, ipns, peerId, isOnline, options: { offline } }) {
   /**
-   * @type {import('ipfs-core-types/src/name').API["resolve"]}
+   * @type {import('ipfs-core-types/src/name').API<{}>["resolve"]}
    */
   async function * resolve (name, options = {}) { // eslint-disable-line require-await
     options = mergeOptions({

--- a/packages/ipfs-core/src/components/object/data.js
+++ b/packages/ipfs-core/src/components/object/data.js
@@ -10,7 +10,7 @@ export function createData ({ repo, preload }) {
   const get = createGet({ repo, preload })
 
   /**
-   * @type {import('ipfs-core-types/src/object').API["data"]}
+   * @type {import('ipfs-core-types/src/object').API<{}>["data"]}
    */
   async function data (multihash, options = {}) {
     const node = await get(multihash, options)

--- a/packages/ipfs-core/src/components/object/get.js
+++ b/packages/ipfs-core/src/components/object/get.js
@@ -8,7 +8,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createGet ({ repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/object').API["get"]}
+   * @type {import('ipfs-core-types/src/object').API<{}>["get"]}
    */
   async function get (cid, options = {}) { // eslint-disable-line require-await
     if (options.preload !== false) {

--- a/packages/ipfs-core/src/components/object/links.js
+++ b/packages/ipfs-core/src/components/object/links.js
@@ -60,7 +60,7 @@ function findLinks (node, links = []) {
  */
 export function createLinks ({ repo, codecs }) {
   /**
-   * @type {import('ipfs-core-types/src/object').API["links"]}
+   * @type {import('ipfs-core-types/src/object').API<{}>["links"]}
    */
   async function links (cid, options = {}) {
     const codec = await codecs.getCodec(cid.code)

--- a/packages/ipfs-core/src/components/object/new.js
+++ b/packages/ipfs-core/src/components/object/new.js
@@ -11,7 +11,7 @@ import { CID } from 'multiformats/cid'
  */
 export function createNew ({ repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/object').API["new"]}
+   * @type {import('ipfs-core-types/src/object').API<{}>["new"]}
    */
   async function _new (options = {}) {
     let data

--- a/packages/ipfs-core/src/components/object/patch/add-link.js
+++ b/packages/ipfs-core/src/components/object/patch/add-link.js
@@ -12,7 +12,7 @@ export function createAddLink ({ repo, preload }) {
   const put = createPut({ repo, preload })
 
   /**
-   * @type {import('ipfs-core-types/src/object/patch').API["addLink"]}
+   * @type {import('ipfs-core-types/src/object/patch').API<{}>["addLink"]}
    */
   async function addLink (cid, link, options = {}) {
     const node = await get(cid, options)

--- a/packages/ipfs-core/src/components/object/patch/append-data.js
+++ b/packages/ipfs-core/src/components/object/patch/append-data.js
@@ -13,7 +13,7 @@ export function createAppendData ({ repo, preload }) {
   const put = createPut({ repo, preload })
 
   /**
-   * @type {import('ipfs-core-types/src/object/patch').API["appendData"]}
+   * @type {import('ipfs-core-types/src/object/patch').API<{}>["appendData"]}
    */
   async function appendData (cid, data, options = {}) {
     const node = await get(cid, options)

--- a/packages/ipfs-core/src/components/object/patch/rm-link.js
+++ b/packages/ipfs-core/src/components/object/patch/rm-link.js
@@ -12,7 +12,7 @@ export function createRmLink ({ repo, preload }) {
   const put = createPut({ repo, preload })
 
   /**
-   * @type {import('ipfs-core-types/src/object/patch').API["rmLink"]}
+   * @type {import('ipfs-core-types/src/object/patch').API<{}>["rmLink"]}
    */
   async function rmLink (multihash, linkRef, options = {}) {
     const node = await get(multihash, options)

--- a/packages/ipfs-core/src/components/object/patch/set-data.js
+++ b/packages/ipfs-core/src/components/object/patch/set-data.js
@@ -12,7 +12,7 @@ export function createSetData ({ repo, preload }) {
   const put = createPut({ repo, preload })
 
   /**
-   * @type {import('ipfs-core-types/src/object/patch').API["setData"]}
+   * @type {import('ipfs-core-types/src/object/patch').API<{}>["setData"]}
    */
   async function setData (cid, data, options = {}) {
     const node = await get(cid, options)

--- a/packages/ipfs-core/src/components/object/put.js
+++ b/packages/ipfs-core/src/components/object/put.js
@@ -10,7 +10,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createPut ({ repo, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/object').API["put"]}
+   * @type {import('ipfs-core-types/src/object').API<{}>["put"]}
    */
   async function put (obj, options = {}) {
     const release = await repo.gcLock.readLock()

--- a/packages/ipfs-core/src/components/object/stat.js
+++ b/packages/ipfs-core/src/components/object/stat.js
@@ -11,7 +11,7 @@ export function createStat ({ repo, preload }) {
   const get = createGet({ repo, preload })
 
   /**
-   * @type {import('ipfs-core-types/src/object').API["stat"]}
+   * @type {import('ipfs-core-types/src/object').API<{}>["stat"]}
    */
   async function stat (cid, options = {}) {
     const node = await get(cid, options)

--- a/packages/ipfs-core/src/components/pin/add-all.js
+++ b/packages/ipfs-core/src/components/pin/add-all.js
@@ -24,7 +24,7 @@ import { PinTypes } from 'ipfs-repo/pin-types'
  */
 export function createAddAll ({ repo, codecs }) {
   /**
-   * @type {import('ipfs-core-types/src/pin').API["addAll"]}
+   * @type {import('ipfs-core-types/src/pin').API<{}>["addAll"]}
    */
   async function * addAll (source, options = {}) {
     /**

--- a/packages/ipfs-core/src/components/pin/add.js
+++ b/packages/ipfs-core/src/components/pin/add.js
@@ -7,7 +7,7 @@ import { CID } from 'multiformats/cid'
  */
 export function createAdd ({ addAll }) {
   /**
-   * @type {import('ipfs-core-types/src/pin').API["add"]}
+   * @type {import('ipfs-core-types/src/pin').API<{}>["add"]}
    */
   return (path, options = {}) => {
     let iter

--- a/packages/ipfs-core/src/components/pin/ls.js
+++ b/packages/ipfs-core/src/components/pin/ls.js
@@ -36,7 +36,7 @@ function toPin (type, cid, metadata) {
  */
 export function createLs ({ repo, codecs }) {
   /**
-   * @type {import('ipfs-core-types/src/pin').API["ls"]}
+   * @type {import('ipfs-core-types/src/pin').API<{}>["ls"]}
    */
   async function * ls (options = {}) {
     /** @type {import('ipfs-core-types/src/pin').PinQueryType} */

--- a/packages/ipfs-core/src/components/pin/rm-all.js
+++ b/packages/ipfs-core/src/components/pin/rm-all.js
@@ -10,7 +10,7 @@ import { PinTypes } from 'ipfs-repo/pin-types'
  */
 export function createRmAll ({ repo, codecs }) {
   /**
-   * @type {import('ipfs-core-types/src/pin').API["rmAll"]}
+   * @type {import('ipfs-core-types/src/pin').API<{}>["rmAll"]}
    */
   async function * rmAll (source, _options = {}) {
     const release = await repo.gcLock.readLock()

--- a/packages/ipfs-core/src/components/pin/rm.js
+++ b/packages/ipfs-core/src/components/pin/rm.js
@@ -2,11 +2,11 @@ import last from 'it-last'
 
 /**
  * @param {Object} config
- * @param {import('ipfs-core-types/src/pin').API["rmAll"]} config.rmAll
+ * @param {import('ipfs-core-types/src/pin').API<{}>["rmAll"]} config.rmAll
  */
 export function createRm ({ rmAll }) {
   /**
-   * @type {import('ipfs-core-types/src/pin').API["rm"]}
+   * @type {import('ipfs-core-types/src/pin').API<{}>["rm"]}
    */
   async function rm (path, options = {}) {
     // @ts-ignore return value of last can be undefined

--- a/packages/ipfs-core/src/components/ping.js
+++ b/packages/ipfs-core/src/components/ping.js
@@ -39,7 +39,7 @@ const basePacket = { success: true, time: 0, text: '' }
  */
 export function createPing ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["ping"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["ping"]}
    */
   async function * ping (peerId, options = {}) {
     const { libp2p } = await network.use()

--- a/packages/ipfs-core/src/components/pubsub.js
+++ b/packages/ipfs-core/src/components/pubsub.js
@@ -20,7 +20,7 @@ export function createPubsub ({ network, config }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/pubsub').API["subscribe"]}
+   * @type {import('ipfs-core-types/src/pubsub').API<{}>["subscribe"]}
    */
   async function subscribe (topic, handler, options = {}) {
     const { libp2p } = await network.use(options)
@@ -29,7 +29,7 @@ export function createPubsub ({ network, config }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/pubsub').API["unsubscribe"]}
+   * @type {import('ipfs-core-types/src/pubsub').API<{}>["unsubscribe"]}
    */
   async function unsubscribe (topic, handler, options = {}) {
     const { libp2p } = await network.use(options)
@@ -38,7 +38,7 @@ export function createPubsub ({ network, config }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/pubsub').API["publish"]}
+   * @type {import('ipfs-core-types/src/pubsub').API<{}>["publish"]}
    */
   async function publish (topic, data, options = {}) {
     const { libp2p } = await network.use(options)
@@ -49,7 +49,7 @@ export function createPubsub ({ network, config }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/pubsub').API["ls"]}
+   * @type {import('ipfs-core-types/src/pubsub').API<{}>["ls"]}
    */
   async function ls (options = {}) {
     const { libp2p } = await network.use(options)
@@ -57,7 +57,7 @@ export function createPubsub ({ network, config }) {
   }
 
   /**
-   * @type {import('ipfs-core-types/src/pubsub').API["peers"]}
+   * @type {import('ipfs-core-types/src/pubsub').API<{}>["peers"]}
    */
   async function peers (topic, options = {}) {
     const { libp2p } = await network.use(options)

--- a/packages/ipfs-core/src/components/refs/index.js
+++ b/packages/ipfs-core/src/components/refs/index.js
@@ -29,12 +29,12 @@ export const Format = {
  * @param {Object} config
  * @param {import('ipfs-repo').IPFSRepo} config.repo
  * @param {import('ipfs-core-utils/multicodecs').Multicodecs} config.codecs
- * @param {import('ipfs-core-types/src/root').API["resolve"]} config.resolve
+ * @param {import('ipfs-core-types/src/root').API<{}>["resolve"]} config.resolve
  * @param {import('../../types').Preload} config.preload
  */
 export function createRefs ({ repo, codecs, resolve, preload }) {
   /**
-   * @type {import('ipfs-core-types/src/refs').API["refs"]}
+   * @type {import('ipfs-core-types/src/refs').API<{}>["refs"]}
    */
   async function * refs (ipfsPath, options = {}) {
     if (options.maxDepth === 0) {
@@ -53,8 +53,13 @@ export function createRefs ({ repo, codecs, resolve, preload }) {
 
     if (options.timeout) {
       const controller = new TimeoutController(options.timeout)
+      const signals = [controller.signal]
 
-      options.signal = anySignal([options.signal, controller.signal])
+      if (options.signal) {
+        signals.push(options.signal)
+      }
+
+      options.signal = anySignal(signals)
     }
 
     /** @type {(string|CID)[]} */
@@ -98,7 +103,7 @@ function getFullPath (preload, ipfsPath, options) {
 /**
  * Get a stream of refs at the given path
  *
- * @param {import('ipfs-core-types/src/root').API["resolve"]} resolve
+ * @param {import('ipfs-core-types/src/root').API<{}>["resolve"]} resolve
  * @param {import('ipfs-repo').IPFSRepo} repo
  * @param {import('ipfs-core-utils/multicodecs').Multicodecs} codecs
  * @param {string} path

--- a/packages/ipfs-core/src/components/refs/local.js
+++ b/packages/ipfs-core/src/components/refs/local.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createLocal ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/refs').API["local"]}
+   * @type {import('ipfs-core-types/src/refs').API<{}>["local"]}
    */
   async function * refsLocal (options = {}) {
     for await (const cid of repo.blocks.queryKeys({}, { signal: options.signal })) {

--- a/packages/ipfs-core/src/components/repo/gc.js
+++ b/packages/ipfs-core/src/components/repo/gc.js
@@ -22,7 +22,7 @@ const log = debug('ipfs:repo:gc')
  */
 export function createGc ({ repo, hashers }) {
   /**
-   * @type {import('ipfs-core-types/src/repo').API["gc"]}
+   * @type {import('ipfs-core-types/src/repo').API<{}>["gc"]}
    */
   async function * gc (options = {}) {
     const start = Date.now()

--- a/packages/ipfs-core/src/components/repo/stat.js
+++ b/packages/ipfs-core/src/components/repo/stat.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createStat ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/repo').API["stat"]}
+   * @type {import('ipfs-core-types/src/repo').API<{}>["stat"]}
    */
   async function stat (options = {}) {
     const stats = await repo.stat()

--- a/packages/ipfs-core/src/components/repo/version.js
+++ b/packages/ipfs-core/src/components/repo/version.js
@@ -7,7 +7,7 @@ import { repoVersion } from 'ipfs-repo/constants'
  */
 export function createVersion ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/repo').API["version"]}
+   * @type {import('ipfs-core-types/src/repo').API<{}>["version"]}
    */
   async function version (options = {}) {
     try {

--- a/packages/ipfs-core/src/components/resolve.js
+++ b/packages/ipfs-core/src/components/resolve.js
@@ -13,7 +13,7 @@ import { resolve as res } from '../utils.js'
  */
 export function createResolve ({ repo, codecs, bases, name }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["resolve"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["resolve"]}
    */
   async function resolve (path, opts = {}) {
     if (!isIpfs.path(path)) {

--- a/packages/ipfs-core/src/components/start.js
+++ b/packages/ipfs-core/src/components/start.js
@@ -15,7 +15,7 @@ import { Service } from '../utils/service.js'
  */
 export function createStart ({ network, preload, peerId, keychain, repo, ipns, mfsPreload, print, hashers, options }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["start"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["start"]}
    */
   const start = async () => {
     const { libp2p } = await Service.start(network, {

--- a/packages/ipfs-core/src/components/stats/bw.js
+++ b/packages/ipfs-core/src/components/stats/bw.js
@@ -1,10 +1,11 @@
 import parseDuration from 'parse-duration'
 import errCode from 'err-code'
 import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
+import PeerId from 'peer-id'
 
 /**
  * @typedef {Object} BWOptions
- * @property {PeerId} [peer] - Specifies a peer to print bandwidth for
+ * @property {string} [peer] - Specifies a peer to print bandwidth for
  * @property {string} [proto] - Specifies a protocol to print bandwidth for
  * @property {boolean} [poll] - Is used to yield bandwidth info at an interval
  * @property {number|string} [interval=1000] - The time interval to wait between updating output, if `poll` is `true`.
@@ -16,7 +17,6 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  * @property {number} rateOut
  *
  * @typedef {import('libp2p')} libp2p
- * @typedef {import('peer-id')} PeerId
  * @typedef {import('multiformats/cid').CID} CID
  * @typedef {import('ipfs-core-types/src/utils').AbortOptions} AbortOptions
  */
@@ -32,7 +32,7 @@ function getBandwidthStats (libp2p, opts) {
   if (!libp2p.metrics) {
     stats = undefined
   } else if (opts.peer) {
-    stats = libp2p.metrics.forPeer(opts.peer)
+    stats = libp2p.metrics.forPeer(PeerId.parse(opts.peer))
   } else if (opts.proto) {
     stats = libp2p.metrics.forProtocol(opts.proto)
   } else {
@@ -64,7 +64,7 @@ function getBandwidthStats (libp2p, opts) {
  */
 export function createBw ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/stats').API["bw"]}
+   * @type {import('ipfs-core-types/src/stats').API<{}>["bw"]}
    */
   const bw = async function * (options = {}) {
     const { libp2p } = await network.use(options)

--- a/packages/ipfs-core/src/components/stop.js
+++ b/packages/ipfs-core/src/components/stop.js
@@ -10,7 +10,7 @@ import { Service } from '../utils/service.js'
  */
 export function createStop ({ network, preload, ipns, repo, mfsPreload }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["stop"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["stop"]}
    */
   const stop = async () => {
     await Promise.all([

--- a/packages/ipfs-core/src/components/swarm/addrs.js
+++ b/packages/ipfs-core/src/components/swarm/addrs.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createAddrs ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/swarm').API["addrs"]}
+   * @type {import('ipfs-core-types/src/swarm').API<{}>["addrs"]}
    */
   async function addrs (options = {}) { // eslint-disable-line require-await
     const peers = []

--- a/packages/ipfs-core/src/components/swarm/connect.js
+++ b/packages/ipfs-core/src/components/swarm/connect.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createConnect ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/swarm').API["connect"]}
+   * @type {import('ipfs-core-types/src/swarm').API<{}>["connect"]}
    */
   async function connect (addr, options = {}) {
     const { libp2p } = await network.use(options)

--- a/packages/ipfs-core/src/components/swarm/disconnect.js
+++ b/packages/ipfs-core/src/components/swarm/disconnect.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createDisconnect ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/swarm').API["disconnect"]}
+   * @type {import('ipfs-core-types/src/swarm').API<{}>["disconnect"]}
    */
   async function disconnect (addr, options = {}) {
     const { libp2p } = await network.use(options)

--- a/packages/ipfs-core/src/components/swarm/local-addrs.js
+++ b/packages/ipfs-core/src/components/swarm/local-addrs.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createLocalAddrs ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/swarm').API["localAddrs"]}
+   * @type {import('ipfs-core-types/src/swarm').API<{}>["localAddrs"]}
    */
   async function localAddrs (options = {}) {
     const { libp2p } = await network.use(options)

--- a/packages/ipfs-core/src/components/swarm/peers.js
+++ b/packages/ipfs-core/src/components/swarm/peers.js
@@ -6,7 +6,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createPeers ({ network }) {
   /**
-   * @type {import('ipfs-core-types/src/swarm').API["peers"]}
+   * @type {import('ipfs-core-types/src/swarm').API<{}>["peers"]}
    */
   async function peers (options = {}) {
     const { libp2p } = await network.use(options)

--- a/packages/ipfs-core/src/components/version.js
+++ b/packages/ipfs-core/src/components/version.js
@@ -7,7 +7,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function createVersion ({ repo }) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["version"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["version"]}
    */
   async function version (_options = {}) {
     const repoVersion = await repo.version.get()

--- a/packages/ipfs-core/src/version.js
+++ b/packages/ipfs-core/src/version.js
@@ -1,4 +1,4 @@
 
-export const ipfsCore = '0.12.1'
+export const ipfsCore = '0.12.2'
 export const commit = ''
-export const interfaceIpfsCore = '^0.152.1'
+export const interfaceIpfsCore = '^0.152.2'

--- a/packages/ipfs-grpc-client/src/core-api/add-all.js
+++ b/packages/ipfs-grpc-client/src/core-api/add-all.js
@@ -111,7 +111,7 @@ async function sendFiles (stream, sink) {
  */
 export function grpcAddAll (grpc, service, opts) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["addAll"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["addAll"]}
    */
   async function * addAll (stream, options = {}) {
     const {

--- a/packages/ipfs-grpc-client/src/core-api/files/ls.js
+++ b/packages/ipfs-grpc-client/src/core-api/files/ls.js
@@ -9,7 +9,7 @@ import { withTimeoutOption } from 'ipfs-core-utils/with-timeout-option'
  */
 export function grpcMfsLs (grpc, service, opts) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["ls"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["ls"]}
    */
   async function * mfsLs (path, options = {}) {
     const request = {

--- a/packages/ipfs-grpc-client/src/core-api/files/write.js
+++ b/packages/ipfs-grpc-client/src/core-api/files/write.js
@@ -23,7 +23,7 @@ async function * stream (path, content) {
  */
 export function grpcMfsWrite (grpc, service, opts) {
   /**
-   * @type {import('ipfs-core-types/src/files').API["write"]}
+   * @type {import('ipfs-core-types/src/files').API<{}>["write"]}
    */
   async function mfsWrite (path, content, options = {}) {
     /**

--- a/packages/ipfs-grpc-client/src/core-api/id.js
+++ b/packages/ipfs-grpc-client/src/core-api/id.js
@@ -10,7 +10,7 @@ import { Multiaddr } from 'multiaddr'
  */
 export function grpcId (grpc, service, opts) {
   /**
-   * @type {import('ipfs-core-types/src/root').API["id"]}
+   * @type {import('ipfs-core-types/src/root').API<{}>["id"]}
    */
   async function id (options = {}) {
     const request = {}

--- a/packages/ipfs-grpc-client/src/core-api/pubsub/subscribe.js
+++ b/packages/ipfs-grpc-client/src/core-api/pubsub/subscribe.js
@@ -10,7 +10,7 @@ import defer from 'p-defer'
  */
 export function grpcPubsubSubscribe (grpc, service, opts) {
   /**
-   * @type {import('ipfs-core-types/src/pubsub').API["subscribe"]}
+   * @type {import('ipfs-core-types/src/pubsub').API<{}>["subscribe"]}
    */
   async function pubsubSubscribe (topic, handler, options = {}) {
     const request = {

--- a/packages/ipfs-grpc-client/src/core-api/pubsub/unsubscribe.js
+++ b/packages/ipfs-grpc-client/src/core-api/pubsub/unsubscribe.js
@@ -10,7 +10,7 @@ import { subscriptions } from './subscriptions.js'
  */
 export function grpcPubsubUnsubscribe (grpc, service, opts) {
   /**
-   * @type {import('ipfs-core-types/src/pubsub').API["unsubscribe"]}
+   * @type {import('ipfs-core-types/src/pubsub').API<{}>["unsubscribe"]}
    */
   async function pubsubUnsubscribe (topic, handler, options = {}) {
     const handlers = []

--- a/packages/ipfs-http-server/src/version.js
+++ b/packages/ipfs-http-server/src/version.js
@@ -1,2 +1,2 @@
 
-export const ipfsHttpClient = '^54.0.1'
+export const ipfsHttpClient = '^54.0.2'

--- a/packages/ipfs/src/package.js
+++ b/packages/ipfs/src/package.js
@@ -1,4 +1,4 @@
 
 export const name = 'ipfs'
-export const version = '0.60.1'
+export const version = '0.60.2'
 export const node = '>=14.0.0'


### PR DESCRIPTION
We can extend options passed to the core-api by defining an extension
object, this is so we can pass http options to the http api client
but still get type safety.

We define a default extension type of `{}` so we don't need to define
the extension in places we aren't extending it (e.g. ipfs-core).

Problem is, JSDoc doesn't pick up the default extension object so we
need to add it to the function definitions.

Refs: https://github.com/ipfs/js-ipfs/pull/3917#discussion_r761886258