### PR TITLE
Added example to load from CDN for browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ console.info(cid)
 // QmXXY5ZxbtuYj6DnfApLiGstzPN7fvSyigrRee3hDWPCaf
 ```
 
+### Use pre-built script in teh browser
+
+Directly load pre-built bundle from a CDN in the browser using <script> tag:
+
+```
+  <script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
+
+```
+The use it in the script:
+```
+  <script>
+
+  const node = await Ipfs.create()
+  const result = await node.add('=^.^= meow meow')
+  const cid = results['cid']
+  console.log("CID for content",cid)
+  
+</script>
+  ```
+  
+
 ## Documentation
 
 * [Concepts](https://docs.ipfs.io/concepts/)

--- a/README.md
+++ b/README.md
@@ -78,25 +78,22 @@ console.info(cid)
 // QmXXY5ZxbtuYj6DnfApLiGstzPN7fvSyigrRee3hDWPCaf
 ```
 
-### Use pre-built script in teh browser
+### Use pre-built script in the browser
 
 Directly load pre-built bundle from a CDN in the browser using <script> tag:
 
 ```
-  <script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
-
+<script src="https://cdn.jsdelivr.net/npm/ipfs/dist/index.min.js"></script>
 ```
-The use it in the script:
+Then use it in the JavaScript:
 ```
-  <script>
-
-  const node = await Ipfs.create()
-  const result = await node.add('=^.^= meow meow')
-  const cid = results['cid']
-  console.log("CID for content",cid)
-  
+<script>
+    const node = await Ipfs.create()
+    const result = await node.add('=^.^= meow meow')
+    const cid = results['cid']
+    console.log("CID for content",cid)  
 </script>
-  ```
+```
   
 
 ## Documentation


### PR DESCRIPTION
Although there are separate examples to use IPFS in the browser, it makes sense to include the browser usage in the main README. Helps beginners to experiment easily.