### PR TITLE
docs:  Object API deprecation

### DIFF
--- a/docs/core-api/OBJECT.md
+++ b/docs/core-api/OBJECT.md
@@ -1,5 +1,7 @@
 # Object API <!-- omit in toc -->
 
+> ⚠️ Object API is [deprecated](https://github.com/ipfs/go-ipfs/issues/7936), use [FILES](FILES.md) and [DAG](DAG.md) APIs instead.
+
 - [`ipfs.object.new([options])`](#ipfsobjectnewoptions)
   - [Parameters](#parameters)
   - [Options](#options)

--- a/docs/core-api/README.md
+++ b/docs/core-api/README.md
@@ -1,11 +1,11 @@
 # IPFS Core API
 
-This directory contains the description of the core JS IPFS API. In order to be considered "valid", a JS IPFS core implementation must expose the API described here. 
+This directory contains the description of the core JS IPFS API. In order to be considered "valid", a JS IPFS core implementation must expose the API described here.
 This abstraction allows for different implementations including:
 1. Full JavaScript native implementation
 2. Delgate implementation that invokes another IPFS implementation (e.g., Kubo)
 
-You can use this loose spec as documentation for consuming the core APIs.  
+You can use this loose spec as documentation for consuming the core APIs.
 
 It is broken up into the following sections:
 
@@ -19,7 +19,7 @@ It is broken up into the following sections:
 * [KEY.md](KEY.md)
 * [MISCELLANEOUS.md](MISCELLANEOUS.md)
 * [NAME.md](NAME.md)
-* [OBJECT.md](OBJECT.md)
+* [OBJECT.md](OBJECT.md) ([deprecated](https://github.com/ipfs/go-ipfs/issues/7936), use the [DAG API](DAG.md) instead)
 * [PIN.md](PIN.md)
 * [PUBSUB.md](PUBSUB.md)
 * [REFS.md](REFS.md)


### PR DESCRIPTION
Context: https://github.com/ipfs/go-ipfs/issues/7936