### PR TITLE
chore: remove noise fork

### DIFF
--- a/packages/ipfs-core-config/package.json
+++ b/packages/ipfs-core-config/package.json
@@ -79,7 +79,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@achingbrain/libp2p-noise": "^5.0.0",
+    "@chainsafe/libp2p-noise": "^5.0.0",
     "blockstore-datastore-adapter": "^2.0.2",
     "datastore-core": "^6.0.7",
     "datastore-fs": "^6.0.1",

--- a/packages/ipfs-core-config/src/libp2p.browser.js
+++ b/packages/ipfs-core-config/src/libp2p.browser.js
@@ -5,7 +5,7 @@ import WS from 'libp2p-websockets'
 import WebRTCStar from 'libp2p-webrtc-star'
 // @ts-expect-error - no types
 import Multiplex from 'libp2p-mplex'
-import { NOISE } from '@achingbrain/libp2p-noise'
+import { NOISE } from '@chainsafe/libp2p-noise'
 import KadDHT from 'libp2p-kad-dht'
 import GossipSub from 'libp2p-gossipsub'
 import { validator, selector } from './utils/ipns.js'

--- a/packages/ipfs-core-config/src/libp2p.js
+++ b/packages/ipfs-core-config/src/libp2p.js
@@ -7,7 +7,7 @@ import KadDHT from 'libp2p-kad-dht'
 import GossipSub from 'libp2p-gossipsub'
 // @ts-expect-error - no types
 import Multiplex from 'libp2p-mplex'
-import { NOISE } from '@achingbrain/libp2p-noise'
+import { NOISE } from '@chainsafe/libp2p-noise'
 import { validator, selector } from './utils/ipns.js'
 import os from 'os'
 

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -65,7 +65,7 @@
     "dep-check": "aegir dep-check -i interface-ipfs-core -i ipfs-core-types -i abort-controller -i npm-run-all --i interface-blockstore"
   },
   "dependencies": {
-    "@achingbrain/libp2p-noise": "^5.0.0",
+    "@chainsafe/libp2p-noise": "^5.0.0",
     "@ipld/car": "^3.1.0",
     "@ipld/dag-cbor": "^6.0.5",
     "@ipld/dag-json": "^8.0.1",

--- a/packages/ipfs-core/test/libp2p.spec.js
+++ b/packages/ipfs-core/test/libp2p.spec.js
@@ -6,7 +6,7 @@ import PeerId from 'peer-id'
 import Libp2p from 'libp2p'
 import { EventEmitter } from 'events'
 import { createLibp2p as libp2pComponent } from '../src/components/libp2p.js'
-import { NOISE as Crypto } from '@achingbrain/libp2p-noise'
+import { NOISE as Crypto } from '@chainsafe/libp2p-noise'
 import gossipsub from 'libp2p-gossipsub'
 
 /**


### PR DESCRIPTION
`@chainsafe/libp2p-noise@5.x.x` has shipped so remove the temporary fork we were using.