### PR TITLE
fix(rmlink): fix rmlink to match docs

### DIFF
--- a/docs/core-api/OBJECT.md
+++ b/docs/core-api/OBJECT.md
@@ -398,9 +398,9 @@ An optional object which may have the following keys:
 ```JavaScript
 // cid is CID of the DAG node created by removing a link
 const cid = await ipfs.object.patch.rmLink(node, {
-  name: 'some-link',
-  size: 10,
-  cid: CID.parse('QmPTkMuuL6PD8L2SwTwbcs1NPg14U8mRzerB1ZrrBrkSDD')
+  Name: 'some-link',
+  Tsize: 10,
+  Hash: CID.parse('QmPTkMuuL6PD8L2SwTwbcs1NPg14U8mRzerB1ZrrBrkSDD')
 })
 ```
 

--- a/packages/ipfs-core/src/components/object/patch/rm-link.js
+++ b/packages/ipfs-core/src/components/object/patch/rm-link.js
@@ -14,9 +14,9 @@ export function createRmLink ({ repo, preload }) {
   /**
    * @type {import('ipfs-core-types/src/object/patch').API<{}>["rmLink"]}
    */
-  async function rmLink (multihash, linkRef, options = {}) {
-    const node = await get(multihash, options)
-    const name = (typeof linkRef === 'string' ? linkRef : linkRef.Name) || ''
+  async function rmLink (cid, link, options = {}) {
+    const node = await get(cid, options)
+    const name = (typeof link === 'string' ? link : link.Name) || ''
 
     node.Links = node.Links.filter(l => l.Name !== name)
 


### PR DESCRIPTION
Resolves #3815 
The test provided for `rmlink` has the object structured as: 
https://github.com/ipfs/js-ipfs/blob/master/packages/interface-ipfs-core/src/object/patch/rm-link.js#L49-L55
```js
const childAsDAGLink = {
   Name: 'my-link',
   Tsize: childBuf.length,
   Hash: CID.createV0(await sha256.digest(childBuf))
}
```
While the documentation has it defined as:
```js
const cid = await ipfs.object.patch.rmLink(node, {
  name: 'some-link',
  size: 10,
  cid: CID.parse('QmPTkMuuL6PD8L2SwTwbcs1NPg14U8mRzerB1ZrrBrkSDD')
})
```
Method has been updated to match the variable names in the documentation and the example has been altered to match the example in the test case.
