### PR TITLE
deps: upgrade @multiformats/multiaddr to 10.4.0

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -73,7 +73,7 @@
     "@libp2p/peer-id": "^1.1.10",
     "@libp2p/peer-id-factory": "^1.0.10",
     "@libp2p/websockets": "^3.0.0",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "@types/node": "^18.0.0",
     "@types/pako": "^2.0.0",
     "@types/readable-stream": "^2.3.13",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -73,7 +73,7 @@
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.10",
     "@multiformats/mafmt": "^11.0.2",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "@multiformats/multiaddr-to-uri": "^9.0.1",
     "byteman": "^1.3.5",
     "execa": "^6.1.0",

--- a/packages/ipfs-core-types/package.json
+++ b/packages/ipfs-core-types/package.json
@@ -52,7 +52,7 @@
     "@libp2p/interface-peer-id": "^1.0.4",
     "@libp2p/interface-peer-info": "^1.0.2",
     "@libp2p/interface-pubsub": "^2.0.0",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "@types/node": "^18.0.0",
     "interface-datastore": "^7.0.0",
     "ipfs-unixfs": "^7.0.0",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -141,7 +141,7 @@
   },
   "dependencies": {
     "@libp2p/logger": "^2.0.0",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "@multiformats/multiaddr-to-uri": "^9.0.1",
     "any-signal": "^3.0.0",
     "blob-to-it": "^1.0.1",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -96,7 +96,7 @@
     "@libp2p/record": "^2.0.0",
     "@libp2p/websockets": "^3.0.0",
     "@multiformats/mafmt": "^11.0.2",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "@multiformats/multiaddr-to-uri": "^9.0.1",
     "@multiformats/murmur3": "^1.1.1",
     "any-signal": "^3.0.0",

--- a/packages/ipfs-grpc-client/package.json
+++ b/packages/ipfs-grpc-client/package.json
@@ -71,7 +71,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.10",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "change-case": "^4.1.1",
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.11.0",

--- a/packages/ipfs-grpc-server/package.json
+++ b/packages/ipfs-grpc-server/package.json
@@ -66,7 +66,7 @@
     "@grpc/grpc-js": "^1.1.8",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.10",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "change-case": "^4.1.1",
     "coercer": "^1.1.2",
     "ipfs-core-types": "^0.11.0",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -72,7 +72,7 @@
     "@ipld/dag-pb": "^2.1.3",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.10",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "any-signal": "^3.0.0",
     "dag-jose": "^2.0.1",
     "err-code": "^3.0.1",

--- a/packages/ipfs-http-server/package.json
+++ b/packages/ipfs-http-server/package.json
@@ -72,7 +72,7 @@
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.10",
-    "@multiformats/multiaddr": "^10.1.8",
+    "@multiformats/multiaddr": "^10.4.0",
     "any-signal": "^3.0.0",
     "dlv": "^1.1.3",
     "hapi-pino": "^8.5.0",


### PR DESCRIPTION
Shipping fix from https://github.com/multiformats/js-multiaddr/pull/253 is required to fix https://github.com/libp2p/go-libp2p-relay-daemon/issues/18 and unblock @thediscordian to update https://docs.ipfs.tech/how-to/create-simple-chat-app/ tutorial 

Filling this PR to see if it is an easy bump that can be shipped as a patch, or more work needs to happen.


## TODO

- [ ] re-run after CID is fixed in  `master` 