### PR TITLE
fix: upgrade dep of ipfs-utils ^9.0.2->^9.0.6

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -75,7 +75,7 @@
     "ipfs-core-types": "^0.10.2",
     "ipfs-unixfs": "^6.0.3",
     "ipfs-unixfs-importer": "^9.0.3",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "ipns": "^0.16.0",
     "is-ipfs": "^6.0.1",
     "iso-random-stream": "^2.0.2",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -71,7 +71,7 @@
     "ipfs-daemon": "^0.12.2",
     "ipfs-http-client": "^56.0.2",
     "ipfs-repo": "^14.0.1",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "it-all": "^1.0.4",
     "it-concat": "^2.0.0",
     "it-first": "^1.0.4",

--- a/packages/ipfs-core-config/package.json
+++ b/packages/ipfs-core-config/package.json
@@ -88,7 +88,7 @@
     "hashlru": "^2.3.0",
     "interface-datastore": "^6.0.2",
     "ipfs-repo": "^14.0.1",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "ipns": "^0.16.0",
     "is-ipfs": "^6.0.1",
     "it-all": "^1.0.4",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -121,7 +121,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.10.2",
     "ipfs-unixfs": "^6.0.3",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "it-all": "^1.0.4",
     "it-map": "^1.0.4",
     "it-peekable": "^1.0.2",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -95,7 +95,7 @@
     "ipfs-unixfs": "^6.0.3",
     "ipfs-unixfs-exporter": "^7.0.3",
     "ipfs-unixfs-importer": "^9.0.3",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "ipns": "^0.16.0",
     "is-domain-name": "^1.0.1",
     "is-ipfs": "^6.0.1",

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -49,7 +49,7 @@
     "ipfs-grpc-server": "^0.8.3",
     "ipfs-http-gateway": "^0.9.2",
     "ipfs-http-server": "^0.11.2",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "just-safe-set": "^2.2.1",
     "libp2p": "^0.36.2",
     "libp2p-webrtc-star": "^0.25.0"

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -63,7 +63,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.10.2",
     "ipfs-core-utils": "^0.14.2",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "it-first": "^1.0.6",
     "it-last": "^1.0.4",
     "merge-options": "^3.0.4",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -89,7 +89,7 @@
     "ipfs-core-types": "^0.10.2",
     "ipfs-http-client": "^56.0.2",
     "ipfs-interop": "^8.0.9",
-    "ipfs-utils": "^9.0.2",
+    "ipfs-utils": "^9.0.6",
     "ipfsd-ctl": "^10.0.4",
     "iso-url": "^1.0.0",
     "libp2p-webrtc-star-signalling-server": "^0.1.1",


### PR DESCRIPTION
Motivation:
* fix https://github.com/ipfs/js-ipfs/issues/4080
  * I'm not sure what the best way is to fully release this in a way that ipfs-core@latest on npm works (which needs to bundle in ipfs-utils @ 9.0.6 not 9.0.2). Happy to try another strategy if you point me in a better direction