### PR TITLE
`ipfs-http-client` update exports field

### DIFF
--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -18,7 +18,9 @@
   "exports": {
     ".": {
       "import": "./src/index.js"
-    }
+    },
+    "./index.js": "./index.js",
+    "./index.min.js": "./index.min.js"
   },
   "eslintConfig": {
     "extends": "ipfs",


### PR DESCRIPTION
# Add exports to `ipfs-http-client`
## Description
Update the `ipfs-http-client` `package.json` to support importing relative paths for the bundled `index.js` and `index.min.js` code.

## Proplem
I'm currently using an ESM-focused bundler (Vite) and importing the source `ipfs-http-client` code causes issues with polyfills. Importing the bundled version fixes this and the minified version enables further optimization. Currently vite imports the `./src/index.js` file as that is what is specified byt the `exports` field. 
I have found a temporary solution in my project by manually resolving the package with `path.resolve(node_modules/ipfs-http-client/index.js)` but this is counter to using the regular node resolution algorithm.

## Solution
By adding subpaths to the exports field, the node resolution algorithm will be able to import the bundle and minified bundled if the developer specifies it. Critically, default import behaviour is not changed. Bundle is imported **only** if the developer species the subpath `import IPFS from 'ipfs-http-client/index.js'`.

## Additional Links
https://webpack.js.org/guides/package-exports/

