### PR TITLE
chore: update changelog types to add docs and deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,6 +233,14 @@ jobs:
           release-type: node
           manifest-file: .release-please-manifest.json
           config-file: .release-please.json
+          changelog-types: |
+            [
+              { "type": "feat", "section": "Features", "hidden": false },
+              { "type": "fix", "section": "Bug Fixes", "hidden": false },
+              { "type": "chore", "section": "Trivial Changes", "hidden": false },
+              { "type": "docs", "section": "Documentation", "hidden": false },
+              { "type": "deps", "section": "Dependencies", "hidden": false }
+            ]
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
This should affect how the release issue is generated, might need some additional lerna config to make sure the github release is created in the same way.