### PR TITLE
deps: update @chainsafe/libp2p-gossipsub to 6.0.0

### DIFF
--- a/packages/ipfs-core-config/package.json
+++ b/packages/ipfs-core-config/package.json
@@ -94,7 +94,7 @@
     "build": "aegir build"
   },
   "dependencies": {
-    "@chainsafe/libp2p-gossipsub": "^5.2.1",
+    "@chainsafe/libp2p-gossipsub": "^6.0.0",
     "@libp2p/floodsub": "^6.0.0",
     "@libp2p/logger": "^2.0.2",
     "@libp2p/mdns": "^6.0.0",

--- a/packages/ipfs-core/package.json
+++ b/packages/ipfs-core/package.json
@@ -148,7 +148,7 @@
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
-    "@chainsafe/libp2p-gossipsub": "^5.2.1",
+    "@chainsafe/libp2p-gossipsub": "^6.0.0",
     "@types/dlv": "^1.1.2",
     "@types/pako": "^2.0.0",
     "@types/rimraf": "^3.0.1",


### PR DESCRIPTION
Updates to latest version with new multiformats dependency