### PR TITLE
fix: missing files on publish

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "clean": "rimraf ./dist",
-    "build": "aegir build && copyfiles ./test/fixtures/**/*, ./dist/cjs && copyfiles ./test/fixtures/**/*, ./dist/esm",
+    "build": "aegir build && copyfiles './test/fixtures/**/*' ./dist/cjs && copyfiles './test/fixtures/**/*' ./dist/esm",
     "lint": "aegir ts -p check && aegir lint",
     "dep-check": "aegir dep-check -i ipfs-core-types -i rimraf -i copyfiles"
   },

--- a/packages/ipfs-core-types/package.json
+++ b/packages/ipfs-core-types/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "lint": "aegir ts -p check && aegir lint",
-    "build": "aegir build && copyfiles src/* src/**/* package.json README.md CHANGELOG.md COPYRIGHT LICENSE-APACHE LICENSE-MIT dist"
+    "build": "aegir build && copyfiles 'src/**/*' package.json README.md CHANGELOG.md COPYRIGHT LICENSE-APACHE LICENSE-MIT dist"
   },
   "files": [
     "*",


### PR DESCRIPTION
When using `copyfiles` globstars need to be quoted on a Mac otherwise they don't work

See the README at https://www.npmjs.com/package/copyfiles

Fixes #3976