### PR TITLE
fix: always close writer so iterator throws on error

### DIFF
--- a/packages/ipfs-core/src/components/dag/export.js
+++ b/packages/ipfs-core/src/components/dag/export.js
@@ -59,9 +59,10 @@ export function createExport ({ repo, preload, codecs }) {
           cid,
           writer,
           codecs)
-        writer.close()
       } catch (/** @type {any} */ e) {
         err = e
+      } finally {
+        writer.close()
       }
     })()
 


### PR DESCRIPTION
When `traverseWrite` throws (abort signal for example), the writer is never closed and the iterator never ends.