### PR TITLE
fix: ipfs-http-client exports

### DIFF
--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -45,7 +45,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "require": "./src/index.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
Fix implemented for making it work when using NodeJs module.createRequire. FYI > https://nodejs.org/api/module.html#modulecreaterequirefilename

Signed-off-by: inglkruiz <12603425+inglkruiz@users.noreply.github.com>