### PR TITLE
deps(dev): update interop suite

### DIFF
--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -95,7 +95,7 @@
     "ipfs-client": "^0.9.0",
     "ipfs-core-types": "^0.12.0",
     "ipfs-http-client": "^58.0.0",
-    "ipfs-interop": "ipfs/interop#feat/upgrade-to-esm-libp2p",
+    "ipfs-interop": "^9.0.0",
     "ipfs-utils": "^9.0.6",
     "ipfsd-ctl": "^12.0.0",
     "iso-url": "^1.0.0",


### PR DESCRIPTION
The interop suite has been updated with the ESM ipfs and libp2p so the branch no longer exists.