### PR TITLE
fix: remove ToJSON type

### DIFF
--- a/packages/ipfs-core-types/src/utils.ts
+++ b/packages/ipfs-core-types/src/utils.ts
@@ -113,12 +113,6 @@ export interface PreloadOptions {
   preload?: boolean
 }
 
-export type ToJSON =
-  | null
-  | string
-  | number
-  | boolean
-
 /**
  * An IPFS path or CID
  */

--- a/packages/ipfs-core-types/src/utils.ts
+++ b/packages/ipfs-core-types/src/utils.ts
@@ -118,8 +118,6 @@ export type ToJSON =
   | string
   | number
   | boolean
-  | ToJSON[]
-  | { toJSON?: () => ToJSON } & { [key: string]: ToJSON }
 
 /**
  * An IPFS path or CID


### PR DESCRIPTION
solves `Type alias 'ToJSON' circularly references itself.`
solves https://github.com/ipfs/js-ipfs/issues/4029