### PR TITLE
deps: update ipfs-utils for node 18 compatibility

### DIFF
--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -87,7 +87,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
     "ipfs-unixfs-importer": "^12.0.0",
-    "ipfs-utils": "^9.0.11",
+    "ipfs-utils": "^9.0.12",
     "ipns": "^5.0.1",
     "is-ipfs": "^8.0.0",
     "iso-random-stream": "^2.0.2",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -87,7 +87,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
     "ipfs-unixfs-importer": "^12.0.0",
-    "ipfs-utils": "^9.0.10",
+    "ipfs-utils": "^9.0.11",
     "ipns": "^5.0.1",
     "is-ipfs": "^8.0.0",
     "iso-random-stream": "^2.0.2",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -87,7 +87,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
     "ipfs-unixfs-importer": "^12.0.0",
-    "ipfs-utils": "^9.0.6",
+    "ipfs-utils": "^9.0.10",
     "ipns": "^5.0.1",
     "is-ipfs": "^8.0.0",
     "iso-random-stream": "^2.0.2",

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -87,7 +87,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
     "ipfs-unixfs-importer": "^12.0.0",
-    "ipfs-utils": "^9.0.12",
+    "ipfs-utils": "^9.0.13",
     "ipns": "^5.0.1",
     "is-ipfs": "^8.0.0",
     "iso-random-stream": "^2.0.2",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -83,7 +83,7 @@
     "ipfs-core-utils": "^0.17.0",
     "ipfs-daemon": "^0.15.0",
     "ipfs-http-client": "^59.0.0",
-    "ipfs-utils": "^9.0.6",
+    "ipfs-utils": "^9.0.10",
     "it-concat": "^3.0.1",
     "it-merge": "^2.0.0",
     "it-pipe": "^2.0.3",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -83,7 +83,7 @@
     "ipfs-core-utils": "^0.17.0",
     "ipfs-daemon": "^0.15.0",
     "ipfs-http-client": "^59.0.0",
-    "ipfs-utils": "^9.0.11",
+    "ipfs-utils": "^9.0.12",
     "it-concat": "^3.0.1",
     "it-merge": "^2.0.0",
     "it-pipe": "^2.0.3",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -83,7 +83,7 @@
     "ipfs-core-utils": "^0.17.0",
     "ipfs-daemon": "^0.15.0",
     "ipfs-http-client": "^59.0.0",
-    "ipfs-utils": "^9.0.10",
+    "ipfs-utils": "^9.0.11",
     "it-concat": "^3.0.1",
     "it-merge": "^2.0.0",
     "it-pipe": "^2.0.3",

--- a/packages/ipfs-cli/package.json
+++ b/packages/ipfs-cli/package.json
@@ -83,7 +83,7 @@
     "ipfs-core-utils": "^0.17.0",
     "ipfs-daemon": "^0.15.0",
     "ipfs-http-client": "^59.0.0",
-    "ipfs-utils": "^9.0.12",
+    "ipfs-utils": "^9.0.13",
     "it-concat": "^3.0.1",
     "it-merge": "^2.0.0",
     "it-pipe": "^2.0.3",

--- a/packages/ipfs-core-config/package.json
+++ b/packages/ipfs-core-config/package.json
@@ -109,7 +109,7 @@
     "hashlru": "^2.3.0",
     "interface-datastore": "^7.0.0",
     "ipfs-repo": "^17.0.0",
-    "ipfs-utils": "^9.0.11",
+    "ipfs-utils": "^9.0.12",
     "is-ipfs": "^8.0.0",
     "it-all": "^2.0.0",
     "it-drain": "^2.0.0",

--- a/packages/ipfs-core-config/package.json
+++ b/packages/ipfs-core-config/package.json
@@ -109,7 +109,7 @@
     "hashlru": "^2.3.0",
     "interface-datastore": "^7.0.0",
     "ipfs-repo": "^17.0.0",
-    "ipfs-utils": "^9.0.12",
+    "ipfs-utils": "^9.0.13",
     "is-ipfs": "^8.0.0",
     "it-all": "^2.0.0",
     "it-drain": "^2.0.0",

--- a/packages/ipfs-core-config/package.json
+++ b/packages/ipfs-core-config/package.json
@@ -109,7 +109,7 @@
     "hashlru": "^2.3.0",
     "interface-datastore": "^7.0.0",
     "ipfs-repo": "^17.0.0",
-    "ipfs-utils": "^9.0.10",
+    "ipfs-utils": "^9.0.11",
     "is-ipfs": "^8.0.0",
     "it-all": "^2.0.0",
     "it-drain": "^2.0.0",

--- a/packages/ipfs-core-config/package.json
+++ b/packages/ipfs-core-config/package.json
@@ -109,7 +109,7 @@
     "hashlru": "^2.3.0",
     "interface-datastore": "^7.0.0",
     "ipfs-repo": "^17.0.0",
-    "ipfs-utils": "^9.0.6",
+    "ipfs-utils": "^9.0.10",
     "is-ipfs": "^8.0.0",
     "it-all": "^2.0.0",
     "it-drain": "^2.0.0",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -149,7 +149,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
-    "ipfs-utils": "^9.0.6",
+    "ipfs-utils": "^9.0.10",
     "it-all": "^2.0.0",
     "it-map": "^2.0.0",
     "it-peekable": "^2.0.0",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -149,7 +149,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
