### PR TITLE
fix: use peer store for id

### DIFF
--- a/packages/ipfs-core/src/components/id.js
+++ b/packages/ipfs-core/src/components/id.js
@@ -104,7 +104,7 @@ async function findPeer (peerId, libp2p, options) {
  * @param {Libp2p} libp2p
  * @param {AbortOptions} options
  */
- async function findPeerOnDht (peerId, libp2p, options) {
+async function findPeerOnDht (peerId, libp2p, options) {
   for await (const event of libp2p._dht.findPeer(peerId, options)) {
     if (event.name === 'FINAL_PEER') {
       break


### PR DESCRIPTION
Instead of using all the various books, just get the peer from the libp2p peer store, trying to fetch the public key from the dht if it's missing.