### PR TITLE
fix: crash when using searchParams option

### DIFF
--- a/packages/ipfs-http-client/src/lib/to-url-search-params.js
+++ b/packages/ipfs-http-client/src/lib/to-url-search-params.js
@@ -9,7 +9,7 @@ export function toUrlSearchParams ({ arg, searchParams, hashAlg, mtime, mode, ..
   if (searchParams) {
     options = {
       ...options,
-      ...searchParams
+      ...Object.fromEntries(searchParams)
     }
   }
 


### PR DESCRIPTION
This pull attempt to fix the issue when trying to use searchParams option for http client.

According to [the doc](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#additional-options), one can provide `searchParams` (an URLSearchParams instance) to add extra query parameters. Currently, this behaviour does not work, see this gist: https://gist.github.com/sk-gachou/2dd253acb1e1663e37119120c2db4768

It crash at this line:
https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/lib/to-url-search-params.js#L42