### PR TITLE
fix: export ipfs-http-client types

### DIFF
--- a/packages/ipfs-http-client/src/index.js
+++ b/packages/ipfs-http-client/src/index.js
@@ -46,11 +46,16 @@ import { createVersion } from './version.js'
 import globSourceImport from 'ipfs-utils/src/files/glob-source.js'
 
 /**
- * @typedef {import('./types').EndpointConfig} EndpointConfig
- * @typedef {import('./types').Options} Options
  * @typedef {import('multiformats/codecs/interface').BlockCodec<any, any>} BlockCodec
  * @typedef {import('multiformats/hashes/interface').MultihashHasher} MultihashHasher
  * @typedef {import('multiformats/bases/interface').MultibaseCodec<any>} MultibaseCodec
+ * @typedef {import('./types').Options} Options
+ * @typedef {import('./types').LoadBaseFn} LoadBaseFn
+ * @typedef {import('./types').LoadCodecFn} LoadCodecFn
+ * @typedef {import('./types').LoadHasherFn} LoadHasherFn
+ * @typedef {import('./types').IPLDOptions} IPLDOptions
+ * @typedef {import('./types').HTTPClientExtraOptions} HTTPClientExtraOptions
+ * @typedef {import('./types').EndpointConfig} EndpointConfig
  * @typedef {import('./types').IPFSHTTPClient} IPFSHTTPClient
  */
 


### PR DESCRIPTION
With the addition of an export-map the `src/types.ts` file is no longer importable so make sure we can import the various ipfs-http-client type defs from the root.