### PR TITLE
fix: update car dependency for CARv2 read support

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@ipld/car": "^3.1.6",
+    "@ipld/car": "^4.1.0",
     "@ipld/dag-cbor": "^7.0.0",
     "@ipld/dag-pb": "^2.1.3",
     "@types/pako": "^1.0.2",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@chainsafe/libp2p-noise": "^5.0.0",
-    "@ipld/car": "^3.1.0",
+    "@ipld/car": "^4.1.0",
     "@ipld/dag-cbor": "^7.0.0",
     "@ipld/dag-json": "^8.0.1",
     "@ipld/dag-pb": "^2.1.3",


### PR DESCRIPTION
4.x adds basic CARv2 read support, so you could `ipfs dag import` a CARv2 with this; also with https://explore.ipld.io/ getting CAR support, this would allow importing and inspection of a CARv2 there.

The breakage was in the return type definition of `CarReader#header()` which I don't believe is touched in js-ipfs, which only cares about `getRoots()` in the header which remains the same.