### PR TITLE
fix: add deps used in ipfs-core-types

### DIFF
--- a/packages/ipfs-core-types/package.json
+++ b/packages/ipfs-core-types/package.json
@@ -43,7 +43,9 @@
   ],
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
+    "@ipld/dag-pb": "^2.1.3",
     "interface-datastore": "^6.0.2",
+    "ipfs-unixfs": "^6.0.3",
     "multiaddr": "^10.0.0",
     "multiformats": "^9.5.1"
   },


### PR DESCRIPTION
These deps were missing