### PR TITLE
Updating Docs in accordance with error #4130

### DIFF
--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -120,7 +120,7 @@ Alternatively it can be an object which may have the following keys:
 #### Example
 
 ```JavaScript
-import { create } from 'ipfs-http-client'
+const { create } = await import('ipfs-http-client')
 
 // connect to the default API address http://localhost:5001
 const client = create()


### PR DESCRIPTION
Updating IPFS-HTTP-CLIENT docs in accordance with the issue highlighted in #4130, ERR_PACKAGE_PATH_NOT_EXPORTED with ipfs-http-client and typescript.


closes #4169 