### PR TITLE
fix: return nested value from dag.get

### DIFF
--- a/packages/interface-ipfs-core/src/block/rm.js
+++ b/packages/interface-ipfs-core/src/block/rm.js
@@ -78,8 +78,8 @@ export function testRm (factory, options) {
 
       expect(result).to.have.lengthOf(3)
 
-      result.forEach((res, index) => {
-        expect(res.cid.toString()).to.equal(cids[index].toString())
+      result.forEach((res) => {
+        expect(cids.map(cid => cid.toString())).to.include(res.cid.toString())
         expect(res).to.not.have.property('error')
       })
     })

--- a/packages/interface-ipfs-core/src/dag/get.js
+++ b/packages/interface-ipfs-core/src/dag/get.js
@@ -283,5 +283,27 @@ export function testGet (factory, options) {
       return expect(ipfs.dag.get(uint8ArrayFromString('INVALID CID')))
         .to.eventually.be.rejected()
     })
+
+    it('should return nested content when getting a CID with a path', async () => {
+      const regularContent = { test: '123' }
+      const cid1 = await ipfs.dag.put(regularContent)
+      const linkedContent = { link: cid1 }
+      const cid2 = await ipfs.dag.put(linkedContent)
+
+      const atPath = await ipfs.dag.get(cid2, { path: '/link' })
+
+      expect(atPath).to.have.deep.property('value', regularContent)
+    })
+
+    it('should not return nested content when getting a CID with a path and localResolve is true', async () => {
+      const regularContent = { test: '123' }
+      const cid1 = await ipfs.dag.put(regularContent)
+      const linkedContent = { link: cid1 }
+      const cid2 = await ipfs.dag.put(linkedContent)
+
+      const atPath = await ipfs.dag.get(cid2, { path: '/link', localResolve: true })
+
+      expect(atPath).to.have.deep.property('value').that.is.an.instanceOf(CID)
+    })
   })
 }

--- a/packages/ipfs-core/src/utils.js
+++ b/packages/ipfs-core/src/utils.js
@@ -200,13 +200,6 @@ export const resolve = async function * (cid, path, codecs, repo, options) {
   let value = await load(cid)
   let lastCid = cid
 
-  if (!parts.length) {
-    yield {
-      value,
-      remainderPath: ''
-    }
-  }
-
   // End iteration if there isn't a CID to follow any more
   while (parts.length) {
     const key = parts.shift()
@@ -247,5 +240,10 @@ export const resolve = async function * (cid, path, codecs, repo, options) {
       lastCid = value
       value = await load(value)
     }
+  }
+
+  yield {
+    value,
+    remainderPath: ''
   }
 }

--- a/packages/ipfs-http-client/src/lib/resolve.js
+++ b/packages/ipfs-http-client/src/lib/resolve.js
@@ -29,13 +29,6 @@ export async function * resolve (cid, path, codecs, getBlock, options) {
   let value = await load(cid)
   let lastCid = cid
 
-  if (!parts.length) {
-    yield {
-      value,
-      remainderPath: ''
-    }
-  }
-
   // End iteration if there isn't a CID to follow any more
   while (parts.length) {
     const key = parts.shift()
@@ -61,5 +54,10 @@ export async function * resolve (cid, path, codecs, getBlock, options) {
       lastCid = cid
       value = await load(value)
     }
+  }
+
+  yield {
+    value,
+    remainderPath: ''
   }
 }


### PR DESCRIPTION
If we're traversing thorough and object and the thing at the end of the path is a CID, load that thing and return it as the final value, unless `localResolve` is true, in which case return the CID.

Fixes #3957