### PR TITLE
docs: core-api/block

### DIFF
--- a/docs/core-api/BLOCK.md
+++ b/docs/core-api/BLOCK.md
@@ -44,13 +44,13 @@ An optional object which may have the following keys:
 
 | Type | Description |
 | -------- | -------- |
-| `Promise<Block>` | A [Block][block] type object, containing both the data and the hash of the block |
+| `Promise<Uint8Array>` | A Uint8Array containing the data of the block |
 
 ### Example
 
 ```JavaScript
 const block = await ipfs.block.get(cid)
-console.log(block.data)
+console.log(block)
 ```
 
 A great source of [examples][] can be found in the tests for this API.


### PR DESCRIPTION
Docs seem to be out of date:

https://github.com/ipfs/js-ipfs/blob/45d9baa7576a0ac924f3d01d49371bf1a4cf654c/packages/ipfs-core-types/src/block/index.ts#L14