### PR TITLE
fix: add node memory stats to prometheus output

### DIFF
--- a/packages/ipfs-http-server/src/api/routes/debug.js
+++ b/packages/ipfs-http-server/src/api/routes/debug.js
@@ -8,7 +8,13 @@ import { disable, enable } from '@libp2p/logger'
 client.register.clear()
 
 /** @type {Record<string, client.Gauge<any>>} */
-const gauges = {}
+const gauges = {
+  'nodejs_memory_usage': new client.Gauge({
+    name: 'nodejs_memory_usage',
+    help: 'nodejs_memory_usage',
+    labelNames: Object.keys(process.memoryUsage())
+  })
+}
 
 // Endpoint for handling debug metrics
 export default [{
@@ -22,6 +28,10 @@ export default [{
     if (!process.env.IPFS_MONITORING) {
       throw Boom.notImplemented('Monitoring is disabled. Enable it by setting environment variable IPFS_MONITORING')
     }
+
+    Object.entries(process.memoryUsage()).forEach(([key, value]) => {
+      gauges['nodejs_memory_usage'].set({ [key]: key }, value)
+    })
 
     const { ipfs } = request.server.app
     // @ts-expect-error libp2p does not exist on ipfs

--- a/packages/ipfs-http-server/src/api/routes/debug.js
+++ b/packages/ipfs-http-server/src/api/routes/debug.js
@@ -9,7 +9,7 @@ client.register.clear()
 
 /** @type {Record<string, client.Gauge<any>>} */
 const gauges = {
-  'nodejs_memory_usage': new client.Gauge({
+  nodejs_memory_usage: new client.Gauge({
     name: 'nodejs_memory_usage',
     help: 'nodejs_memory_usage',
     labelNames: Object.keys(process.memoryUsage())
@@ -30,7 +30,7 @@ export default [{
     }
 
     Object.entries(process.memoryUsage()).forEach(([key, value]) => {
-      gauges['nodejs_memory_usage'].set({ [key]: key }, value)
+      gauges.nodejs_memory_usage.set({ [key]: key }, value)
     })
 
     const { ipfs } = request.server.app


### PR DESCRIPTION
The default prometheus memory stats are clunky and hard to interpret without additional tools like graphana because you get separate measurements for different types of memory usage.

Add a single `nodejs_memory_usage` metric that is the output of `process.memoryUsage()`.