### PR TITLE
Support for TypeScript + ESM

### DIFF
--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -17,7 +17,8 @@
   ],
   "exports": {
     ".": {
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "types": "./dist/src/index.d.ts"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
We need typings inside "export" to support TypeScript with ESM enabled. See [TypeScript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html).