### PR TITLE
chore: re-enable examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -51,9 +51,10 @@ jobs:
           - name: ipfs browser mfs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-mfs.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          - name: ipfs browser nextjs
-            repo: https://github.com/ipfs-examples/js-ipfs-browser-nextjs.git
-            deps: ipfs-core@$PWD/packages/ipfs-core/dist
+          # fails with No native build was found for platform=darwin arch=x64 runtime=node abi=93 uv=1 libc=glibc node=16.13.0 webpack=true
+          #- name: ipfs browser nextjs
+          #  repo: https://github.com/ipfs-examples/js-ipfs-browser-nextjs.git
+          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser parceljs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-parceljs.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -45,15 +45,15 @@ jobs:
           - name: ipfs browser exchange files
             repo: https://github.com/ipfs-examples/js-ipfs-browser-exchange-files.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs@$PWD/packages/ipfs/dist,ipfs-core-types@$PWD/packages/ipfs-core-types/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
-          #- name: ipfs browser ipns publish TODO: re-enable after example bumped to go-ipfs 0.11 and ipfs-http-client from https://github.com/ipfs/js-ipfs/pull/3922
-          #  repo: https://github.com/ipfs-examples/js-ipfs-browser-ipns-publish.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs browser ipns publish
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-ipns-publish.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs browser mfs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-mfs.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          # - name: ipfs browser nextjs
-          #   repo: https://github.com/ipfs-examples/js-ipfs-browser-nextjs.git
-          #   deps: ipfs-core@$PWD/packages/ipfs-core/dist
+          - name: ipfs browser nextjs
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-nextjs.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser parceljs
             repo: https://github.com/ipfs-examples/js-ipfs-browser-parceljs.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
@@ -69,27 +69,27 @@ jobs:
           - name: ipfs browser video streaming
             repo: https://github.com/ipfs-examples/js-ipfs-browser-video-streaming.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          #- name: ipfs browser vue
-          #  repo: https://github.com/ipfs-examples/js-ipfs-browser-vue.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist
+          - name: ipfs browser vue
+            repo: https://github.com/ipfs-examples/js-ipfs-browser-vue.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs browser webpack
             repo: https://github.com/ipfs-examples/js-ipfs-browser-webpack.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          #- name: ipfs circuit relaying
-          #  repo: https://github.com/ipfs-examples/js-ipfs-circuit-relaying.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs circuit relaying
+            repo: https://github.com/ipfs-examples/js-ipfs-circuit-relaying.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs custom ipfs repo
             repo: https://github.com/ipfs-examples/js-ipfs-custom-ipfs-repo.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          #- name: ipfs custom ipld formats
-          #  repo: https://github.com/ipfs-examples/js-ipfs-custom-ipld-formats.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
+          - name: ipfs custom ipld formats
+            repo: https://github.com/ipfs-examples/js-ipfs-custom-ipld-formats.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-daemon@$PWD/packages/ipfs-daemon/dist,ipfs-http-client@$PWD/packages/ipfs-http-client/dist
           - name: ipfs custom libp2p
             repo: https://github.com/ipfs-examples/js-ipfs-custom-libp2p.git
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          #- name: ipfs-http-client browser pubsub TODO: re-enable after example bumped to go-ipfs 0.11 and ipfs-http-client from https://github.com/ipfs/js-ipfs/pull/3922
-          #  repo: https://github.com/ipfs-examples/js-ipfs-http-client-browser-pubsub.git
-          #  deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist,ipfs@$PWD/packages/ipfs/dist
+          - name: ipfs-http-client browser pubsub
+            repo: https://github.com/ipfs-examples/js-ipfs-http-client-browser-pubsub.git
+            deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist,ipfs@$PWD/packages/ipfs/dist
           - name: ipfs-http-client bundle webpack
             repo: https://github.com/ipfs-examples/js-ipfs-http-client-bundle-webpack.git
             deps: ipfs-http-client@$PWD/packages/ipfs-http-client/dist,ipfs@$PWD/packages/ipfs/dist
@@ -105,21 +105,21 @@ jobs:
           - name: ipfs-client add files
             repo: https://github.com/ipfs-examples/js-ipfs-ipfs-client-add-files.git
             deps: ipfs@$PWD/packages/ipfs/dist,ipfs-client@$PWD/packages/ipfs-client/dist
-          #- name: ipfs electron js
-          #  repo: https://github.com/ipfs-examples/js-ipfs-run-in-electron.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist
+          - name: ipfs electron js
+            repo: https://github.com/ipfs-examples/js-ipfs-run-in-electron.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: ipfs running multiple nodes
             repo: https://github.com/ipfs-examples/js-ipfs-running-multiple-nodes.git
             deps: ipfs@$PWD/packages/ipfs/dist
-          #- name: ipfs traverse ipld graphs
-          #  repo: https://github.com/ipfs-examples/js-ipfs-traverse-ipld-graphs.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          #- name: types with typescript
-          #  repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-ts.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist
-          #- name: types with typed js
-          #  repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-typed-js.git
-          #  deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-core-types@$PWD/packages/ipfs-core-types/dist
+          - name: ipfs traverse ipld graphs
+            repo: https://github.com/ipfs-examples/js-ipfs-traverse-ipld-graphs.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
+          - name: types with typescript
+            repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-ts.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
+          - name: types with typed js
+            repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-typed-js.git
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-core-types@$PWD/packages/ipfs-core-types/dist
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
All examples have been updated to use the latest js-ipfs so they should start being testable again.