### PR TITLE
fix: override hashing algorithm when importing files

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -120,7 +120,7 @@ jobs:
             deps: ipfs-core@$PWD/packages/ipfs-core/dist
           - name: types with typed js
             repo: https://github.com/ipfs-examples/js-ipfs-types-use-ipfs-from-typed-js.git
-            deps: ipfs-core@$PWD/packages/ipfs-core/dist,ipfs-core-types@$PWD/packages/ipfs-core-types/dist
+            deps: ipfs-core@$PWD/packages/ipfs-core/dist
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/packages/interface-ipfs-core/src/add-all.js
+++ b/packages/interface-ipfs-core/src/add-all.js
@@ -483,7 +483,7 @@ export function testAddAll (factory, options) {
     it('should add with sha2-256 by default', async function () {
       const content = String(Math.random() + Date.now())
 
-      const files = await all(ipfs.addAll(content))
+      const files = await all(ipfs.addAll([content]))
 
       expect(files).to.have.nested.property('[0].cid.multihash.code', sha256.code)
     })
@@ -491,7 +491,7 @@ export function testAddAll (factory, options) {
     it('should add with a different hashing algorithm', async function () {
       const content = String(Math.random() + Date.now())
 
-      const files = await all(ipfs.addAll(content))
+      const files = await all(ipfs.addAll([content]))
 
       expect(files).to.have.nested.property('[0].cid.multihash.code', sha512.code)
     })

--- a/packages/interface-ipfs-core/src/add-all.js
+++ b/packages/interface-ipfs-core/src/add-all.js
@@ -480,7 +480,7 @@ export function testAddAll (factory, options) {
         .and.to.have.property('name').that.equals('TimeoutError')
     })
 
-    it('should add with sha2-256 by default', async function () {
+    it('should add all with sha2-256 by default', async function () {
       const content = String(Math.random() + Date.now())
 
       const files = await all(ipfs.addAll([content]))
@@ -488,10 +488,10 @@ export function testAddAll (factory, options) {
       expect(files).to.have.nested.property('[0].cid.multihash.code', sha256.code)
     })
 
-    it('should add with a different hashing algorithm', async function () {
+    it('should add all with a different hashing algorithm', async function () {
       const content = String(Math.random() + Date.now())
 
-      const files = await all(ipfs.addAll([content]))
+      const files = await all(ipfs.addAll([content], { hashAlg: 'sha2-512' }))
 
       expect(files).to.have.nested.property('[0].cid.multihash.code', sha512.code)
     })

--- a/packages/interface-ipfs-core/src/add-all.js
+++ b/packages/interface-ipfs-core/src/add-all.js
@@ -15,6 +15,7 @@ import bufferStream from 'it-buffer-stream'
 import * as raw from 'multiformats/codecs/raw'
 import * as dagPB from '@ipld/dag-pb'
 import resolve from 'aegir/utils/resolve.js'
+import { sha256, sha512 } from 'multiformats/hashes/sha2'
 
 /**
  * @typedef {import('ipfsd-ctl').Factory} Factory
@@ -477,6 +478,22 @@ export function testAddAll (factory, options) {
       await expect(ipfs.object.get(out[0].cid, { timeout: 500 }))
         .to.eventually.be.rejected()
         .and.to.have.property('name').that.equals('TimeoutError')
+    })
+
+    it('should add with sha2-256 by default', async function () {
+      const content = String(Math.random() + Date.now())
+
+      const files = await all(ipfs.addAll(content))
+
+      expect(files).to.have.nested.property('[0].cid.multihash.code', sha256.code)
+    })
+
+    it('should add with a different hashing algorithm', async function () {
+      const content = String(Math.random() + Date.now())
+
+      const files = await all(ipfs.addAll(content))
+
+      expect(files).to.have.nested.property('[0].cid.multihash.code', sha512.code)
     })
 
     it('should respect raw leaves when file is smaller than one block and no metadata is present', async () => {

--- a/packages/interface-ipfs-core/src/add.js
+++ b/packages/interface-ipfs-core/src/add.js
@@ -11,6 +11,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import last from 'it-last'
 import * as raw from 'multiformats/codecs/raw'
 import * as dagPB from '@ipld/dag-pb'
+import { sha256, sha512 } from 'multiformats/hashes/sha2'
 
 const echoUrl = (/** @type {string} */ text) => `${process.env.ECHO_SERVER}/download?data=${encodeURIComponent(text)}`
 const redirectUrl = (/** @type {string} */ url) => `${process.env.ECHO_SERVER}/redirect?to=${encodeURI(url)}`
@@ -272,6 +273,22 @@ export function testAdd (factory, options) {
       await expect(ipfs.object.get(file.cid, { timeout: 4000 }))
         .to.eventually.be.rejected()
         .and.to.have.property('name').that.equals('TimeoutError')
+    })
+
+    it('should add with sha2-256 by default', async function () {
+      const content = String(Math.random() + Date.now())
+
+      const file = await ipfs.add(content)
+
+      expect(file).to.have.nested.property('cid.multihash.code', sha256.code)
+    })
+
+    it('should add with a different hashing algorithm', async function () {
+      const content = String(Math.random() + Date.now())
+
+      const file = await ipfs.add(content, { hashAlg: 'sha2-512' })
+
+      expect(file).to.have.nested.property('cid.multihash.code', sha512.code)
     })
 
     it('should add with mode as string', async function () {

--- a/packages/ipfs-core/src/components/index.js
+++ b/packages/ipfs-core/src/components/index.js
@@ -126,7 +126,8 @@ class IPFS {
     const { add, addAll, cat, get, ls } = new RootAPI({
       preload,
       repo,
-      options: options.EXPERIMENTAL
+      options: options.EXPERIMENTAL,
+      hashers: this.hashers
     })
 
     const files = createFiles({

--- a/packages/ipfs-core/src/components/root.js
+++ b/packages/ipfs-core/src/components/root.js
@@ -15,11 +15,12 @@ export class RootAPI {
   /**
    * @param {Context} context
    */
-  constructor ({ preload, repo, options }) {
+  constructor ({ preload, repo, hashers, options }) {
     const addAll = createAddAll({
       preload,
       repo,
-      options
+      options,
+      hashers
     })
 
     this.addAll = addAll


### PR DESCRIPTION
Looks like this got missed during the multiformats migration.

Fixes #3952