### PR TITLE
Updates findProvs example

### DIFF
--- a/docs/core-api/DHT.md
+++ b/docs/core-api/DHT.md
@@ -109,7 +109,7 @@ Note that if `options.numProviders` are not found an error will be thrown.
 ### Example
 
 ```JavaScript
-const providers = ipfs.dht.findProvs('QmdPAhQRxrDKqkGPvQzBvjYe3kU8kiEEAd2J6ETEamKAD9')
+const providers = ipfs.dht.findProvs(Ipfs.CID.parse('QmdPAhQRxrDKqkGPvQzBvjYe3kU8kiEEAd2J6ETEamKAD9'))
 
 for await (const provider of providers) {
   console.log(provider.id.toString())

--- a/docs/core-api/DHT.md
+++ b/docs/core-api/DHT.md
@@ -109,7 +109,9 @@ Note that if `options.numProviders` are not found an error will be thrown.
 ### Example
 
 ```JavaScript
-const providers = ipfs.dht.findProvs(Ipfs.CID.parse('QmdPAhQRxrDKqkGPvQzBvjYe3kU8kiEEAd2J6ETEamKAD9'))
+import { CID } from 'multiformats/cid'
+
+const providers = ipfs.dht.findProvs(CID.parse('QmdPAhQRxrDKqkGPvQzBvjYe3kU8kiEEAd2J6ETEamKAD9'))
 
 for await (const provider of providers) {
   console.log(provider.id.toString())


### PR DESCRIPTION
Perhaps this is outdated? findProvs (as mentioned on lines 87-89) is expecting a CID, not a string