-    "ipfs-utils": "^9.0.10",
+    "ipfs-utils": "^9.0.11",
     "it-all": "^2.0.0",
     "it-map": "^2.0.0",
     "it-peekable": "^2.0.0",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -149,7 +149,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
-    "ipfs-utils": "^9.0.11",
+    "ipfs-utils": "^9.0.12",
     "it-all": "^2.0.0",
     "it-map": "^2.0.0",
     "it-peekable": "^2.0.0",

--- a/packages/ipfs-core-utils/package.json
+++ b/packages/ipfs-core-utils/package.json
@@ -149,7 +149,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-unixfs": "^9.0.0",
-    "ipfs-utils": "^9.0.12",
+    "ipfs-utils": "^9.0.13",
     "it-all": "^2.0.0",
     "it-map": "^2.0.0",
     "it-peekable": "^2.0.0",

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -71,7 +71,7 @@
     "ipfs-grpc-server": "^0.11.0",
     "ipfs-http-gateway": "^0.12.0",
     "ipfs-http-server": "^0.14.0",
-    "ipfs-utils": "^9.0.10",
+    "ipfs-utils": "^9.0.11",
     "libp2p": "next"
   },
   "devDependencies": {

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -71,7 +71,7 @@
     "ipfs-grpc-server": "^0.11.0",
     "ipfs-http-gateway": "^0.12.0",
     "ipfs-http-server": "^0.14.0",
-    "ipfs-utils": "^9.0.6",
+    "ipfs-utils": "^9.0.10",
     "libp2p": "next"
   },
   "devDependencies": {

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -71,7 +71,7 @@
     "ipfs-grpc-server": "^0.11.0",
     "ipfs-http-gateway": "^0.12.0",
     "ipfs-http-server": "^0.14.0",
-    "ipfs-utils": "^9.0.11",
+    "ipfs-utils": "^9.0.12",
     "libp2p": "next"
   },
   "devDependencies": {

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -71,7 +71,7 @@
     "ipfs-grpc-server": "^0.11.0",
     "ipfs-http-gateway": "^0.12.0",
     "ipfs-http-server": "^0.14.0",
-    "ipfs-utils": "^9.0.12",
+    "ipfs-utils": "^9.0.13",
     "libp2p": "next"
   },
   "devDependencies": {

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -78,7 +78,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-core-utils": "^0.17.0",
-    "ipfs-utils": "^9.0.11",
+    "ipfs-utils": "^9.0.12",
     "it-first": "^2.0.0",
     "it-last": "^2.0.0",
     "merge-options": "^3.0.4",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -78,7 +78,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-core-utils": "^0.17.0",
-    "ipfs-utils": "^9.0.6",
+    "ipfs-utils": "^9.0.10",
     "it-first": "^2.0.0",
     "it-last": "^2.0.0",
     "merge-options": "^3.0.4",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -78,7 +78,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-core-utils": "^0.17.0",
-    "ipfs-utils": "^9.0.12",
+    "ipfs-utils": "^9.0.13",
     "it-first": "^2.0.0",
     "it-last": "^2.0.0",
     "merge-options": "^3.0.4",

--- a/packages/ipfs-http-client/package.json
+++ b/packages/ipfs-http-client/package.json
@@ -78,7 +78,7 @@
     "err-code": "^3.0.1",
     "ipfs-core-types": "^0.13.0",
     "ipfs-core-utils": "^0.17.0",
-    "ipfs-utils": "^9.0.10",
+    "ipfs-utils": "^9.0.11",
     "it-first": "^2.0.0",
     "it-last": "^2.0.0",
     "merge-options": "^3.0.4",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -95,7 +95,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-http-client": "^59.0.0",
     "ipfs-interop": "ipfs/interop#deps/update-multiformats",
-    "ipfs-utils": "^9.0.10",
+    "ipfs-utils": "^9.0.11",
     "ipfsd-ctl": "^12.0.3",
     "iso-url": "^1.0.0",
     "kubo-rpc-client": "^2.0.2",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -95,7 +95,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-http-client": "^59.0.0",
     "ipfs-interop": "ipfs/interop#deps/update-multiformats",
-    "ipfs-utils": "^9.0.12",
+    "ipfs-utils": "^9.0.13",
     "ipfsd-ctl": "^12.0.3",
     "iso-url": "^1.0.0",
     "kubo-rpc-client": "^2.0.2",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -95,7 +95,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-http-client": "^59.0.0",
     "ipfs-interop": "ipfs/interop#deps/update-multiformats",
-    "ipfs-utils": "^9.0.11",
+    "ipfs-utils": "^9.0.12",
     "ipfsd-ctl": "^12.0.3",
     "iso-url": "^1.0.0",
     "kubo-rpc-client": "^2.0.2",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -95,7 +95,7 @@
     "ipfs-core-types": "^0.13.0",
     "ipfs-http-client": "^59.0.0",
     "ipfs-interop": "ipfs/interop#deps/update-multiformats",
-    "ipfs-utils": "^9.0.6",
+    "ipfs-utils": "^9.0.10",
     "ipfsd-ctl": "^12.0.3",
     "iso-url": "^1.0.0",
     "kubo-rpc-client": "^2.0.2",


### PR DESCRIPTION
Recent node versions ship with a global fetch which requires the duplex option to be set when sending readble streams as the request body so ensure we have the latest ipfs-utils that sets that option.