### PR TITLE
fix: ipfs-http-client should lowercase key type when submitting to kubo

### DIFF
--- a/packages/ipfs-http-client/src/key/gen.js
+++ b/packages/ipfs-http-client/src/key/gen.js
@@ -14,6 +14,8 @@ export const createGen = configure(api => {
   async function gen (name, options) {
     const opts = options ?? { type: 'Ed25519' }
 
+    opts.type = opts.type.toLowerCase()
+
     const res = await api.post('key/gen', {
       signal: opts.signal,
       searchParams: toUrlSearchParams({


### PR DESCRIPTION
Fixes #4272

Without this one cannot generate a new key in TypeScript with Kubo since the TypeScript types require uppercase key names.

Not sure if the types should be changed since I'm not sure if js-ipfs-core relies on the uppercase version.