### PR TITLE
chore: disable dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   commit-message:
     prefix: "deps"
     prefix-development: "deps(dev)"


### PR DESCRIPTION
FYI: js-ipfs is being deprecated in favor of [Helia](https://github.com/ipfs/helia).  You can learn more about this deprecation and the corresponding migration guide [here](https://github.com/ipfs/js-ipfs/issues/4336).