### PR TITLE
deps: update libp2p to 0.39.0

### DIFF
--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -137,7 +137,7 @@
     "it-tar": "^6.0.0",
     "it-to-buffer": "^2.0.0",
     "just-safe-set": "^4.0.2",
-    "libp2p": "^0.38.0",
+    "libp2p": "^0.39.0",
     "merge-options": "^3.0.4",
     "mortice": "^3.0.0",
     "multiformats": "^9.5.1",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -90,7 +90,7 @@
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/kad-dht": "^3.0.0",
     "@libp2p/logger": "^2.0.0",
-    "@libp2p/mplex": "^5.0.0",
+    "@libp2p/mplex": "^5.2.0",
     "@libp2p/peer-id": "^1.1.10",
     "@libp2p/peer-id-factory": "^1.0.10",
     "@libp2p/record": "^2.0.0",

--- a/packages/ipfs-core/src/components/network.js
+++ b/packages/ipfs-core/src/components/network.js
@@ -64,10 +64,6 @@ export class Network {
       keychainConfig: undefined
     })
 
-    if (libp2p.keychain) {
-      await libp2p.loadKeychain()
-    }
-
     await libp2p.start()
 
     for (const ma of libp2p.getMultiaddrs()) {

--- a/packages/ipfs-core/src/components/storage.js
+++ b/packages/ipfs-core/src/components/storage.js
@@ -159,8 +159,6 @@ const initRepo = async (print, repo, options) => {
   })
 
   if (libp2p.keychain) {
-    await libp2p.loadKeychain()
-
     await repo.config.set('Keychain', {
       // @ts-expect-error private field
       DEK: libp2p.keychain.init.dek
@@ -263,10 +261,6 @@ const configureRepo = async (repo, options) => {
       ...changed.Keychain
     }
   })
-
-  if (libp2p.keychain) {
-    await libp2p.loadKeychain()
-  }
 
   return { peerId, keychain: libp2p.keychain }
 }

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -72,7 +72,7 @@
     "ipfs-http-gateway": "^0.10.0",
     "ipfs-http-server": "^0.12.0",
     "ipfs-utils": "^9.0.6",
-    "libp2p": "^0.38.0"
+    "libp2p": "^0.39.0"
   },
   "devDependencies": {
     "aegir": "^37.0.11",


### PR DESCRIPTION
The update removes the need to load the keychain manually.