### PR TITLE
fix: replace slice with subarray for increased performance

### DIFF
--- a/packages/ipfs-cli/src/commands/cat.js
+++ b/packages/ipfs-cli/src/commands/cat.js
@@ -6,6 +6,7 @@ import parseDuration from 'parse-duration'
  * @property {string} Argv.ipfsPath
  * @property {number} Argv.offset
  * @property {number} Argv.length
+ * @property {boolean} Argv.preload
  * @property {number} Argv.timeout
  */
 
@@ -26,14 +27,19 @@ const command = {
       number: true,
       describe: 'Maximum number of bytes to read'
     },
+    preload: {
+      boolean: true,
+      default: true,
+      describe: 'Preload this object when adding'
+    },
     timeout: {
       string: true,
       coerce: parseDuration
     }
   },
 
-  async handler ({ ctx: { ipfs, print }, ipfsPath, offset, length, timeout }) {
-    for await (const buf of ipfs.cat(ipfsPath, { offset, length, timeout })) {
+  async handler ({ ctx: { ipfs, print }, ipfsPath, offset, length, preload, timeout }) {
+    for await (const buf of ipfs.cat(ipfsPath, { offset, length, preload, timeout })) {
       print.write(buf)
     }
   }

--- a/packages/ipfs-cli/src/commands/get.js
+++ b/packages/ipfs-cli/src/commands/get.js
@@ -110,7 +110,6 @@ const command = {
             await fs.promises.mkdir(path.dirname(outputPath), { recursive: true })
             await pipe(
               body,
-              (source) => map(source, buf => buf.slice()),
               toIterable.sink(fs.createWriteStream(outputPath))
             )
           } else if (header.type === 'directory') {

--- a/packages/ipfs-cli/test/get.spec.js
+++ b/packages/ipfs-cli/test/get.spec.js
@@ -27,11 +27,7 @@ const defaultOptions = {
 async function * tarballed (files) {
   yield * pipe(
     files,
-    pack(),
-    /**
-     * @param {AsyncIterable<Uint8Array>} source
-     */
-    (source) => map(source, buf => buf.slice())
+    pack()
   )
 }
 

--- a/packages/ipfs-core/src/components/files/utils/hamt-constants.js
+++ b/packages/ipfs-core/src/components/files/utils/hamt-constants.js
@@ -11,7 +11,7 @@ export async function hamtHashFn (buf) {
     // Murmur3 outputs 128 bit but, accidentally, IPFS Go's
     // implementation only uses the first 64, so we must do the same
     // for parity..
-    .slice(0, 8)
+    .subarray(0, 8)
     // Invert buffer because that's how Go impl does it
     .reverse()
 }

--- a/packages/ipfs-core/src/components/files/utils/to-async-iterator.js
+++ b/packages/ipfs-core/src/components/files/utils/to-async-iterator.js
@@ -56,7 +56,7 @@ export function toAsyncIterator (content) {
         }
 
         return new Promise((resolve, reject) => {
-          const chunk = content.slice(index, MFS_MAX_CHUNK_SIZE)
+          const chunk = content.subarray(index, MFS_MAX_CHUNK_SIZE)
           index += MFS_MAX_CHUNK_SIZE
 
           const reader = new global.FileReader()

--- a/packages/ipfs-core/src/components/files/write.js
+++ b/packages/ipfs-core/src/components/files/write.js
@@ -334,7 +334,7 @@ const limitAsyncStreamBytes = (stream, limit) => {
       emitted += buf.length
 
       if (emitted > limit) {
-        yield buf.slice(0, limit - emitted)
+        yield buf.subarray(0, limit - emitted)
 
         return
       }
@@ -353,7 +353,7 @@ const asyncZeroes = (count, chunkSize = MFS_MAX_CHUNK_SIZE) => {
 
   async function * _asyncZeroes () {
     while (true) {
-      yield buf.slice()
+      yield buf
     }
   }
 

--- a/packages/ipfs-core/src/components/get.js
+++ b/packages/ipfs-core/src/components/get.js
@@ -57,11 +57,7 @@ export function createGet ({ repo, preload }) {
           },
           body: file.content()
         }],
-        pack(),
-        /**
-         * @param {AsyncIterable<Uint8Array>} source
-         */
-        (source) => map(source, buf => buf.slice())
+        pack()
         )
       } else {
         args.push(
@@ -126,11 +122,7 @@ export function createGet ({ repo, preload }) {
             yield output
           }
         },
-        pack(),
-        /**
-         * @param {AsyncIterable<Uint8Array>} source
-         */
-        (source) => map(source, buf => buf.slice())
+        pack()
       ]
 
       if (options.compress) {

--- a/packages/ipfs-grpc-server/src/utils/web-socket-message-channel.js
+++ b/packages/ipfs-grpc-server/src/utils/web-socket-message-channel.js
@@ -77,7 +77,7 @@ export class WebSocketMessageChannel {
         return
       }
 
-      const header = buf.slice(offset, HEADER_SIZE + offset)
+      const header = buf.subarray(offset, HEADER_SIZE + offset)
       const length = header.readUInt32BE(1)
       offset += HEADER_SIZE
 
@@ -85,7 +85,7 @@ export class WebSocketMessageChannel {
         return
       }
 
-      const message = buf.slice(offset, offset + length)
+      const message = buf.subarray(offset, offset + length)
       const deserialized = this.handler.deserialize(message)
       this.source.push(deserialized)
     })

--- a/packages/ipfs-http-gateway/src/resources/gateway.js
+++ b/packages/ipfs-http-gateway/src/resources/gateway.js
@@ -132,11 +132,7 @@ export const Gateway = {
     }
 
     const { source, contentType } = await detectContentType(ipfsPath, ipfs.cat(data.cid, catOptions))
-    const responseStream = toStream.readable((async function * () {
-      for await (const chunk of source) {
-        yield chunk.slice() // Convert BufferList to Buffer
-      }
-    })())
+    const responseStream = toStream.readable(source)
 
     const res = h.response(responseStream).code(rangeResponse ? 206 : 200)
 

--- a/packages/ipfs-http-response/src/utils/content-type.js
+++ b/packages/ipfs-http-response/src/utils/content-type.js
@@ -28,11 +28,11 @@ export const detectContentType = async (path, source) => {
 
       if (done) {
         return {
-          source: map(stream, (buf) => buf.slice())
+          source: map(stream, (buf) => buf.subarray())
         }
       }
 
-      fileSignature = await fileTypeFromBuffer(value.slice())
+      fileSignature = await fileTypeFromBuffer(value.subarray())
 
       output = (async function * () { // eslint-disable-line require-await
         yield value
@@ -62,7 +62,14 @@ export const detectContentType = async (path, source) => {
   }
 
   if (output != null) {
-    return { source: map(output, (buf) => buf.slice()), contentType }
+    return {
+      source: async function * () {
+        for await (const list of output) {
+          yield * list
+        }
+      }(),
+      contentType
+    }
   }
 
   return { source, contentType }


### PR DESCRIPTION
In several places we call `.slice` as a way to transform `BufferList`s to `Uint8Array`s. Due to refactors in some places we are now calling `.slice` on `Uint8Array`s which is a memory-copy operation.

In other places `Uint8ArrayList`s are now returned instead of `BufferList`s on which `.slice` is also a memory-copy operation.

Swap `.slice` for `.subarray` which is no-copy for `Uint8Array`s and can be no-copy for `Uint8ArrayList`s too, where there is only a single backing buffer.

In places where we need to transform multiple `Uint8ArrayList`s to multiple `Uint8Array`s, yield the iterators of the `Uint8ArrayList`s as this is also a no-copy operation.