### PR TITLE
docs: add deprecation notice to readmes

### DIFF
--- a/packages/interface-ipfs-core/README.md
+++ b/packages/interface-ipfs-core/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # interface-ipfs-core <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/interface-ipfs-core/package.json
+++ b/packages/interface-ipfs-core/package.json
@@ -112,6 +112,7 @@
     "pako": "^2.0.4",
     "readable-stream": "^4.0.0",
     "sinon": "^15.0.1",
+    "stream": "^0.0.2",
     "uint8arrays": "^4.0.2",
     "wherearewe": "^2.0.1"
   },

--- a/packages/ipfs-cli/README.md
+++ b/packages/ipfs-cli/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-cli <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-cli/src/commands/config/profile.js
+++ b/packages/ipfs-cli/src/commands/config/profile.js
@@ -12,7 +12,6 @@ const command = {
 
   builder (yargs) {
     return yargs
-      // @ts-expect-error types are wrong
       .command(commands)
   },
 

--- a/packages/ipfs-client/README.md
+++ b/packages/ipfs-client/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-client <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-core-config/README.md
+++ b/packages/ipfs-core-config/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-core-config <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-core-types/README.md
+++ b/packages/ipfs-core-types/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-core-types <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-core-utils/README.md
+++ b/packages/ipfs-core-utils/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-core-utils <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-core/README.md
+++ b/packages/ipfs-core/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-core <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-daemon/README.md
+++ b/packages/ipfs-daemon/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-daemon <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-grpc-client/README.md
+++ b/packages/ipfs-grpc-client/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-grpc-client <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-grpc-client/test/utils.spec.js
+++ b/packages/ipfs-grpc-client/test/utils.spec.js
@@ -11,6 +11,7 @@ describe('utils', () => {
     it('should transform a bidirectional client into an async iterable', async () => {
       const service = 'service'
       const options = {
+        host: '',
         metadata: {
           foo: 'bar'
         }
@@ -42,6 +43,7 @@ describe('utils', () => {
     it('should propagate client errors', async () => {
       const service = 'service'
       const options = {
+        host: '',
         metadata: {
           foo: 'bar'
         }

--- a/packages/ipfs-grpc-protocol/README.md
+++ b/packages/ipfs-grpc-protocol/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-grpc-protocol <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-grpc-server/README.md
+++ b/packages/ipfs-grpc-server/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-grpc-server <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-http-client/README.md
+++ b/packages/ipfs-http-client/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-http-client <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)
@@ -17,7 +27,7 @@
 - [Getting Started](#getting-started)
   - [Next Steps](#next-steps)
 - [Usage](#usage)
-  - - [`create([options])`](#createoptions)
+    - [`create([options])`](#createoptions)
     - [Parameters](#parameters)
     - [Options](#options)
     - [Returns](#returns)

--- a/packages/ipfs-http-gateway/README.md
+++ b/packages/ipfs-http-gateway/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-http-gateway <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-http-response/README.md
+++ b/packages/ipfs-http-response/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-http-response <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-http-server/README.md
+++ b/packages/ipfs-http-server/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-http-server <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-message-port-client/README.md
+++ b/packages/ipfs-message-port-client/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-message-port-client <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-message-port-protocol/README.md
+++ b/packages/ipfs-message-port-protocol/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-message-port-protocol <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs-message-port-server/README.md
+++ b/packages/ipfs-message-port-server/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs-message-port-server <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)

--- a/packages/ipfs/README.md
+++ b/packages/ipfs/README.md
@@ -1,3 +1,13 @@
+> # ⛔️ DEPRECATED: [js-IPFS](https://github.com/ipfs/js-ipfs) has been superseded by [Helia](https://github.com/ipfs/helia) <!-- omit in toc -->
+>
+> To help you upgrade your app to use Helia please see the following resources:
+>
+>  - [Migration guide](https://github.com/ipfs/helia/wiki/%F0%9F%9A%9B-Migrating-from-js-IPFS)
+>  - [FAQ](https://github.com/ipfs/helia/wiki/%E2%9D%93-FAQ)
+>  - [Hello Helia talk](https://www.youtube.com/watch?v=T_FlhkLSgH8)
+>  - [The State of IPFS in JS](https://blog.ipfs.tech/state-of-ipfs-in-js/)
+>  - [discuss.ipfs.tech post](..)
+
 # ipfs <!-- omit in toc -->
 
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)


### PR DESCRIPTION
Adds a notice to every readme advising of deprecation and containing pointers to docs that help with the upgrade to Helia.